### PR TITLE
Restructure conditional compiles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           - target: x86_64-pc-windows-msvc
             os: windows
-            features: selfupdate,windowsstore
+            features: windowsstore
           - target: x86_64-apple-darwin
             os: macos
             features: selfupdate
@@ -36,7 +36,7 @@ jobs:
             features: selfupdate
           - target: i686-pc-windows-msvc
             os: windows
-            features: selfupdate,windowsstore
+            features: windowsstore
           - target: i686-unknown-linux-gnu
             os: ubuntu
             features: selfupdate

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -77,7 +77,7 @@ fn do_initial_setup(juliaupconfig_path: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(not(target_os = "windows"),feature = "selfupdate"))]
+#[cfg(feature = "selfupdate")]
 fn run_selfupdate(config_data: &JuliaupConfig) -> Result<()> {
     use chrono::Utc;
     use std::process::Stdio;
@@ -108,7 +108,7 @@ fn run_selfupdate(config_data: &JuliaupConfig) -> Result<()> {
     Ok(())
 }
 
-#[cfg(any(target_os = "windows",not(feature = "selfupdate")))]
+#[cfg(not(feature = "selfupdate"))]
 fn run_selfupdate(_config_data: &JuliaupConfig) -> Result<()> {
     Ok(())
 }

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -12,12 +12,14 @@ use juliaup::command_config_symlinks::run_command_config_symlinks;
 use juliaup::command_initial_setup_from_launcher::run_command_initial_setup_from_launcher;
 use juliaup::command_api::run_command_api;
 #[cfg(feature = "selfupdate")]
-use juliaup::{command_selfchannel::run_command_selfchannel,command_selfupdate::run_command_selfupdate,command_selfinstall::run_command_selfinstall, command_selfuninstall::run_command_selfuninstall};
-#[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
-use juliaup::command_config_backgroundselfupdate::run_command_config_backgroundselfupdate;
-#[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
-use juliaup::command_config_startupselfupdate::run_command_config_startupselfupdate;
-
+use juliaup::{
+    command_selfchannel::run_command_selfchannel,
+    command_selfupdate::run_command_selfupdate,
+    command_selfinstall::run_command_selfinstall,
+    command_selfuninstall::run_command_selfuninstall,
+    command_config_backgroundselfupdate::run_command_config_backgroundselfupdate,
+    command_config_startupselfupdate::run_command_config_startupselfupdate,
+};
 
 #[derive(Parser)]
 #[clap(name="Juliaup", version)]
@@ -64,7 +66,7 @@ enum Juliaup {
     #[clap(name = "46029ef5-0b73-4a71-bff3-d0d05de42aac", setting(clap::AppSettings::Hidden))]
     InitialSetupFromLauncher {
     },
-    #[cfg(feature = "selfupdate")]
+    #[cfg(any(feature = "selfupdate", feature = "windowsstore"))]
     #[clap(subcommand, name = "self")]
     SelfSubCmd(SelfSubCmd),
     // This is used for the cron jobs that we create. By using this UUID for the command
@@ -74,18 +76,22 @@ enum Juliaup {
     SecretSelfUpdate {},
 }
 
-#[cfg(feature = "selfupdate")]
+#[cfg(any(feature = "selfupdate", feature = "windowsstore"))]
 #[derive(Parser)]
 /// Manage this juliaup installation
 enum SelfSubCmd {
+    #[cfg(any(feature = "selfupdate", feature = "windowsstore"))]
     /// Update juliaup itself
     Update {},
+    #[cfg(feature = "selfupdate")]
     /// Configure the channel to use for juliaup updates
     Channel {
         channel: String
     },
+    #[cfg(feature = "selfupdate")]
     /// Install this version of juliaup into the system
     Install {},
+    #[cfg(feature = "selfupdate")]
     /// Uninstall this version of juliaup from the system
     Uninstall {},
 }
@@ -99,14 +105,14 @@ enum ConfigSubCmd {
         /// New Value
         value: Option<bool>
     },
-    #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
+    #[cfg(feature = "selfupdate")]
     #[clap(name="backgroundselfupdateinterval")]
     /// The time between automatic background updates of Juliaup in minutes, use 0 to disable.
     BackgroundSelfupdateInterval {
         /// New value
         value: Option<i64>
     },
-    #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
+    #[cfg(feature = "selfupdate")]
     #[clap(name="startupselfupdateinterval")]
     /// The time between automatic updates at Julia startup of Juliaup in minutes, use 0 to disable.
     StartupSelfupdateInterval {
@@ -129,20 +135,24 @@ fn main() -> Result<()> {
         Juliaup::Config(subcmd) => match subcmd {
             #[cfg(not(target_os = "windows"))]
             ConfigSubCmd::ChannelSymlinks {value} => run_command_config_symlinks(value),
-            #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
+            #[cfg(feature = "selfupdate")]
             ConfigSubCmd::BackgroundSelfupdateInterval {value} => run_command_config_backgroundselfupdate(value),
-            #[cfg(all(not(target_os = "windows"), feature = "selfupdate"))]
+            #[cfg(feature = "selfupdate")]
             ConfigSubCmd::StartupSelfupdateInterval {value} => run_command_config_startupselfupdate(value),
         },
         Juliaup::Api {command} => run_command_api(command),
         Juliaup::InitialSetupFromLauncher {} => run_command_initial_setup_from_launcher(),
         #[cfg(feature = "selfupdate")]
         Juliaup::SecretSelfUpdate {} => run_command_selfupdate(),
-        #[cfg(feature = "selfupdate")]
+        #[cfg(any(feature = "selfupdate", feature = "windowsstore"))]
         Juliaup::SelfSubCmd(subcmd) => match subcmd {
+            #[cfg(any(feature = "selfupdate", feature = "windowsstore"))]
             SelfSubCmd::Update {} => run_command_selfupdate(),
+            #[cfg(feature = "selfupdate")]
             SelfSubCmd::Channel {channel}  =>  run_command_selfchannel(channel),
+            #[cfg(feature = "selfupdate")]
             SelfSubCmd::Install {} => run_command_selfinstall(),
+            #[cfg(feature = "selfupdate")]
             SelfSubCmd::Uninstall {} => run_command_selfuninstall(),
         }
     }

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -14,12 +14,13 @@ use juliaup::command_api::run_command_api;
 #[cfg(feature = "selfupdate")]
 use juliaup::{
     command_selfchannel::run_command_selfchannel,
-    command_selfupdate::run_command_selfupdate,
     command_selfinstall::run_command_selfinstall,
     command_selfuninstall::run_command_selfuninstall,
     command_config_backgroundselfupdate::run_command_config_backgroundselfupdate,
     command_config_startupselfupdate::run_command_config_startupselfupdate,
 };
+#[cfg(any(feature = "selfupdate", feature = "windowsstore"))]
+use juliaup::command_selfupdate::run_command_selfupdate;
 
 #[derive(Parser)]
 #[clap(name="Juliaup", version)]

--- a/src/command_add.rs
+++ b/src/command_add.rs
@@ -41,7 +41,8 @@ pub fn run_command_add(channel: String) -> Result<()> {
     save_config_db(&mut config_file)
         .with_context(|| format!("Failed to save configuration file from `add` command after '{}' was installed.", channel))?;
 
-    if std::env::consts::OS != "windows" && create_symlinks {
+    #[cfg(not(target_os = "windows)"))]
+    if create_symlinks {
         create_symlink(
             &JuliaupConfigChannel::SystemChannel {
                 version: required_version.clone(),

--- a/src/command_config_backgroundselfupdate.rs
+++ b/src/command_config_backgroundselfupdate.rs
@@ -1,7 +1,7 @@
-#[cfg(not(target_os = "windows"))]
+#[cfg(feature = "selfupdate")]
 use anyhow::Result;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(feature = "selfupdate")]
 pub fn run_command_config_backgroundselfupdate(value: Option<i64>) -> Result<()> {
     use crate::operations::{install_background_selfupdate, uninstall_background_selfupdate};
     use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};

--- a/src/command_config_startupselfupdate.rs
+++ b/src/command_config_startupselfupdate.rs
@@ -1,7 +1,7 @@
-#[cfg(not(target_os = "windows"))]
+#[cfg(feature = "selfupdate")]
 use anyhow::Result;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(feature = "selfupdate")]
 pub fn run_command_config_startupselfupdate(value: Option<i64>) -> Result<()> {
     use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
     use anyhow::{bail, Context};

--- a/src/command_config_symlinks.rs
+++ b/src/command_config_symlinks.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 pub fn run_command_config_symlinks(value: Option<bool>) -> Result<()> {
     use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
     use crate::operations::{create_symlink, remove_symlink};
-    use anyhow::{bail, Context};
+    use anyhow::Context;
 
     match value {
         Some(value) => {
@@ -13,10 +13,6 @@ pub fn run_command_config_symlinks(value: Option<bool>) -> Result<()> {
                 .with_context(|| "`config` command failed to load configuration data.")?;
     
             let mut value_changed = false;
-
-            if std::env::consts::OS == "windows" {
-                bail!("Symlinks not supported on Windows.");
-            }
 
             if value != config_file.data.settings.create_channel_symlinks {
                 config_file.data.settings.create_channel_symlinks = value;

--- a/src/command_link.rs
+++ b/src/command_link.rs
@@ -32,7 +32,8 @@ pub fn run_command_link(channel: String, file: String, args: Vec<String>) -> Res
     save_config_db(&mut config_file)
         .with_context(|| "`link` command failed to save configuration db.")?;
 
-    if std::env::consts::OS != "windows" && create_symlinks {
+    #[cfg(not(target_os = "windows)"))]
+    if create_symlinks {
         create_symlink(
             &JuliaupConfigChannel::LinkedChannel {
                 command: file.clone(),

--- a/src/command_remove.rs
+++ b/src/command_remove.rs
@@ -17,9 +17,8 @@ pub fn run_command_remove(channel: String) -> Result<()> {
 
     config_file.data.installed_channels.remove(&channel);
 
-    if std::env::consts::OS != "windows" {
-        remove_symlink(&format!("julia-{}", channel))?;
-    }
+    #[cfg(not(target_os = "windows)"))]
+    remove_symlink(&format!("julia-{}", channel))?;
 
     garbage_collect_versions(&mut config_file.data)?;
 

--- a/src/command_selfchannel.rs
+++ b/src/command_selfchannel.rs
@@ -1,11 +1,11 @@
-#[cfg(not(feature = "windowsstore"))]
-use crate::config_file::*;
-#[cfg(not(feature = "windowsstore"))]
-use anyhow::{bail, Context};
+#[cfg(feature = "selfupdate")]
 use anyhow::Result;
 
-#[cfg(not(feature = "windowsstore"))]
+#[cfg(feature = "selfupdate")]
 pub fn run_command_selfchannel(channel: String) -> Result<()> {
+    use crate::config_file::{load_mut_config_db, save_config_db};
+    use anyhow::{bail, Context};
+
     let mut config_file = load_mut_config_db()
         .with_context(|| "`self update` command failed to load configuration data.")?;
 
@@ -17,13 +17,6 @@ pub fn run_command_selfchannel(channel: String) -> Result<()> {
 
     save_config_db(&mut config_file)
         .with_context(|| "`selfchannel` command failed to save configuration db.")?;
-
-    Ok(())
-}
-
-#[cfg(feature = "windowsstore")]
-pub fn run_command_selfchannel(_channel: String) -> Result<()> {
-    println!("This command is currently not supported in the Windows Store distributed version of juliaup.");
 
     Ok(())
 }

--- a/src/command_selfinstall.rs
+++ b/src/command_selfinstall.rs
@@ -1,26 +1,13 @@
+#[cfg(feature = "selfupdate")]
 use anyhow::Result;
 
-#[cfg(all(not(feature = "windowsstore"),feature = "selfupdate"))]
+#[cfg(feature = "selfupdate")]
 pub fn run_command_selfinstall() -> Result<()> {
     use crate::command_config_backgroundselfupdate::run_command_config_backgroundselfupdate;
 
     run_command_config_backgroundselfupdate(Some(60)).unwrap();
 
     println!("Successfully created a background task that updates juliaup itself.");
-
-    Ok(())
-}
-
-#[cfg(all(not(feature = "windowsstore"),not(feature = "selfupdate")))]
-pub fn run_command_selfinstall() -> Result<()> {    
-    println!("This command is not supported in this version of juliaup.");
-
-    Ok(())
-}
-
-#[cfg(feature = "windowsstore")]
-pub fn run_command_selfinstall() -> Result<()> {
-    println!("This command is currently not supported in the Windows Store distributed version of juliaup.");
 
     Ok(())
 }

--- a/src/command_selfuninstall.rs
+++ b/src/command_selfuninstall.rs
@@ -1,26 +1,13 @@
+#[cfg(feature = "selfupdate")]
 use anyhow::Result;
 
-#[cfg(all(not(feature = "windowsstore"),feature = "selfupdate"))]
+#[cfg(feature = "selfupdate")]
 pub fn run_command_selfuninstall() -> Result<()> {
     use crate::command_config_backgroundselfupdate::run_command_config_backgroundselfupdate;
 
     run_command_config_backgroundselfupdate(Some(0)).unwrap();
 
     println!("Successfully removed the background task that updates juliaup itself.");
-
-    Ok(())
-}
-
-#[cfg(all(not(feature = "windowsstore"),not(feature = "selfupdate")))]
-pub fn run_command_selfuninstall() -> Result<()> {    
-    println!("This command is not supported in this version of juliaup.");
-
-    Ok(())
-}
-
-#[cfg(feature = "windowsstore")]
-pub fn run_command_selfuninstall() -> Result<()> {
-    println!("This command is currently not supported in the Windows Store distributed version of juliaup.");
 
     Ok(())
 }

--- a/src/command_selfupdate.rs
+++ b/src/command_selfupdate.rs
@@ -1,35 +1,15 @@
-#[cfg(feature = "selfupdate")]
-#[cfg(not(feature = "windowsstore"))]
-use crate::config_file::*;
-#[cfg(feature = "selfupdate")]
-#[cfg(not(feature = "windowsstore"))]
-use crate::utils::get_juliaserver_base_url;
-#[cfg(feature = "selfupdate")]
-#[cfg(not(feature = "windowsstore"))]
-use anyhow::{bail, anyhow};
-#[cfg(feature = "selfupdate")]
-use anyhow::Context;
+#[cfg(any(feature = "selfupdate", feature = "windowsstore"))]
 use anyhow::Result;
-#[cfg(feature = "selfupdate")]
-#[cfg(not(feature = "windowsstore"))]
-use crate::operations::{download_juliaup_version,download_extract_sans_parent};
-#[cfg(feature = "selfupdate")]
-#[cfg(not(feature = "windowsstore"))]
-use crate::get_juliaup_target;
-#[cfg(all(feature = "windowsstore", feature = "selfupdate"))]
-use windows::{core::Interface,Win32::{System::Console::GetConsoleWindow, UI::Shell::IInitializeWithWindow}};
 
-#[cfg(not(feature = "selfupdate"))]
+#[cfg(feature = "selfupdate")]
 pub fn run_command_selfupdate() -> Result<()> {
-    println!("error: self-update is disabled for this build of juliaup");
-    println!("error: you should probably use your system package manager to update juliaup");
+    use crate::config_file::{load_mut_config_db, save_config_db};
+    use crate::utils::get_juliaserver_base_url;
+    use anyhow::{bail, anyhow};
+    use anyhow::Context;
+    use crate::operations::{download_juliaup_version,download_extract_sans_parent};
+    use crate::get_juliaup_target;
 
-    Ok(())
-}
-
-#[cfg(feature = "selfupdate")]
-#[cfg(not(feature = "windowsstore"))]
-pub fn run_command_selfupdate() -> Result<()> {
     let mut config_data =
         load_mut_config_db().with_context(|| "`selfupdate` command failed to load configuration db.")?;
 
@@ -87,9 +67,10 @@ pub fn run_command_selfupdate() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "selfupdate")]
 #[cfg(feature = "windowsstore")]
 pub fn run_command_selfupdate() -> Result<()> {
+    use windows::{core::Interface,Win32::{System::Console::GetConsoleWindow, UI::Shell::IInitializeWithWindow}};
+
     let update_manager = windows::Services::Store::StoreContext::GetDefault()    
         .with_context(|| "Failed to get the store context.")?;
 

--- a/src/command_selfupdate.rs
+++ b/src/command_selfupdate.rs
@@ -69,6 +69,7 @@ pub fn run_command_selfupdate() -> Result<()> {
 
 #[cfg(feature = "windowsstore")]
 pub fn run_command_selfupdate() -> Result<()> {
+    use anyhow::Context;
     use windows::{core::Interface,Win32::{System::Console::GetConsoleWindow, UI::Shell::IInitializeWithWindow}};
 
     let update_manager = windows::Services::Store::StoreContext::GetDefault()    

--- a/src/command_update.rs
+++ b/src/command_update.rs
@@ -25,7 +25,8 @@ fn update_channel(config_db: &mut JuliaupConfig, channel: &String, version_db: &
                     },
                 );
 
-                if std::env::consts::OS != "windows" && config_db.settings.create_channel_symlinks {
+                #[cfg(not(target_os = "windows)"))]
+                if config_db.settings.create_channel_symlinks {
                     create_symlink(
                         &JuliaupConfigChannel::SystemChannel {
                             version: should_version.version.clone(),

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -272,7 +272,7 @@ r#"#!/bin/sh
 #[cfg(target_os = "windows")]
 pub fn create_symlink(_: &JuliaupConfigChannel, _: &String) -> Result<()> { Ok(()) }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(feature = "selfupdate")]
 pub fn install_background_selfupdate(interval: i64) -> Result<()> {
     use itertools::Itertools;
     use std::{io::Write, process::Stdio};
@@ -333,7 +333,7 @@ pub fn install_background_selfupdate(interval: i64) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(feature = "selfupdate")]
 pub fn uninstall_background_selfupdate() -> Result<()> {
     use std::{io::Write, process::Stdio};
     use itertools::Itertools;


### PR DESCRIPTION
The new model is that if no feature is selected, none of the self update features are compiled. And then one can _either_ select `selfupdate` or `windowsstore`. Also sorted out some of the platform specific compile statements.