### PR TITLE
fix: add missing `/` for JULIAUP_SERVER URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ The available system provided channels are:
 
 All of these channels can be combined with the `~x86`, `~x64` or `~aarch64` suffix to download a specific platform version.
 
+## Juliaup server
+
+Juliaup by default downloads julia binary tarballs from the official server "https://julialang-s3.julialang.org".
+If requested, the environment variable `JULIAUP_SERVER` can be used to tell Juliaup to use a third-patry mirror server.
+
 ## More information
 
 [This JuliaCon 2021 talk](https://www.youtube.com/watch?v=rFlbjWC6zYA) is a short introduction to Juliaup. Note that the video was recorded before the Linux and Mac versions were finished, but all the information about `juliaup` itself applies equally on Linux and Mac.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 pub fn get_juliaserver_base_url() -> Result<Url> {
     let base_url = if let Ok(val) = std::env::var("JULIAUP_SERVER") { 
-        val
+        if val.ends_with("/") {val} else {format!("{}/", val)}
      } else {
         "https://julialang-s3.julialang.org".to_string() 
     };


### PR DESCRIPTION
For server URL "https://myserver.com/julia-releases", an extra backslash is required so that `join` does not drop the "julia-release" prefix.

This fixes usage such as:

`JULIAUP_SERVER=https://mirrors.bfsu.edu.cn/julia-releases juliaup add 1.7.2`

The second commit mentions the secret `JULIAUP_SERVER` environment variable in README.