### PR TITLE
use pretty format when writing json files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -500,7 +500,7 @@ fn main() -> Result<()> {
 
     let version_db_path = out_path.join("versionsdb.json");
     let file = File::create(&version_db_path)?;
-    serde_json::to_writer(file, &db)?;
+    serde_json::to_writer_pretty(file, &db)?;
 
     let file = File::open(Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("versions.json"))?;
     let data: Value = serde_json::from_reader(file)?;

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -79,7 +79,7 @@ pub fn save_config_db(config_data: &JuliaupConfig) -> Result<()> {
         )
     })?;
 
-    serde_json::to_writer(file, &config_data)
+    serde_json::to_writer_pretty(file, &config_data)
         .with_context(|| format!("Failed to write configuration file '{}'.", display))?;
     Ok(())
 }


### PR DESCRIPTION
I think this makes it a bit easier when developing and seeing what is inside the file. There is no requirement of having this be minimal since it won't be transferred over a network so I think this is ok. 