### PR TITLE
Make `winres` a Windows-only build dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,14 @@ windows = { version = "0.29", features = ["alloc", "std", "Win32_Foundation", "W
 
 [build-dependencies]
 anyhow = "1"
-winres = "0.1"
 itertools = "0.10"
 serde = {version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1"
 built = "0.5.1"
+
+[target.'cfg(windows)'.build-dependencies]
+winres = "0.1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,9 @@
 extern crate itertools;
 extern crate semver;
 extern crate serde;
-extern crate winres;
 extern crate serde_json;
+#[cfg(windows)]
+extern crate winres;
 #[path = "src/jsonstructs_versionsdb.rs"]
 mod jsonstructs_versionsdb;
 
@@ -763,7 +764,8 @@ fn main() -> Result<()> {
         format!("pub const BUNDLED_JULIA_VERSION: &str = {}; pub const BUNDLED_JULIA_FULL_VERSION: &str = {};", bundled_version, bundled_full_version)
     ).unwrap();
 
-    if cfg!(target_os = "windows") {
+    #[cfg(windows)]
+    {
         let mut res = winres::WindowsResource::new();
         res.set_icon("src/julia.ico");
         res.compile().unwrap();


### PR DESCRIPTION
`winres` is only used on Windows (and using it on other platforms is undefined behaviour: https://crates.io/crates/winres). I was playing around with the Fedora packaging system and this build dependency is problematic since (unsurprisingly) there's no Fedora package of the `winres` crate. Therefore this PR makes `winres` a Windows-only build dependency and replaces `cfg!` with a `cfg` directive in build.rs, as explained in the documentation (https://crates.io/crates/winres).

(BTW it seems one still has to patch Cargo.toml if one wants to create a Fedora package but one does not have to patch build.rs anymore: https://docs.fedoraproject.org/en-US/packaging-guidelines/Rust/#_nightly_features_and_dependencies_for_other_platforms)