### PR TITLE
make the download progress bar consistent with the Pkg theme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ windows = "0.18.0"
 thiserror = "1.0"
 indicatif = "0.16"
 atty = "0.2.14"
+console = "0.14"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -5,6 +5,7 @@ use crate::jsonstructs_versionsdb::JuliaupVersionDB;
 use crate::utils::get_juliaup_home_path;
 use crate::utils::parse_versionstring;
 use anyhow::{anyhow, Context, Result};
+use console::style;
 use flate2::read::GzDecoder;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::{
@@ -42,9 +43,10 @@ fn download_extract_sans_parent(url: &String, target_path: &Path) -> Result<()> 
         Some(content_length) => ProgressBar::new(content_length),
         None => ProgressBar::new_spinner(),
     };
-
+    
+    pb.set_prefix("  Downloading:");
     pb.set_style(ProgressStyle::default_bar()
-    .template("{spinner:.green} [{elapsed_precise}] [{bar:.cyan/blue}] {bytes}/{total_bytes} eta: {eta}")
+    .template("{prefix:.cyan.bold} [{bar}] {bytes}/{total_bytes} eta: {eta}")
                 .progress_chars("=> "));
 
     let foo = pb.wrap_read(response.into_reader());
@@ -86,7 +88,7 @@ pub fn install_version(
 
     std::fs::create_dir_all(target_path.parent().unwrap())?;
 
-    eprintln!("Installing Julia {} ({}).", version, platform);
+    eprintln!("{} Julia {} ({}).", style("Installing").green().bold(), version, platform);
 
     download_extract_sans_parent(&download_url, &target_path)?;
 


### PR DESCRIPTION
I thought it would look nice if Pkg and juliaup were consistent with the Pkg progress bars.

Here is Pkg:
![image](https://user-images.githubusercontent.com/1282691/129966096-0dbf3d6c-3302-4350-96bd-9afdb6422266.png)

And here is juliaup with the PR:
![image](https://user-images.githubusercontent.com/1282691/129966126-1ecd449e-cc1b-4ff9-8de5-f6c1c95a8b2a.png)
