### PR TITLE
Move config values for self update into separate file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,10 @@ jobs:
             features: dummy
           - target: x86_64-apple-darwin
             os: macos
-            features: selfupdate
+            features: dummy
           - target: x86_64-unknown-linux-gnu
             os: ubuntu
-            features: selfupdate
+            features: dummy
           - target: i686-pc-windows-msvc
             os: windows
             features: dummy

--- a/src/command_api.rs
+++ b/src/command_api.rs
@@ -41,11 +41,11 @@ pub fn run_command_api(command: String) -> Result<()> {
         other_versions: Vec::new(),
     };
 
-    let config_data =
+    let config_file =
         load_config_db()
         .with_context(|| "Failed to load configuration file while running the getconfig1 API command.")?;
 
-    for (key, value) in config_data.installed_channels {
+    for (key, value) in config_file.data.installed_channels {
         let curr = match value {
             JuliaupConfigChannel::SystemChannel {
                 version: fullversion,
@@ -55,7 +55,7 @@ pub fn run_command_api(command: String) -> Result<()> {
 
                 version.build = semver::BuildMetadata::EMPTY;
 
-                match config_data.installed_versions.get(&fullversion) {
+                match config_file.data.installed_versions.get(&fullversion) {
                     Some(channel) => JuliaupChannelInfo {
                         name: key.clone(),
                         file: julia_bin_root_path
@@ -111,7 +111,7 @@ pub fn run_command_api(command: String) -> Result<()> {
             },
         };
 
-        match config_data.default {
+        match config_file.data.default {
             Some(ref default_value) => {
                 if &key == default_value {
                     ret_value.default = Some(curr.clone());

--- a/src/command_config_backgroundselfupdate.rs
+++ b/src/command_config_backgroundselfupdate.rs
@@ -21,8 +21,8 @@ pub fn run_command_config_backgroundselfupdate(value: Option<i64>, quiet: bool) 
 
             let value = if value==0 {None} else {Some(value)};
 
-            if value != config_file.data.settings.background_selfupdate_interval {
-                config_file.data.settings.background_selfupdate_interval = value;
+            if value != config_file.self_data.background_selfupdate_interval {
+                config_file.self_data.background_selfupdate_interval = value;
 
                 value_changed = true;
 
@@ -55,13 +55,13 @@ pub fn run_command_config_backgroundselfupdate(value: Option<i64>, quiet: bool) 
             }
         },
         None => {
-            let config_data = load_config_db()
+            let config_file = load_config_db()
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {
                 eprintln!(
                     "Property 'backgroundselfupdateinterval' set to '{}'",
-                    match config_data.settings.background_selfupdate_interval {
+                    match config_file.self_data.background_selfupdate_interval {
                         Some(value) => value,
                         None => 0
                     }

--- a/src/command_config_modifypath.rs
+++ b/src/command_config_modifypath.rs
@@ -5,20 +5,20 @@ use anyhow::Result;
 pub fn run_command_config_modifypath(value: Option<bool>, quiet: bool) -> Result<()> {
     use crate::operations::{add_binfolder_to_path_in_shell_scripts, remove_binfolder_from_path_in_shell_scripts};
     use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
-    use anyhow::{Context,anyhow};
-
+    use crate::utils::get_juliaup_executable_path;
+    use anyhow::Context;
 
     match value {
         Some(value) => {
             let mut config_file = load_mut_config_db()
                 .with_context(|| "`config` command failed to load configuration data.")?;
     
-            let executable_path = config_file.data.clone().self_install_location.ok_or(anyhow!("Trying to configure PATH modifications but the config file is missing the field SelfInstallLocation."))?;
+            let executable_path = get_juliaup_executable_path().unwrap();
 
             let mut value_changed = false;
 
-            if value != config_file.data.settings.modify_path {
-                config_file.data.settings.modify_path = value;
+            if value != config_file.self_data.modify_path {
+                config_file.self_data.modify_path = value;
 
                 value_changed = true;
             }
@@ -43,11 +43,11 @@ pub fn run_command_config_modifypath(value: Option<bool>, quiet: bool) -> Result
             }
         },
         None => {
-            let config_data = load_config_db()
+            let config_file = load_config_db()
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {
-                eprintln!("Property 'modifypath' set to '{}'", config_data.settings.modify_path);
+                eprintln!("Property 'modifypath' set to '{}'", config_file.self_data.modify_path);
             }
         }
     };

--- a/src/command_config_startupselfupdate.rs
+++ b/src/command_config_startupselfupdate.rs
@@ -19,8 +19,8 @@ pub fn run_command_config_startupselfupdate(value: Option<i64>, quiet: bool) -> 
 
             let value = if value==0 {None} else {Some(value)};
 
-            if value != config_file.data.settings.startup_selfupdate_interval {
-                config_file.data.settings.startup_selfupdate_interval = value;
+            if value != config_file.self_data.startup_selfupdate_interval {
+                config_file.self_data.startup_selfupdate_interval = value;
 
                 value_changed = true;
             }
@@ -44,13 +44,13 @@ pub fn run_command_config_startupselfupdate(value: Option<i64>, quiet: bool) -> 
             }
         },
         None => {
-            let config_data = load_config_db()
+            let config_file = load_config_db()
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {
                 eprintln!(
                     "Property 'startupselfupdateinterval' set to '{}'",
-                    match config_data.settings.startup_selfupdate_interval {
+                    match config_file.self_data.startup_selfupdate_interval {
                         Some(value) => value,
                         None => 0
                     }

--- a/src/command_config_symlinks.rs
+++ b/src/command_config_symlinks.rs
@@ -41,11 +41,11 @@ pub fn run_command_config_symlinks(value: Option<bool>, quiet: bool) -> Result<(
             }
         },
         None => {
-            let config_data = load_config_db()
+            let config_file = load_config_db()
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {
-                eprintln!("Property 'channelsymlinks' set to '{}'", config_data.settings.create_channel_symlinks);
+                eprintln!("Property 'channelsymlinks' set to '{}'", config_file.data.settings.create_channel_symlinks);
             }
         }
     };

--- a/src/command_selfchannel.rs
+++ b/src/command_selfchannel.rs
@@ -13,7 +13,7 @@ pub fn run_command_selfchannel(channel: String) -> Result<()> {
         bail!("'{}' is not a valid juliaup channel, you can only specify 'release', 'releasepreview' or 'dev'.", channel);
     }
 
-    config_file.data.juliaup_channel = Some(channel.clone());
+    config_file.self_data.juliaup_channel = Some(channel.clone());
 
     save_config_db(&mut config_file)
         .with_context(|| "`selfchannel` command failed to save configuration db.")?;

--- a/src/command_selfupdate.rs
+++ b/src/command_selfupdate.rs
@@ -10,10 +10,10 @@ pub fn run_command_selfupdate() -> Result<()> {
     use crate::operations::{download_juliaup_version,download_extract_sans_parent};
     use crate::{get_juliaup_target, get_own_version};
 
-    let mut config_data =
+    let mut config_file =
         load_mut_config_db().with_context(|| "`selfupdate` command failed to load configuration db.")?;
 
-    let juliaup_channel = match &config_data.data.juliaup_channel {
+    let juliaup_channel = match &config_file.self_data.juliaup_channel {
         Some(juliaup_channel) => juliaup_channel.to_string(),
         None => "release".to_string()
     };
@@ -35,9 +35,9 @@ pub fn run_command_selfupdate() -> Result<()> {
 
     let version = download_juliaup_version(&version_url.to_string())?;
 
-    config_data.data.last_selfupdate = Some(chrono::Utc::now());
+    config_file.self_data.last_selfupdate = Some(chrono::Utc::now());
 
-    save_config_db(&mut config_data)
+    save_config_db(&mut config_file)
         .with_context(|| "Failed to save configuration file.")?;
 
     if version==get_own_version().unwrap() {

--- a/src/command_status.rs
+++ b/src/command_status.rs
@@ -21,18 +21,18 @@ struct ChannelRow {
 }
 
 pub fn run_command_status() -> Result<()> {
-    let config_data =
+    let config_file =
         load_config_db().with_context(|| "`status` command failed to load configuration file.")?;
 
     let versiondb_data =
         load_versions_db().with_context(|| "`status` command failed to load versions db.")?;
 
-    let rows_in_table: Vec<_> = config_data.installed_channels
+    let rows_in_table: Vec<_> = config_file.data.installed_channels
         .iter()
         .sorted_by_key(|i| i.0.to_string())
         .map(|i| -> ChannelRow {
             ChannelRow {
-                default: match config_data.default {
+                default: match config_file.data.default {
                     Some(ref default_value) => {
                         if &i.0 == &default_value {
                             "*"

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -389,7 +389,7 @@ pub fn uninstall_background_selfupdate() -> Result<()> {
 const S_MARKER: &str = "# >>> juliaup initialize >>>";
 const E_MARKER: &str = "# <<< juliaup initialize <<<";
 
-fn get_shell_script_juliaup_content(bin_path: &str) -> Result<String> {
+fn get_shell_script_juliaup_content(bin_path: &PathBuf) -> Result<String> {
     let mut result = String::new();
 
     result.push_str(S_MARKER);
@@ -400,8 +400,8 @@ fn get_shell_script_juliaup_content(bin_path: &str) -> Result<String> {
     result.push_str("# This is added to both ~/.bashrc ~/.profile to mitigate each's shortcommings\n");
     result.push_str("# e.g. ~/.bashrc is is only for interactive shells and ~/.profile is often not loaded\n");
     result.push('\n');
-    result.push_str(&format!("case \":$PATH:\" in *:{}:*);; *)\n", bin_path));
-    result.push_str(&format!("    export PATH={}${{PATH:+:${{PATH}}}};;\n", bin_path));
+    result.push_str(&format!("case \":$PATH:\" in *:{}:*);; *)\n", bin_path.to_string_lossy()));
+    result.push_str(&format!("    export PATH={}${{PATH:+:${{PATH}}}};;\n", bin_path.to_string_lossy()));
     result.push_str("esac\n");
     result.push('\n');
     result.push_str(E_MARKER);
@@ -439,7 +439,7 @@ fn match_markers(buffer: &str, include_newlines: bool) -> Result<Option<(usize,u
     }
 }
 
-fn add_path_to_specific_file(bin_path: &str, path: PathBuf) -> Result<()> {
+fn add_path_to_specific_file(bin_path: &PathBuf, path: PathBuf) -> Result<()> {
     let mut file = std::fs::OpenOptions::new().read(true).write(true).create(true).open(&path)
     .with_context(|| "Failed to open juliaup config file.")?;
 
@@ -498,7 +498,7 @@ fn remove_path_from_specific_file(path: PathBuf) -> Result<()> {
     Ok(())
 }
 
-pub fn add_binfolder_to_path_in_shell_scripts(bin_path: &str) -> Result<()> {
+pub fn add_binfolder_to_path_in_shell_scripts(bin_path: &PathBuf) -> Result<()> {
     let home_dir = dirs::home_dir().unwrap();
 
     add_path_to_specific_file(bin_path, home_dir.join(".bashrc")).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,6 +63,33 @@ pub fn get_juliaupconfig_lockfile_path() -> Result<PathBuf> {
     Ok(path)
 }
 
+#[cfg(feature = "selfupdate")]
+pub fn get_juliaupselfconfig_path() -> Result<PathBuf> {
+    let my_own_path = std::env::current_exe()
+            .with_context(|| "Could not determine the path of the running exe.")?;
+
+    let my_own_folder = my_own_path.parent()
+        .ok_or_else(|| anyhow!("Could not determine parent."))?;
+
+    let my_parent_folder = my_own_folder.parent()
+        .ok_or_else(|| anyhow!("Could not determine parent."))?;
+
+    let path = my_parent_folder.join("juliaupself.json");
+
+    Ok(path)
+}
+
+#[cfg(feature = "selfupdate")]
+pub fn get_juliaup_executable_path() -> Result<PathBuf> {
+    let my_own_path = std::env::current_exe()
+        .with_context(|| "Could not determine the path of the running exe.")?;
+
+    let my_own_folder = my_own_path.parent()
+        .ok_or_else(|| anyhow!("Could not determine parent."))?;
+
+    Ok(my_own_folder.to_path_buf())
+}
+
 pub fn get_bin_dir() -> Result<PathBuf> {
     let entry_sep = if std::env::consts::OS == "windows" {';'} else {':'};
 


### PR DESCRIPTION
The idea is that the self update config file is _not_ being redirected by the content of `JULIA_DEPOT`.