### PR TITLE
Name setting channelsymlinks & nest in config file

### DIFF
--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -89,8 +89,9 @@ enum SelfSubCmd {
 #[derive(Parser)]
 enum ConfigSubCmd {
     #[cfg(not(target_os = "windows"))]
+    #[clap(name="channelsymlinks")]
     /// Create a separate symlink per channel
-    Symlinks  {
+    ChannelSymlinks  {
         /// New Value
         value: Option<bool>
     }
@@ -109,7 +110,7 @@ fn main() -> Result<()> {
         Juliaup::Link {channel, file, args} => run_command_link(channel, file, args),
         Juliaup::Config(subcmd) => match subcmd {
             #[cfg(not(target_os = "windows"))]
-            ConfigSubCmd::Symlinks {value} => run_command_config_symlinks(value),
+            ConfigSubCmd::ChannelSymlinks {value} => run_command_config_symlinks(value),
         },
         Juliaup::Api {command} => run_command_api(command),
         Juliaup::InitialSetupFromLauncher {} => run_command_initial_setup_from_launcher(),

--- a/src/command_add.rs
+++ b/src/command_add.rs
@@ -36,7 +36,7 @@ pub fn run_command_add(channel: String) -> Result<()> {
         config_file.data.default = Some(channel.clone());
     }
 
-    let create_symlinks = config_file.data.create_symlinks;
+    let create_symlinks = config_file.data.settings.create_channel_symlinks;
 
     save_config_db(config_file)
         .with_context(|| format!("Failed to save configuration file from `add` command after '{}' was installed.", channel))?;

--- a/src/command_config_symlinks.rs
+++ b/src/command_config_symlinks.rs
@@ -15,8 +15,8 @@ pub fn run_command_config_symlinks(value: Option<bool>) -> Result<()> {
                 bail!("Symlinks not supported on Windows.");
             }
 
-            if value != config_file.data.create_symlinks {
-                config_file.data.create_symlinks = value;
+            if value != config_file.data.settings.create_channel_symlinks {
+                config_file.data.settings.create_channel_symlinks = value;
                 value_changed = true;
 
                 for (channel_name, channel) in &config_file.data.installed_channels {
@@ -33,17 +33,17 @@ pub fn run_command_config_symlinks(value: Option<bool>) -> Result<()> {
                 .with_context(|| "Failed to save configuration file from `config` command.")?;
 
             if value_changed {
-                eprintln!("Property 'symlinks' set to '{}'", value);
+                eprintln!("Property 'channelsymlinks' set to '{}'", value);
             }
             else {
-                eprintln!("Property 'symlinks' is already set to '{}'", value);
+                eprintln!("Property 'channelsymlinks' is already set to '{}'", value);
             }
         },
         None => {
             let config_data = load_config_db()
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
-            eprintln!("Property 'symlinks' set to '{}'", config_data.create_symlinks);
+            eprintln!("Property 'channelsymlinks' set to '{}'", config_data.settings.create_channel_symlinks);
         }
     };
 

--- a/src/command_link.rs
+++ b/src/command_link.rs
@@ -27,7 +27,7 @@ pub fn run_command_link(channel: String, file: String, args: Vec<String>) -> Res
         },
     );
 
-    let create_symlinks = config_file.data.create_symlinks;
+    let create_symlinks = config_file.data.settings.create_channel_symlinks;
 
     save_config_db(config_file)
         .with_context(|| "`link` command failed to save configuration db.")?;

--- a/src/command_update.rs
+++ b/src/command_update.rs
@@ -25,7 +25,7 @@ fn update_channel(config_db: &mut JuliaupConfig, channel: &String, version_db: &
                     },
                 );
 
-                if std::env::consts::OS != "windows" && config_db.create_symlinks {
+                if std::env::consts::OS != "windows" && config_db.settings.create_channel_symlinks {
                     create_symlink(
                         &JuliaupConfigChannel::SystemChannel {
                             version: should_version.version.clone(),

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -32,6 +32,16 @@ pub enum JuliaupConfigChannel {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+pub struct JuliaupConfigSettings {
+    #[serde(rename = "CreateChannelSymlinks", default, skip_serializing_if = "is_default")]
+    pub create_channel_symlinks: bool,
+}
+
+impl Default for JuliaupConfigSettings {
+    fn default() -> Self { JuliaupConfigSettings {create_channel_symlinks: false} }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
 pub struct JuliaupConfig {
     #[serde(rename = "Default")]
     pub default: Option<String>,
@@ -41,8 +51,8 @@ pub struct JuliaupConfig {
     pub installed_channels: HashMap<String, JuliaupConfigChannel>,
     #[serde(rename = "JuliaupChannel", skip_serializing_if = "Option::is_none")]
     pub juliaup_channel: Option<String>,
-    #[serde(rename = "CreateSymlinks", default, skip_serializing_if = "is_default")]
-    pub create_symlinks: bool,
+    #[serde(rename = "Settings", default)]
+    pub settings: JuliaupConfigSettings,
 }
 
 pub struct JuliaupConfigFile {
@@ -89,7 +99,9 @@ pub fn load_config_db() -> Result<JuliaupConfig> {
                     installed_versions: HashMap::new(),
                     installed_channels: HashMap::new(),
                     juliaup_channel: None,
-                    create_symlinks: false,
+                    settings: JuliaupConfigSettings {
+                        create_channel_symlinks: false,
+                    },
                 })
             },
             other_error => {
@@ -149,7 +161,9 @@ pub fn load_mut_config_db() -> Result<JuliaupConfigFile> {
                 installed_versions: HashMap::new(),
                 installed_channels: HashMap::new(),
                 juliaup_channel: None,
-                create_symlinks: false,
+                settings: JuliaupConfigSettings{
+                    create_channel_symlinks: false,
+                },
             };
 
             serde_json::to_writer_pretty(&file, &new_config)


### PR DESCRIPTION
This is largely cosmetic: I renamed the setting to `channelsymlinks`, and I put it in a nested `Settings` element in the config file.