### PR TITLE
Add Homebrew installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ A prerelease version of the installer can be installed on Linux or Mac by execut
 curl -fsSL https://install.julialang.org/releasepreview | sh
 ```
 
-in a shell. Note that the Mac and Linux version are considered prerelease, have known bugs and might often break.
+in a shell. [Homebrew](https://brew.sh) users can also do
+
+```
+brew install juliaup
+```
+
+Note that the Mac and Linux version are considered prerelease, have known bugs and might often break.
 
 ### Arch Linux
 


### PR DESCRIPTION
Juliaup can now be installed via Homebrew (on both macOS and Linux), so let's mention it on the README for the benefit of users who might want to manage their installation using that.