### PR TITLE
Added how to launch a channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Here are some of the things you can do with `juliaup`:
 - `juliaup link dev ~/juliasrc/julia` configures the `dev` channel to use a binary that you provide that is located at `~/juliasrc/julia`. You can then use `dev` as if it was a system provided channel, i.e. make it the default or use it with the `+` version selector. You can use other names than `dev` and link as many versions into `juliaup` as you want.
 - `juliaup` shows you what other commands are available.
 
+To launch the Julia version in channel `release`, run `julia +release` in your terminal.\
 The available system provided channels are:
 - `release`: always points to the latest stable version.
 - `lts`: always points to the latest long term supported version.


### PR DESCRIPTION
Closes https://github.com/JuliaLang/juliaup/issues/185.
Adds information about how to launch a specific channel. Originally only in the README.md.

The information should also be added to the output from `juliaup help`. I am however unable to parse the code/locate the right file enough to figure out where to add it. I am envisioning something like the second line I have added under `USAGE` blow:

```
PS C:\Users\username> juliaup
Juliaup 1.4.1

The Julia Version Manager

USAGE:
    juliaup.exe <SUBCOMMAND>
    julia +<channel>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    add        Add a specific Julia version or channel to your system
    default    Set the default Julia version
    gc         Garbage collect uninstalled Julia versions
    help       Print this message or the help of the given subcommand(s)
    link       Link an existing Julia binary to a custom channel name
    remove     Remove a Julia version from your system
    status     Show all installed Julia versions
    update     Update all or a specific channel to the latest Julia version
```