### PR TITLE
Fix docstring for `modifypath`

### DIFF
--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -121,7 +121,7 @@ enum ConfigSubCmd {
     },
     #[cfg(feature = "selfupdate")]
     #[clap(name="modifypath")]
-    /// The time between automatic updates at Julia startup of Juliaup in minutes, use 0 to disable.
+    /// Add the Julia binaries to your PATH by manipulating various shell startup scripts.
     ModifyPath {
         /// New value
         value: Option<bool>


### PR DESCRIPTION
Docstring and CLI help was showing
```bash
$ juliaup config help modifypath
juliaup-config-modifypath 
The time between automatic updates at Julia startup of Juliaup in minutes, use 0 to disable

USAGE:
    juliaup config modifypath [VALUE]

ARGS:
    <VALUE>    New value

OPTIONS:
    -h, --help    Print help information
```
