### PR TITLE
added basic shell bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,21 @@ The installer also bundles a full Julia version manager called `juliaup`. One ca
 ## Using Juliaup
 
 If you want to try it, here is what you should do:
+
+### Windows Users
 - Make sure you don't have any version of Julia on your PATH. `Juliaup` will handle all `PATH` related aspects of your Julia installation.
 - Install Julia from the Windows Store [here](https://www.microsoft.com/store/apps/9NJNWW8PVKMN).
 
 Once you have that installed, `julia` is on the `PATH`, there is a start menu shortcut and it will show up as a profile in Windows Terminal. Any of those will start Julia. The VS Code extension will also automatically find this Julia installation.
 
+### Linux Users
+- Run `curl https://github.com/JuliaLang/juliaup/blob/master/juliaup-init.sh | sh`.  This will
+    create `$HOME/.julia/bin/juliaup`.
+- Optionally, add `~/.julia/bin` to your path (`export PATH=$HOME/.julia/bin:$PATH`).  If you skip
+    this step you'll need to specify the full path to get `juliaup`.
+- Run `juliaup` with the commands described below.
+
+### Subcommands
 Here are some of the things you can do with `juliaup`:
 - `juliaup update` installs the latest availabe Julia version for all your channels.
 - `juliaup update release` updates the `release` channel to the latest version.

--- a/juliaup.sh
+++ b/juliaup.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#================================================================
+# juliaup bootstrap script
+#================================================================
+DOWNLOAD_URL="https://github.com/JuliaLang/juliaup/releases/download/v1.2.2/x86_64-unknown-linux-gnu.tar.gz"
+DEFAULT_INSTALL_DIR=$HOME/.julia/bin
+#TODO: this really needs to be changed
+EXTRACTED_DIR='target\x86_64-unknown-linux-gnu'
+
+print_help() {
+    cat 1>&2 <<EOF
+juliaup-init
+The installer for juliaup
+
+USAGE:
+    juliaup-init [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help            Help information
+
+OPTIONS:
+    -d, --install-dir     Specify a directory to store juliaup binary, ~/.julia/juliaup by default.    
+EOF
+}
+
+check_cmd() {
+    command -v "$1" > /dev/null 2>&1
+}
+
+downloader() {
+    if check_cmd wget; then
+        echo wget
+    elif check_cmd curl; then
+        echo curl
+    fi
+}
+
+install_juliaup() {
+    DLD=`downloader`
+    if [[ $DLD =~ wget ]]; then
+        wget $DOWNLOAD_URL -O $1
+    elif [[ $DLD =~ curl ]]; then
+        curl $1 --output $1
+    fi
+}
+
+cleanup() {
+    rm $1/juliaup.tmp.tar.gz
+    rm -r $1/$EXTRACTED_DIR
+}
+
+main() {
+    INSTALLDIR=$DEFAULT_INSTALL_DIR
+    while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
+        -h | --help )
+            print_help
+            exit 0
+            ;;
+        -d | --install-dir )
+            shift; INSTALLDIR=$1
+    esac; shift; done
+
+    echo "============================= juliaup bootstrap installer ============================"
+
+    if [[ -d $INSTALLDIR ]]; then
+        if [[ -e $INSTALLDIR/juliaup ]]; then
+            echo "$INSTALLDIR/juliaup already exists"
+            exit 1
+        fi
+    else
+        mkdir -p $INSTALLDIR
+    fi
+
+    echo "installing to $INSTALLDIR/juliaup..."
+
+    install_juliaup $INSTALLDIR/juliaup.tmp.tar.gz
+
+    tar xzf $INSTALLDIR/juliaup.tmp.tar.gz -C $INSTALLDIR
+    mv $INSTALLDIR/$EXTRACTED_DIR/juliaup $INSTALLDIR
+    chmod a+x $INSTALLDIR/juliaup
+
+    cleanup $INSTALLDIR
+
+    echo "done."
+    exit 0
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
Hello all.  Following up on a discussion some of us had on slack: to a linux user this package looks a little bit weird.  The reason for this is that rust binaries are usually built from scratch with `cargo` if they are not available from the package manager.  That would be pretty awkward for `juliaup` since it's effectively asking users to install one entire package manager (`cargo`) to download another package manager (`Pkg`).  To put it another way: to a linux user it looks a little weird that this is anything other than shell scripts and Julia code.

To rectify this, my suggestion would be to make it as easy as possible to fetch the binary to an appropriate place (this can ultimately be reduced to pretty much two clicks and hitting enter).  This is [the same approach that rustup](https://rustup.rs/) takes.

To help get things going, I have added a basic shell script for downloading the binary and sticking it in what I deemed to be an appropriate location.  There's obviously a lot more that can be done here, most importantly handling of different architectures and weird edge cases, but I thought it might make a good starting point (and yes, it works).

If this is something you indeed want to do, it might be good to secure a julialang.org url for this script somewhere.

This is somewhat similar to the bootstrapping [install script](https://gitlab.com/ExpandingMan/dotfiles/-/blob/master/install) I've been using for quite a while for my dotfiles installer which is written in Julia.

In retrospect, I realize I was probably overzealous in making changes to the README since you may not want to expose this from this initial PR alone, so I'd be glad to revert that...