### PR TITLE
automatically create symlinks for channels

### DIFF
--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -7,6 +7,7 @@ use anyhow::{Result};
 use juliaup::command_add::run_command_add;
 use juliaup::command_default::run_command_default;
 use juliaup::command_status::run_command_status;
+use juliaup::command_config::run_command_config;
 use juliaup::command_initial_setup_from_launcher::run_command_initial_setup_from_launcher;
 use juliaup::command_api::run_command_api;
 #[cfg(feature = "selfupdate")]
@@ -48,6 +49,11 @@ enum Juliaup {
     /// Garbage collect uninstalled Julia versions
     Gc {
     },
+    /// Change config values of Juliaup
+    Config {
+        property: String,
+        value: String
+    },
     #[clap(setting(clap::AppSettings::Hidden))]
     Api {
         command: String
@@ -83,6 +89,7 @@ fn main() -> Result<()> {
         Juliaup::Update {channel} => run_command_update(channel),
         Juliaup::Gc {} => run_command_gc(),
         Juliaup::Link {channel, file, args} => run_command_link(channel, file, args),
+        Juliaup::Config {property, value} => run_command_config(property, value),
         Juliaup::Api {command} => run_command_api(command),
         Juliaup::InitialSetupFromLauncher {} => run_command_initial_setup_from_launcher(),
         #[cfg(feature = "selfupdate")]

--- a/src/command_add.rs
+++ b/src/command_add.rs
@@ -36,10 +36,12 @@ pub fn run_command_add(channel: String) -> Result<()> {
         config_file.data.default = Some(channel.clone());
     }
 
+    let create_symlinks = config_file.data.create_symlinks;
+
     save_config_db(config_file)
         .with_context(|| format!("Failed to save configuration file from `add` command after '{}' was installed.", channel))?;
 
-    if std::env::consts::OS != "windows" && config_data.create_symlinks {
+    if std::env::consts::OS != "windows" && create_symlinks {
         create_symlink(
             &JuliaupConfigChannel::SystemChannel {
                 version: required_version.clone(),

--- a/src/command_add.rs
+++ b/src/command_add.rs
@@ -1,4 +1,4 @@
-use crate::operations::install_version;
+use crate::operations::{install_version, create_symlink};
 use crate::config_file::{JuliaupConfigChannel, load_mut_config_db, save_config_db};
 use crate::versions_file::load_versions_db;
 use anyhow::{anyhow, bail, Context, Result};
@@ -38,6 +38,15 @@ pub fn run_command_add(channel: String) -> Result<()> {
 
     save_config_db(config_file)
         .with_context(|| format!("Failed to save configuration file from `add` command after '{}' was installed.", channel))?;
+
+    if std::env::consts::OS != "windows" && config_data.create_symlinks {
+        create_symlink(
+            &JuliaupConfigChannel::SystemChannel {
+                version: required_version.clone(),
+            },
+            &format!("julia-{}", channel),
+        )?;
+    }
 
     Ok(())
 }

--- a/src/command_config.rs
+++ b/src/command_config.rs
@@ -1,10 +1,10 @@
-use crate::config_file::{load_config_db, save_config_db};
+use crate::config_file::{load_mut_config_db, save_config_db};
 use crate::operations::{create_symlink, remove_symlink};
 use anyhow::{bail, Context, Result};
 
 pub fn run_command_config(property: String, value: String) -> Result<()> {
-    let mut config_data =
-        load_config_db().with_context(|| "`config` command failed to load configuration file.")?;
+    let mut config_file = load_mut_config_db()
+        .with_context(|| "`config` command failed to load configuration data.")?;
 
     let mut value_changed = false;
 
@@ -20,17 +20,15 @@ pub fn run_command_config(property: String, value: String) -> Result<()> {
                 _     => bail!("Value for 'symlinks' must be either 'on' or 'off'."),
             };
 
-            if create_symlinks != config_data.create_symlinks {
-                config_data.create_symlinks = create_symlinks;
+            if create_symlinks != config_file.data.create_symlinks {
+                config_file.data.create_symlinks = create_symlinks;
                 value_changed = true;
 
-                if create_symlinks {
-                    for (channel_name, channel) in &config_data.installed_channels {
+                for (channel_name, channel) in &config_file.data.installed_channels {
+                    if create_symlinks {
                         create_symlink(channel, &format!("julia-{}", channel_name))?;
                     }
-                }
-                else {
-                    for (channel_name, _) in &config_data.installed_channels {
+                    else {
                         remove_symlink(&format!("julia-{}", channel_name))?;
                     }
                 }
@@ -39,7 +37,8 @@ pub fn run_command_config(property: String, value: String) -> Result<()> {
         s => bail!(format!("Unknown property '{}'.", s)),
     };
 
-    save_config_db(&config_data)?;
+    save_config_db(config_file)
+        .with_context(|| "Failed to save configuration file from `config` command.")?;
 
     if value_changed {
         eprintln!("Property '{}' set to '{}'", property, value);

--- a/src/command_config.rs
+++ b/src/command_config.rs
@@ -1,0 +1,52 @@
+use crate::config_file::{load_config_db, save_config_db};
+use crate::operations::{create_symlink, remove_symlink};
+use anyhow::{bail, Context, Result};
+
+pub fn run_command_config(property: String, value: String) -> Result<()> {
+    let mut config_data =
+        load_config_db().with_context(|| "`config` command failed to load configuration file.")?;
+
+    let mut value_changed = false;
+
+    match property.as_str() {
+        "symlinks" => {
+            if std::env::consts::OS == "windows" {
+                bail!("Symlinks not supported on Windows.");
+            }
+
+            let create_symlinks = match value.as_str() {
+                "on"  => true,
+                "off" => false,
+                _     => bail!("Value for 'symlinks' must be either 'on' or 'off'."),
+            };
+
+            if create_symlinks != config_data.create_symlinks {
+                config_data.create_symlinks = create_symlinks;
+                value_changed = true;
+
+                if create_symlinks {
+                    for (channel_name, channel) in &config_data.installed_channels {
+                        create_symlink(channel, &format!("julia-{}", channel_name))?;
+                    }
+                }
+                else {
+                    for (channel_name, _) in &config_data.installed_channels {
+                        remove_symlink(&format!("julia-{}", channel_name))?;
+                    }
+                }
+            }
+        },
+        s => bail!(format!("Unknown property '{}'.", s)),
+    };
+
+    save_config_db(&config_data)?;
+
+    if value_changed {
+        eprintln!("Property '{}' set to '{}'", property, value);
+    }
+    else {
+        eprintln!("Property '{}' is already set to '{}'", property, value);
+    }
+
+    Ok(())
+}

--- a/src/command_initial_setup_from_launcher.rs
+++ b/src/command_initial_setup_from_launcher.rs
@@ -5,6 +5,5 @@ pub fn run_command_initial_setup_from_launcher() -> Result<()> {
     run_command_add("release".to_string())
         .with_context(|| "Failed to run `run_command_add` from the `run_command_initial_setup_from_launcher` command.")?;
 
-
     Ok(())
 }

--- a/src/command_link.rs
+++ b/src/command_link.rs
@@ -19,7 +19,7 @@ pub fn run_command_link(channel: String, file: String, args: Vec<String>) -> Res
         eprintln!("WARNING: The channel name `{}` is also a system channel. By linking your custom binary to this channel you are hiding this system channel.", channel);
     }
 
-    config_data.installed_channels.insert(
+    config_file.data.installed_channels.insert(
         channel.clone(),
         JuliaupConfigChannel::LinkedChannel {
             command: file.clone(),
@@ -27,10 +27,12 @@ pub fn run_command_link(channel: String, file: String, args: Vec<String>) -> Res
         },
     );
 
+    let create_symlinks = config_file.data.create_symlinks;
+
     save_config_db(config_file)
         .with_context(|| "`link` command failed to save configuration db.")?;
 
-    if std::env::consts::OS != "windows" && config_data.create_symlinks {
+    if std::env::consts::OS != "windows" && create_symlinks {
         create_symlink(
             &JuliaupConfigChannel::LinkedChannel {
                 command: file.clone(),

--- a/src/command_remove.rs
+++ b/src/command_remove.rs
@@ -1,4 +1,4 @@
-use crate::{operations::garbage_collect_versions, config_file::{load_mut_config_db, save_config_db}};
+use crate::{operations::{garbage_collect_versions, remove_symlink}, config_file::{load_mut_config_db, save_config_db}};
 use anyhow::{bail, Context, Result};
 
 pub fn run_command_remove(channel: String) -> Result<()> {
@@ -16,6 +16,10 @@ pub fn run_command_remove(channel: String) -> Result<()> {
     }
 
     config_file.data.installed_channels.remove(&channel);
+
+    if std::env::consts::OS != "windows" {
+        remove_symlink(&format!("julia-{}", channel))?;
+    }
 
     garbage_collect_versions(&mut config_file.data)?;
 

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -145,6 +145,7 @@ pub fn load_mut_config_db() -> Result<JuliaupConfigFile> {
                 installed_versions: HashMap::new(),
                 installed_channels: HashMap::new(),
                 juliaup_channel: None,
+                create_symlinks: false,
             };
 
             serde_json::to_writer_pretty(&file, &new_config)

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -36,7 +36,9 @@ pub struct JuliaupConfig {
     #[serde(rename = "InstalledChannels")]
     pub installed_channels: HashMap<String, JuliaupConfigChannel>,
     #[serde(rename = "JuliaupChannel", skip_serializing_if = "Option::is_none")]
-    pub juliaup_channel: Option<String>
+    pub juliaup_channel: Option<String>,
+    #[serde(rename = "CreateSymlinks", default)]
+    pub create_symlinks: bool,
 }
 
 pub struct JuliaupConfigFile {
@@ -83,6 +85,7 @@ pub fn load_config_db() -> Result<JuliaupConfig> {
                     installed_versions: HashMap::new(),
                     installed_channels: HashMap::new(),
                     juliaup_channel: None,
+                    create_symlinks: false,
                 })
             },
             other_error => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod command_link;
 pub mod command_status;
 pub mod command_remove;
 pub mod command_update;
+pub mod command_config;
 pub mod command_initial_setup_from_launcher;
 pub mod command_api;
 pub mod command_selfupdate;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -229,7 +229,8 @@ pub fn create_symlink(
 
             eprintln!("{} {} for Julia {} ({}).", style("Creating symlink").cyan().bold(), symlink_name, version, platform);
 
-            std::os::unix::fs::symlink(target_path.join("bin").join("julia"), &symlink_path)?;
+            std::os::unix::fs::symlink(target_path.join("bin").join("julia"), &symlink_path)
+                .with_context(|| format!("failed to create symlink `{}`.", symlink_path.to_string_lossy()))?;
         },
         JuliaupConfigChannel::LinkedChannel { command, args } => {
             let formatted_command = match args {
@@ -247,11 +248,12 @@ r#"#!/bin/sh
 "#,
                     formatted_command,
                 ),
-            )?;
+            ).with_context(|| format!("failed to create shim `{}`.", symlink_path.to_string_lossy()))?;
 
             // set as executable
             let perms = std::fs::Permissions::from_mode(0o755);
-            std::fs::set_permissions(&symlink_path, perms)?;
+            std::fs::set_permissions(&symlink_path, perms)
+                .with_context(|| format!("failed to change permissions for shim `{}`.", symlink_path.to_string_lossy()))?;
         },
     };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,6 +63,46 @@ pub fn get_juliaupconfig_lockfile_path() -> Result<PathBuf> {
     Ok(path)
 }
 
+pub fn get_bin_dir() -> Result<PathBuf> {
+    let entry_sep = if std::env::consts::OS == "windows" {';'} else {':'};
+
+    let path = match std::env::var("JULIAUP_BIN_DIR") {
+        Ok(val) => {
+            let path = PathBuf::from(val.to_string().split(entry_sep).next().unwrap()); // We can unwrap here because even when we split an empty string we should get a first element.
+
+            if !path.is_absolute() {
+                bail!("The `JULIAUP_BIN_DIR` environment variable contains a value that resolves to an an invalid path `{}`.", path.display());
+            };
+
+            path
+        }
+        Err(_) => {
+            let mut path = std::env::current_exe()
+                .with_context(|| "Could not determine the path of the running exe.")?
+                .parent()
+                .ok_or_else(|| anyhow!("Could not determine parent."))?
+                .to_path_buf();
+
+            if let Some(home_dir) = dirs::home_dir() {
+                if !path.starts_with(&home_dir) {
+                    path = home_dir.join(".local").join("bin");
+
+                    if !path.is_absolute() {
+                        bail!(
+                            "The system returned an invalid home directory path `{}`.",
+                            path.display()
+                        );
+                    };
+                }
+            }
+
+            path
+        },
+    };
+
+    Ok(path)
+}
+
 pub fn get_arch() -> Result<String> {
     if std::env::consts::ARCH == "x86" {
         return Ok("x86".to_string());


### PR DESCRIPTION
With this PR, Juliaup automatically creates symlinks in `~/.local/bin`
for each new channel and updates them accordingly. I have intentionally
disabled this on Windows for now since `symlink` is not supported there
and I am not sure if there even is a `PATH` equivalent on Windows.

This functionality follows other tools such as jill and also allows
users to avoid going through `julialauncher`, which can sometimes
complicate things, e.g. when running Julia through GDB.

One remaining question is whether we want to add an option or env var to
turn off this behavior.
