### PR TITLE
Make background self update a config

### DIFF
--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -97,7 +97,7 @@ enum ConfigSubCmd {
         /// New Value
         value: Option<bool>
     },
-    #[cfg(feature = "selfupdate")]
+    #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
     #[clap(name="backgroundselfupdateinterval")]
     /// The time between automatic background updates of Juliaup in minutes, use 0 to disable.
     BackgroundSelfupdateInterval {
@@ -120,7 +120,7 @@ fn main() -> Result<()> {
         Juliaup::Config(subcmd) => match subcmd {
             #[cfg(not(target_os = "windows"))]
             ConfigSubCmd::ChannelSymlinks {value} => run_command_config_symlinks(value),
-            #[cfg(feature = "selfupdate")]
+            #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
             ConfigSubCmd::BackgroundSelfupdateInterval {value} => run_command_config_backgroundselfupdate(value),
         },
         Juliaup::Api {command} => run_command_api(command),

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -1,3 +1,4 @@
+use juliaup::command_config_backgroundselfupdate::run_command_config_backgroundselfupdate;
 use juliaup::{command_link::run_command_link};
 use juliaup::command_gc::run_command_gc;
 use juliaup::command_update::run_command_update;
@@ -94,6 +95,12 @@ enum ConfigSubCmd {
     ChannelSymlinks  {
         /// New Value
         value: Option<bool>
+    },
+    #[cfg(not(target_os = "windows"))]
+    #[clap(name="backgroundselfupdateinterval")]
+    BackgroundSelfupdateInterval {
+        /// New Value
+        value: Option<i64>
     }
 }
 
@@ -111,6 +118,7 @@ fn main() -> Result<()> {
         Juliaup::Config(subcmd) => match subcmd {
             #[cfg(not(target_os = "windows"))]
             ConfigSubCmd::ChannelSymlinks {value} => run_command_config_symlinks(value),
+            ConfigSubCmd::BackgroundSelfupdateInterval {value} => run_command_config_backgroundselfupdate(value),
         },
         Juliaup::Api {command} => run_command_api(command),
         Juliaup::InitialSetupFromLauncher {} => run_command_initial_setup_from_launcher(),

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -12,7 +12,9 @@ use juliaup::command_config_symlinks::run_command_config_symlinks;
 use juliaup::command_initial_setup_from_launcher::run_command_initial_setup_from_launcher;
 use juliaup::command_api::run_command_api;
 #[cfg(feature = "selfupdate")]
-use juliaup::{command_selfchannel::run_command_selfchannel,command_selfupdate::run_command_selfupdate,command_selfinstall::run_command_selfinstall, command_selfuninstall::run_command_selfuninstall, command_config_backgroundselfupdate::run_command_config_backgroundselfupdate};
+use juliaup::{command_selfchannel::run_command_selfchannel,command_selfupdate::run_command_selfupdate,command_selfinstall::run_command_selfinstall, command_selfuninstall::run_command_selfuninstall};
+#[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
+use juliaup::command_config_backgroundselfupdate::run_command_config_backgroundselfupdate;
 
 
 #[derive(Parser)]

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -1,4 +1,3 @@
-use juliaup::command_config_backgroundselfupdate::run_command_config_backgroundselfupdate;
 use juliaup::{command_link::run_command_link};
 use juliaup::command_gc::run_command_gc;
 use juliaup::command_update::run_command_update;
@@ -13,7 +12,7 @@ use juliaup::command_config_symlinks::run_command_config_symlinks;
 use juliaup::command_initial_setup_from_launcher::run_command_initial_setup_from_launcher;
 use juliaup::command_api::run_command_api;
 #[cfg(feature = "selfupdate")]
-use juliaup::{command_selfchannel::run_command_selfchannel,command_selfupdate::run_command_selfupdate,command_selfinstall::run_command_selfinstall, command_selfuninstall::run_command_selfuninstall};
+use juliaup::{command_selfchannel::run_command_selfchannel,command_selfupdate::run_command_selfupdate,command_selfinstall::run_command_selfinstall, command_selfuninstall::run_command_selfuninstall, command_config_backgroundselfupdate::run_command_config_backgroundselfupdate};
 
 
 #[derive(Parser)]
@@ -96,7 +95,7 @@ enum ConfigSubCmd {
         /// New Value
         value: Option<bool>
     },
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(feature = "selfupdate")]
     #[clap(name="backgroundselfupdateinterval")]
     /// The time between automatic background updates of Juliaup in minutes, use 0 to disable.
     BackgroundSelfupdateInterval {
@@ -119,6 +118,7 @@ fn main() -> Result<()> {
         Juliaup::Config(subcmd) => match subcmd {
             #[cfg(not(target_os = "windows"))]
             ConfigSubCmd::ChannelSymlinks {value} => run_command_config_symlinks(value),
+            #[cfg(feature = "selfupdate")]
             ConfigSubCmd::BackgroundSelfupdateInterval {value} => run_command_config_backgroundselfupdate(value),
         },
         Juliaup::Api {command} => run_command_api(command),

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -98,8 +98,9 @@ enum ConfigSubCmd {
     },
     #[cfg(not(target_os = "windows"))]
     #[clap(name="backgroundselfupdateinterval")]
+    /// The time between automatic background updates of Juliaup in minutes, use 0 to disable.
     BackgroundSelfupdateInterval {
-        /// New Value
+        /// New value
         value: Option<i64>
     }
 }

--- a/src/command_config_backgroundselfupdate.rs
+++ b/src/command_config_backgroundselfupdate.rs
@@ -1,0 +1,67 @@
+use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
+use anyhow::{bail, Context, Result};
+
+#[cfg(not(target_os = "windows"))]
+pub fn run_command_config_backgroundselfupdate(value: Option<i64>) -> Result<()> {
+    use crate::operations::{install_background_selfupdate, uninstall_background_selfupdate};
+
+    match value {
+        Some(value) => {
+            if value < 0 {
+                bail!("Invalid argument.");
+            }
+
+            let mut config_file = load_mut_config_db()
+                .with_context(|| "`config` command failed to load configuration data.")?;
+    
+            let mut value_changed = false;
+
+            let value = if value==0 {None} else {Some(value)};
+
+            if value != config_file.data.settings.background_selfupdate_interval {
+                config_file.data.settings.background_selfupdate_interval = value;
+
+                value_changed = true;
+
+                match value {
+                    Some(value) => {
+                        install_background_selfupdate(value).unwrap();
+                    },
+                    None => {
+                        uninstall_background_selfupdate().unwrap();
+                    }
+                }
+            }
+
+            save_config_db(config_file)
+                .with_context(|| "Failed to save configuration file from `config` command.")?;
+
+            if value_changed {
+                eprintln!("Property 'backgroundselfupdateinterval' set to '{}'", match value {
+                    Some(value) => value,
+                    None => 0
+                });
+            }
+            else {
+                eprintln!("Property 'backgroundselfupdateinterval' is already set to '{}'", match value {
+                    Some(value) => value,
+                    None => 0
+                });
+            }
+        },
+        None => {
+            let config_data = load_config_db()
+                .with_context(|| "`config` command failed to load configuration data.")?;
+
+            eprintln!(
+                "Property 'backgroundselfupdateinterval' set to '{}'",
+                match config_data.settings.background_selfupdate_interval {
+                    Some(value) => value,
+                    None => 0
+                }
+            );
+        }
+    };
+
+    Ok(())
+}

--- a/src/command_selfinstall.rs
+++ b/src/command_selfinstall.rs
@@ -2,62 +2,9 @@ use anyhow::Result;
 
 #[cfg(all(not(feature = "windowsstore"),feature = "selfupdate"))]
 pub fn run_command_selfinstall() -> Result<()> {
-    use itertools::Itertools;
-    use std::{io::Write, process::Stdio};
-    use anyhow::Context;
+    use crate::command_config_backgroundselfupdate::run_command_config_backgroundselfupdate;
 
-    let own_exe_path = std::env::current_exe()
-        .with_context(|| "Could not determine the path of the running exe.")?;
-
-    let my_own_path = own_exe_path.to_str().unwrap();
-        
-    match std::env::var("WSL_DISTRO_NAME") {
-        // This is the WSL case, where we schedule a Windows task to do the update
-        Ok(val) => {
-            std::process::Command::new("schtasks.exe")
-                .args([
-                    "/create",
-                    "/sc",
-                    "hourly",
-                    "/mo",
-                    "5",
-                    "/tn",
-                    &format!("Juliaup self update for WSL {} distribution", val),
-                    "/f",
-                    "/it",
-                    "/tr",
-                    &format!("wsl --distribution {} {} self update", val, my_own_path)
-                ])
-                .output()
-                .with_context(|| "Failed to create new Windows task for juliaup.")?;
-        },
-        Err(_e) => {
-            let output = std::process::Command::new("crontab")
-                .args(["-l"])
-                .output()
-                .with_context(|| "Failed to retrieve crontab configuration.")?;
-
-            let new_crontab_content = String::from_utf8(output.stdout)?
-                .lines()
-                .filter(|x| !x.contains("4c79c12db1d34bbbab1f6c6f838f423f"))
-                .chain([&format!("0 * * * * {} 4c79c12db1d34bbbab1f6c6f838f423f", my_own_path), ""])
-                .join("\n");
-
-            let mut child = std::process::Command::new("crontab")
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()?;
-
-            let child_stdin = child.stdin.as_mut().unwrap();
-
-            child_stdin.write_all(new_crontab_content.as_bytes())?;
-
-            // Close stdin to finish and avoid indefinite blocking
-            drop(child_stdin);
-                
-            child.wait_with_output()?;
-        },
-    };
+    run_command_config_backgroundselfupdate(Some(60)).unwrap();
 
     println!("Successfully created a background task that updates juliaup itself.");
 

--- a/src/command_selfuninstall.rs
+++ b/src/command_selfuninstall.rs
@@ -2,51 +2,9 @@ use anyhow::Result;
 
 #[cfg(all(not(feature = "windowsstore"),feature = "selfupdate"))]
 pub fn run_command_selfuninstall() -> Result<()> {
-    use anyhow::Context;
-    use std::{io::Write, process::Stdio};
-    use itertools::Itertools;
+    use crate::command_config_backgroundselfupdate::run_command_config_backgroundselfupdate;
 
-    match std::env::var("WSL_DISTRO_NAME") {
-        // This is the WSL case, where we schedule a Windows task to do the update
-        Ok(val) => {            
-            std::process::Command::new("schtasks.exe")
-                .args([
-                    "/delete",
-                    "/tn",
-                    &format!("Juliaup self update for WSL {} distribution", val),
-                    "/f",
-                ])
-                .output()
-                .with_context(|| "Failed to remove Windows task for juliaup.")?;
-
-        },
-        Err(_e) => {
-            let output = std::process::Command::new("crontab")
-                .args(["-l"])
-                .output()
-                .with_context(|| "Failed to remove cron task.")?;
-
-            let new_crontab_content = String::from_utf8(output.stdout)?
-                .lines()
-                .filter(|x| !x.contains("4c79c12db1d34bbbab1f6c6f838f423f"))
-                .chain([""])
-                .join("\n");
-
-            let mut child = std::process::Command::new("crontab")
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()?;
-
-            let child_stdin = child.stdin.as_mut().unwrap();
-
-            child_stdin.write_all(new_crontab_content.as_bytes())?;
-
-            // Close stdin to finish and avoid indefinite blocking
-            drop(child_stdin);
-                
-            child.wait_with_output()?;
-        },
-    };
+    run_command_config_backgroundselfupdate(Some(0)).unwrap();
 
     println!("Successfully removed the background task that updates juliaup itself.");
 

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -35,10 +35,17 @@ pub enum JuliaupConfigChannel {
 pub struct JuliaupConfigSettings {
     #[serde(rename = "CreateChannelSymlinks", default, skip_serializing_if = "is_default")]
     pub create_channel_symlinks: bool,
+    #[serde(rename = "BackgroundSelfUpdateInterval", skip_serializing_if = "Option::is_none")]
+    pub background_selfupdate_interval: Option<i64>,
 }
 
 impl Default for JuliaupConfigSettings {
-    fn default() -> Self { JuliaupConfigSettings {create_channel_symlinks: false} }
+    fn default() -> Self { 
+        JuliaupConfigSettings {
+            create_channel_symlinks: false,
+            background_selfupdate_interval: None,
+        }
+     }
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -101,6 +108,7 @@ pub fn load_config_db() -> Result<JuliaupConfig> {
                     juliaup_channel: None,
                     settings: JuliaupConfigSettings {
                         create_channel_symlinks: false,
+                        background_selfupdate_interval: None,
                     },
                 })
             },
@@ -163,6 +171,7 @@ pub fn load_mut_config_db() -> Result<JuliaupConfigFile> {
                 juliaup_channel: None,
                 settings: JuliaupConfigSettings{
                     create_channel_symlinks: false,
+                    background_selfupdate_interval: None,
                 },
             };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod command_status;
 pub mod command_remove;
 pub mod command_update;
 pub mod command_config_symlinks;
+pub mod command_config_backgroundselfupdate;
 pub mod command_initial_setup_from_launcher;
 pub mod command_api;
 pub mod command_selfupdate;


### PR DESCRIPTION
The idea is that the entire background self update setting story is just another configuration that can be turned on and off. `self install` eventually will just be an interactive way to select a couple of default configuration settings (not in this PR yet).