### PR TITLE
move AUR job to dev channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
 
   deploy-release-channel-aur:
     needs: build-juliaup
-    environment: release-preview-channel
+    environment: dev-channel
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:


### PR DESCRIPTION
Once development settles down a bit, we can always move this to a more stable channel, but I think for now it's reasonable if this just follows the dev releases to get new features out there right away. The key should be set up already, IIRC.