### PR TITLE
Startup self update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "chunked_transfer"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +501,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "atty",
+ "chrono",
  "clap",
  "cli-table",
  "cluFlock",
@@ -589,6 +604,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "640c20e9df4a2d4a5adad5b47e17d76dac3e824346b181931c3ec9f7a85687b1"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -994,6 +1019,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ url = "2"
 cli-table = "0.4"
 itertools = "0.10"
 cluFlock = "1.2.5"
+chrono = {version = "0.4", features = ["serde"]}
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.28", features = ["alloc", "std", "Win32_Foundation", "Win32_UI_Shell", "Win32_System_Console", "Services_Store", "Foundation", "Foundation_Collections"] }

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 #[cfg(target_os = "windows")]
 use anyhow::bail;
-use chrono::Utc;
 use juliaup::config_file::{load_config_db, JuliaupConfig, JuliaupConfigChannel};
 use juliaup::jsonstructs_versionsdb::JuliaupVersionDB;
 use juliaup::utils::get_juliaupconfig_path;
@@ -9,7 +8,6 @@ use juliaup::versions_file::load_versions_db;
 use normpath::PathExt;
 use std::path::Path;
 use std::path::PathBuf;
-use std::process::Stdio;
 use ctrlc;
 
 #[derive(thiserror::Error, Debug)]
@@ -81,6 +79,9 @@ fn do_initial_setup(juliaupconfig_path: &Path) -> Result<()> {
 
 #[cfg(all(not(target_os = "windows"),feature = "selfupdate"))]
 fn run_selfupdate(config_data: &JuliaupConfig) -> Result<()> {
+    use chrono::Utc;
+    use std::process::Stdio;
+
     if let Some(val) = config_data.settings.startup_selfupdate_interval {
         let should_run = if let Some(last_selfupdate) = config_data.last_selfupdate {
             let update_time = last_selfupdate + chrono::Duration::minutes(val);
@@ -108,7 +109,7 @@ fn run_selfupdate(config_data: &JuliaupConfig) -> Result<()> {
 }
 
 #[cfg(any(target_os = "windows",not(feature = "selfupdate")))]
-fn run_selfupdate(config_data: &JuliaupConfig) -> Result<()> {
+fn run_selfupdate(_config_data: &JuliaupConfig) -> Result<()> {
     Ok(())
 }
 

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -14,7 +14,9 @@ use juliaup::command_api::run_command_api;
 #[cfg(feature = "selfupdate")]
 use juliaup::{command_selfchannel::run_command_selfchannel,command_selfupdate::run_command_selfupdate,command_selfinstall::run_command_selfinstall, command_selfuninstall::run_command_selfuninstall};
 #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
-use juliaup::command_config_backgroundselfupdate::{run_command_config_backgroundselfupdate,run_command_config_startupselfupdate};
+use juliaup::command_config_backgroundselfupdate::run_command_config_backgroundselfupdate;
+#[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
+use juliaup::command_config_startupselfupdate::run_command_config_startupselfupdate;
 
 
 #[derive(Parser)]

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -1,3 +1,4 @@
+use juliaup::command_config_startupselfupdate::run_command_config_startupselfupdate;
 use juliaup::{command_link::run_command_link};
 use juliaup::command_gc::run_command_gc;
 use juliaup::command_update::run_command_update;
@@ -103,7 +104,14 @@ enum ConfigSubCmd {
     BackgroundSelfupdateInterval {
         /// New value
         value: Option<i64>
-    }
+    },
+    #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
+    #[clap(name="startupselfupdateinterval")]
+    /// The time between automatic updates at Julia startup of Juliaup in minutes, use 0 to disable.
+    StartupSelfupdateInterval {
+        /// New value
+        value: Option<i64>
+    },
 }
 
 fn main() -> Result<()> {
@@ -122,6 +130,7 @@ fn main() -> Result<()> {
             ConfigSubCmd::ChannelSymlinks {value} => run_command_config_symlinks(value),
             #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
             ConfigSubCmd::BackgroundSelfupdateInterval {value} => run_command_config_backgroundselfupdate(value),
+            ConfigSubCmd::StartupSelfupdateInterval {value} => run_command_config_startupselfupdate(value),
         },
         Juliaup::Api {command} => run_command_api(command),
         Juliaup::InitialSetupFromLauncher {} => run_command_initial_setup_from_launcher(),

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -1,4 +1,3 @@
-use juliaup::command_config_startupselfupdate::run_command_config_startupselfupdate;
 use juliaup::{command_link::run_command_link};
 use juliaup::command_gc::run_command_gc;
 use juliaup::command_update::run_command_update;
@@ -15,7 +14,7 @@ use juliaup::command_api::run_command_api;
 #[cfg(feature = "selfupdate")]
 use juliaup::{command_selfchannel::run_command_selfchannel,command_selfupdate::run_command_selfupdate,command_selfinstall::run_command_selfinstall, command_selfuninstall::run_command_selfuninstall};
 #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
-use juliaup::command_config_backgroundselfupdate::run_command_config_backgroundselfupdate;
+use juliaup::command_config_backgroundselfupdate::{run_command_config_backgroundselfupdate,run_command_config_startupselfupdate};
 
 
 #[derive(Parser)]
@@ -130,6 +129,7 @@ fn main() -> Result<()> {
             ConfigSubCmd::ChannelSymlinks {value} => run_command_config_symlinks(value),
             #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
             ConfigSubCmd::BackgroundSelfupdateInterval {value} => run_command_config_backgroundselfupdate(value),
+            #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
             ConfigSubCmd::StartupSelfupdateInterval {value} => run_command_config_startupselfupdate(value),
         },
         Juliaup::Api {command} => run_command_api(command),

--- a/src/command_add.rs
+++ b/src/command_add.rs
@@ -38,7 +38,7 @@ pub fn run_command_add(channel: String) -> Result<()> {
 
     let create_symlinks = config_file.data.settings.create_channel_symlinks;
 
-    save_config_db(config_file)
+    save_config_db(&mut config_file)
         .with_context(|| format!("Failed to save configuration file from `add` command after '{}' was installed.", channel))?;
 
     if std::env::consts::OS != "windows" && create_symlinks {

--- a/src/command_config_backgroundselfupdate.rs
+++ b/src/command_config_backgroundselfupdate.rs
@@ -1,9 +1,11 @@
+#[cfg(not(target_os = "windows"))]
+use anyhow::Result;
 
 #[cfg(not(target_os = "windows"))]
 pub fn run_command_config_backgroundselfupdate(value: Option<i64>) -> Result<()> {
     use crate::operations::{install_background_selfupdate, uninstall_background_selfupdate};
     use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
-    use anyhow::{bail, Context, Result};
+    use anyhow::{bail, Context};
 
 
     match value {

--- a/src/command_config_backgroundselfupdate.rs
+++ b/src/command_config_backgroundselfupdate.rs
@@ -1,9 +1,10 @@
-use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
-use anyhow::{bail, Context, Result};
 
 #[cfg(not(target_os = "windows"))]
 pub fn run_command_config_backgroundselfupdate(value: Option<i64>) -> Result<()> {
     use crate::operations::{install_background_selfupdate, uninstall_background_selfupdate};
+    use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
+    use anyhow::{bail, Context, Result};
+
 
     match value {
         Some(value) => {

--- a/src/command_config_backgroundselfupdate.rs
+++ b/src/command_config_backgroundselfupdate.rs
@@ -33,7 +33,7 @@ pub fn run_command_config_backgroundselfupdate(value: Option<i64>) -> Result<()>
                 }
             }
 
-            save_config_db(config_file)
+            save_config_db(&mut config_file)
                 .with_context(|| "Failed to save configuration file from `config` command.")?;
 
             if value_changed {

--- a/src/command_config_startupselfupdate.rs
+++ b/src/command_config_startupselfupdate.rs
@@ -1,0 +1,56 @@
+use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
+use anyhow::{bail, Context, Result};
+
+#[cfg(not(target_os = "windows"))]
+pub fn run_command_config_startupselfupdate(value: Option<i64>) -> Result<()> {
+    match value {
+        Some(value) => {
+            if value < 0 {
+                bail!("Invalid argument.");
+            }
+
+            let mut config_file = load_mut_config_db()
+                .with_context(|| "`config` command failed to load configuration data.")?;
+    
+            let mut value_changed = false;
+
+            let value = if value==0 {None} else {Some(value)};
+
+            if value != config_file.data.settings.startup_selfupdate_interval {
+                config_file.data.settings.startup_selfupdate_interval = value;
+
+                value_changed = true;
+            }
+
+            save_config_db(&mut config_file)
+                .with_context(|| "Failed to save configuration file from `config` command.")?;
+
+            if value_changed {
+                eprintln!("Property 'startupselfupdateinterval' set to '{}'", match value {
+                    Some(value) => value,
+                    None => 0
+                });
+            }
+            else {
+                eprintln!("Property 'startupselfupdateinterval' is already set to '{}'", match value {
+                    Some(value) => value,
+                    None => 0
+                });
+            }
+        },
+        None => {
+            let config_data = load_config_db()
+                .with_context(|| "`config` command failed to load configuration data.")?;
+
+            eprintln!(
+                "Property 'startupselfupdateinterval' set to '{}'",
+                match config_data.settings.startup_selfupdate_interval {
+                    Some(value) => value,
+                    None => 0
+                }
+            );
+        }
+    };
+
+    Ok(())
+}

--- a/src/command_config_startupselfupdate.rs
+++ b/src/command_config_startupselfupdate.rs
@@ -1,7 +1,10 @@
 #[cfg(not(target_os = "windows"))]
+use anyhow::Result;
+
+#[cfg(not(target_os = "windows"))]
 pub fn run_command_config_startupselfupdate(value: Option<i64>) -> Result<()> {
     use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
-    use anyhow::{bail, Context, Result};
+    use anyhow::{bail, Context};
 
     match value {
         Some(value) => {

--- a/src/command_config_startupselfupdate.rs
+++ b/src/command_config_startupselfupdate.rs
@@ -1,8 +1,8 @@
-use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
-use anyhow::{bail, Context, Result};
-
 #[cfg(not(target_os = "windows"))]
 pub fn run_command_config_startupselfupdate(value: Option<i64>) -> Result<()> {
+    use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
+    use anyhow::{bail, Context, Result};
+
     match value {
         Some(value) => {
             if value < 0 {

--- a/src/command_config_symlinks.rs
+++ b/src/command_config_symlinks.rs
@@ -1,9 +1,10 @@
-use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
-use crate::operations::{create_symlink, remove_symlink};
-use anyhow::{bail, Context, Result};
 
 #[cfg(not(target_os = "windows"))]
 pub fn run_command_config_symlinks(value: Option<bool>) -> Result<()> {
+    use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
+    use crate::operations::{create_symlink, remove_symlink};
+    use anyhow::{bail, Context, Result};
+
     match value {
         Some(value) => {
             let mut config_file = load_mut_config_db()

--- a/src/command_config_symlinks.rs
+++ b/src/command_config_symlinks.rs
@@ -29,7 +29,7 @@ pub fn run_command_config_symlinks(value: Option<bool>) -> Result<()> {
                 }
             }
 
-            save_config_db(config_file)
+            save_config_db(&mut config_file)
                 .with_context(|| "Failed to save configuration file from `config` command.")?;
 
             if value_changed {

--- a/src/command_config_symlinks.rs
+++ b/src/command_config_symlinks.rs
@@ -1,9 +1,11 @@
+#[cfg(not(target_os = "windows"))]
+use anyhow::Result;
 
 #[cfg(not(target_os = "windows"))]
 pub fn run_command_config_symlinks(value: Option<bool>) -> Result<()> {
     use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
     use crate::operations::{create_symlink, remove_symlink};
-    use anyhow::{bail, Context, Result};
+    use anyhow::{bail, Context};
 
     match value {
         Some(value) => {

--- a/src/command_default.rs
+++ b/src/command_default.rs
@@ -17,7 +17,7 @@ pub fn run_command_default(channel: String) -> Result<()> {
 
     config_file.data.default = Some(channel.clone());
 
-    save_config_db(config_file)
+    save_config_db(&mut config_file)
         .with_context(|| "`default` command failed to save configuration db.")?;
 
     eprintln!("Configured the default Julia version to be '{}'.", channel);

--- a/src/command_gc.rs
+++ b/src/command_gc.rs
@@ -8,7 +8,7 @@ pub fn run_command_gc() -> Result<()> {
 
     garbage_collect_versions(&mut config_file.data)?;
 
-    save_config_db(config_file)
+    save_config_db(&mut config_file)
         .with_context(|| "`gc` command failed to save configuration db.")?;
 
     Ok(())

--- a/src/command_link.rs
+++ b/src/command_link.rs
@@ -29,7 +29,7 @@ pub fn run_command_link(channel: String, file: String, args: Vec<String>) -> Res
 
     let create_symlinks = config_file.data.settings.create_channel_symlinks;
 
-    save_config_db(config_file)
+    save_config_db(&mut config_file)
         .with_context(|| "`link` command failed to save configuration db.")?;
 
     if std::env::consts::OS != "windows" && create_symlinks {

--- a/src/command_remove.rs
+++ b/src/command_remove.rs
@@ -23,7 +23,7 @@ pub fn run_command_remove(channel: String) -> Result<()> {
 
     garbage_collect_versions(&mut config_file.data)?;
 
-    save_config_db(config_file)
+    save_config_db(&mut config_file)
         .with_context(|| format!("Failed to save configuration file from `remove` command after '{}' was installed.", channel))?;
 
     eprintln!("Julia '{}' successfully removed.", channel);

--- a/src/command_selfchannel.rs
+++ b/src/command_selfchannel.rs
@@ -15,7 +15,7 @@ pub fn run_command_selfchannel(channel: String) -> Result<()> {
 
     config_file.data.juliaup_channel = Some(channel.clone());
 
-    save_config_db(config_file)
+    save_config_db(&mut config_file)
         .with_context(|| "`selfchannel` command failed to save configuration db.")?;
 
     Ok(())

--- a/src/command_update.rs
+++ b/src/command_update.rs
@@ -68,7 +68,7 @@ pub fn run_command_update(channel: Option<String>) -> Result<()> {
 
     garbage_collect_versions(&mut config_file.data)?;
 
-    save_config_db(config_file)
+    save_config_db(&mut config_file)
         .with_context(|| "`update` command failed to save configuration db.")?;
 
     Ok(())

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -208,7 +208,7 @@ pub fn load_mut_config_db() -> Result<JuliaupConfigFile> {
     Ok(result)
 }
 
-pub fn save_config_db(mut juliaup_config_file: JuliaupConfigFile) -> Result<()> {
+pub fn save_config_db(juliaup_config_file: &mut JuliaupConfigFile) -> Result<()> {
     juliaup_config_file.file.rewind()
         .with_context(|| "Failed to rewind config file for write.")?;
 
@@ -220,9 +220,6 @@ pub fn save_config_db(mut juliaup_config_file: JuliaupConfigFile) -> Result<()> 
 
     juliaup_config_file.file.sync_all()
         .with_context(|| "Failed to write config data to disc.")?;
-
-    juliaup_config_file.lock.unlock()
-        .with_context(|| "Failed to unlock.")?;
 
     Ok(())
 }

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, ErrorKind, Seek, SeekFrom};
+use chrono::{DateTime,Utc};
 
 fn is_default<T: Default + PartialEq>(t: &T) -> bool {
     t == &T::default()
@@ -37,6 +38,8 @@ pub struct JuliaupConfigSettings {
     pub create_channel_symlinks: bool,
     #[serde(rename = "BackgroundSelfUpdateInterval", skip_serializing_if = "Option::is_none")]
     pub background_selfupdate_interval: Option<i64>,
+    #[serde(rename = "StartupSelfUpdateInterval", skip_serializing_if = "Option::is_none")]
+    pub startup_selfupdate_interval: Option<i64>,
 }
 
 impl Default for JuliaupConfigSettings {
@@ -44,6 +47,7 @@ impl Default for JuliaupConfigSettings {
         JuliaupConfigSettings {
             create_channel_symlinks: false,
             background_selfupdate_interval: None,
+            startup_selfupdate_interval: None,
         }
      }
 }
@@ -60,6 +64,8 @@ pub struct JuliaupConfig {
     pub juliaup_channel: Option<String>,
     #[serde(rename = "Settings", default)]
     pub settings: JuliaupConfigSettings,
+    #[serde(rename = "LastSelfUpdate", skip_serializing_if = "Option::is_none")]
+    pub last_selfupdate: Option<DateTime<Utc>>,
 }
 
 pub struct JuliaupConfigFile {
@@ -109,7 +115,9 @@ pub fn load_config_db() -> Result<JuliaupConfig> {
                     settings: JuliaupConfigSettings {
                         create_channel_symlinks: false,
                         background_selfupdate_interval: None,
+                        startup_selfupdate_interval: None,
                     },
+                    last_selfupdate: None,                    
                 })
             },
             other_error => {
@@ -172,7 +180,9 @@ pub fn load_mut_config_db() -> Result<JuliaupConfigFile> {
                 settings: JuliaupConfigSettings{
                     create_channel_symlinks: false,
                     background_selfupdate_interval: None,
+                    startup_selfupdate_interval: None,
                 },
+                last_selfupdate: None,
             };
 
             serde_json::to_writer_pretty(&file, &new_config)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod command_remove;
 pub mod command_update;
 pub mod command_config_symlinks;
 pub mod command_config_backgroundselfupdate;
+pub mod command_config_startupselfupdate;
 pub mod command_initial_setup_from_launcher;
 pub mod command_api;
 pub mod command_selfupdate;


### PR DESCRIPTION
The idea is that we have another auto update for juliap itself: this option checks for new versions at an interval whenever `julialauncher` is started.