### PR TITLE
Use valid semver identifiers for available_versions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -80,51 +80,51 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
     for v in &original_available_versions {
         if target_os == "windows" && target_arch == "x86_64" {
             db.available_versions.insert(
-                format!("{}+0~x64", v),
+                format!("{}+0.x64", v),
                 JuliaupVersionDBVersion {url_path: format!("bin/winnt/x64/{}.{}/julia-{}-win64.tar.gz", v.major, v.minor, v)}
             );
             db.available_versions.insert(
-                format!("{}+0~x86", v),
+                format!("{}+0.x86", v),
                 JuliaupVersionDBVersion {url_path: format!("bin/winnt/x86/{}.{}/julia-{}-win32.tar.gz", v.major, v.minor, v)}
             );
         } else if target_os == "windows" && target_arch == "x86" {
             db.available_versions.insert(
-                format!("{}+0~x86", v),
+                format!("{}+0.x86", v),
                 JuliaupVersionDBVersion {url_path: format!("bin/winnt/x86/{}.{}/julia-{}-win32.tar.gz", v.major, v.minor, v)}
             );
         } else if target_os == "linux" && target_arch == "x86_64" {
             db.available_versions.insert(
-                format!("{}+0~x64", v),
+                format!("{}+0.x64", v),
                 JuliaupVersionDBVersion {url_path: format!("bin/linux/x64/{}.{}/julia-{}-linux-x86_64.tar.gz", v.major, v.minor, v)}
             );
             db.available_versions.insert(
-                format!("{}+0~x86", v),
+                format!("{}+0.x86", v),
                 JuliaupVersionDBVersion {url_path: format!("bin/linux/x86/{}.{}/julia-{}-linux-i686.tar.gz", v.major, v.minor, v)}
             );
         } else if target_os == "linux" && target_arch == "x86" {
             db.available_versions.insert(
-                format!("{}+0~x86", v),
+                format!("{}+0.x86", v),
                 JuliaupVersionDBVersion {url_path: format!("bin/linux/x86/{}.{}/julia-{}-linux-i686.tar.gz", v.major, v.minor, v)}
             );
         } else if target_os == "linux" && target_arch == "aarch64" {
             db.available_versions.insert(
-                format!("{}+0~aarch64", v),
+                format!("{}+0.aarch64", v),
                 JuliaupVersionDBVersion {url_path: format!("bin/linux/aarch64/{}.{}/julia-{}-linux-aarch64.tar.gz", v.major, v.minor, v)}
             );
         } else if target_os == "macos" && target_arch == "x86_64"{
             db.available_versions.insert(
-                format!("{}+0~x64", v),
+                format!("{}+0.x64", v),
                 JuliaupVersionDBVersion {url_path: format!("bin/mac/x64/{}.{}/julia-{}-mac64.tar.gz", v.major, v.minor, v)}
             );
         } else if target_os == "macos" && target_arch == "aarch64"{
             db.available_versions.insert(
-                format!("{}+0~x64", v),
+                format!("{}+0.x64", v),
                 JuliaupVersionDBVersion {url_path: format!("bin/mac/x64/{}.{}/julia-{}-mac64.tar.gz", v.major, v.minor, v)}
             );
 
             if v >= &Version::new(1,7, 0) && v != &Version::new(1,7, 3){
                 db.available_versions.insert(
-                    format!("{}+0~aarch64", v),
+                    format!("{}+0.aarch64", v),
                     JuliaupVersionDBVersion {url_path: format!("bin/mac/aarch64/{}.{}/julia-{}-macaarch64.tar.gz", v.major, v.minor, v)}
                 );
             }
@@ -137,32 +137,32 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
             db.available_channels.insert(
                 format!("{}", v),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", v),
+                    version: format!("{}+0.x64", v),
                 },
             );
             db.available_channels.insert(
                 format!("{}~x64", v),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", v),
+                    version: format!("{}+0.x64", v),
                 },
             );
             db.available_channels.insert(
                 format!("{}~x86", v),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x86", v),
+                    version: format!("{}+0.x86", v),
                 },
             );
         } else if target_arch == "x86" {
             db.available_channels.insert(
                 format!("{}", v),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x86", v),
+                    version: format!("{}+0.x86", v),
                 },
             );
             db.available_channels.insert(
                 format!("{}~x86", v),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x86", v),
+                    version: format!("{}+0.x86", v),
                 },
             );
         } else if target_arch == "aarch64" {
@@ -170,32 +170,32 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
                 db.available_channels.insert(
                     format!("{}", v),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x86", v),
+                        version: format!("{}+0.x86", v),
                     },
                 );
                 db.available_channels.insert(
                     format!("{}~x64", v),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x64", v),
+                        version: format!("{}+0.x64", v),
                     },
                 );
                 db.available_channels.insert(
                     format!("{}~x86", v),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x86", v),
+                        version: format!("{}+0.x86", v),
                     },
                 );
             } else if target_os == "linux" {
                 db.available_channels.insert(
                     format!("{}", v),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~aarch64", v),
+                        version: format!("{}+0.aarch64", v),
                     },
                 );
                 db.available_channels.insert(
                     format!("{}~aarch64", v),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~aarch64", v),
+                        version: format!("{}+0.aarch64", v),
                     },
                 );
             } else if target_os == "macos" {
@@ -203,28 +203,28 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
                     db.available_channels.insert(
                         format!("{}", v),
                         JuliaupVersionDBChannel {
-                            version: format!("{}+0~aarch64", v),
+                            version: format!("{}+0.aarch64", v),
                         },
                     );
                 } else {
                     db.available_channels.insert(
                         format!("{}", v),
                         JuliaupVersionDBChannel {
-                            version: format!("{}+0~x64", v),
+                            version: format!("{}+0.x64", v),
                         },
                     );
                 }
                 db.available_channels.insert(
                     format!("{}~x64", v),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x64", v),
+                        version: format!("{}+0.x64", v),
                     },
                 );
                 if v >= &Version::new(1,7, 0) && v != &Version::new(1,7, 3) {
                     db.available_channels.insert(
                         format!("{}~aarch64", v),
                         JuliaupVersionDBChannel {
-                            version: format!("{}+0~aarch64", v),
+                            version: format!("{}+0.aarch64", v),
                         },
                     );
                 }
@@ -253,32 +253,32 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
             db.available_channels.insert(
                 format!("{}.{}", major, minor),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", v),
+                    version: format!("{}+0.x64", v),
                 },
             );
             db.available_channels.insert(
                 format!("{}.{}~x64", major, minor),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", v),
+                    version: format!("{}+0.x64", v),
                 },
             );
             db.available_channels.insert(
                 format!("{}.{}~x86", major, minor),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x86", v),
+                    version: format!("{}+0.x86", v),
                 },
             );
         } else if target_arch == "x86" {
             db.available_channels.insert(
                 format!("{}.{}", major, minor),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x86", v),
+                    version: format!("{}+0.x86", v),
                 },
             );
             db.available_channels.insert(
                 format!("{}.{}~x86", major, minor),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x86", v),
+                    version: format!("{}+0.x86", v),
                 },
             );
         } else if target_arch == "aarch64" {
@@ -286,32 +286,32 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
                 db.available_channels.insert(
                     format!("{}.{}", major, minor),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x86", v),
+                        version: format!("{}+0.x86", v),
                     },
                 );
                 db.available_channels.insert(
                     format!("{}.{}~x64", major, minor),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x64", v),
+                        version: format!("{}+0.x64", v),
                     },
                 );
                 db.available_channels.insert(
                     format!("{}.{}~x86", major, minor),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x86", v),
+                        version: format!("{}+0.x86", v),
                     },
                 );
             } else if target_os == "linux" {
                 db.available_channels.insert(
                     format!("{}.{}", major, minor),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~aarch64", v),
+                        version: format!("{}+0.aarch64", v),
                     },
                 );
                 db.available_channels.insert(
                     format!("{}.{}~aarch64", major, minor),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~aarch64", v),
+                        version: format!("{}+0.aarch64", v),
                     },
                 );
             } else if target_os == "macos" {
@@ -319,21 +319,21 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
                     db.available_channels.insert(
                         format!("{}.{}", major, minor),
                         JuliaupVersionDBChannel {
-                            version: format!("{}+0~aarch64", v),
+                            version: format!("{}+0.aarch64", v),
                         },
                     );
                 } else {
                     db.available_channels.insert(
                         format!("{}.{}", major, minor),
                         JuliaupVersionDBChannel {
-                            version: format!("{}+0~x64", v),
+                            version: format!("{}+0.x64", v),
                         },
                     );
                 }
                 db.available_channels.insert(
                     format!("{}.{}~x64", major, minor),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x64", v),
+                        version: format!("{}+0.x64", v),
                     },
                 );
 
@@ -342,14 +342,14 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
                     db.available_channels.insert(
                         format!("{}.{}~aarch64", major, minor),
                         JuliaupVersionDBChannel {
-                            version: format!("{}+0~aarch64", Version::new(1,7, 2)),
+                            version: format!("{}+0.aarch64", Version::new(1,7, 2)),
                         },
                     );
                 } else if v >= &&Version::new(1,7, 0) {
                     db.available_channels.insert(
                         format!("{}.{}~aarch64", major, minor),
                         JuliaupVersionDBChannel {
-                            version: format!("{}+0~aarch64", v),
+                            version: format!("{}+0.aarch64", v),
                         },
                     );
                 }
@@ -366,32 +366,32 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
             db.available_channels.insert(
                 format!("{}", major),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", v),
+                    version: format!("{}+0.x64", v),
                 },
             );
             db.available_channels.insert(
                 format!("{}~x64", major),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", v),
+                    version: format!("{}+0.x64", v),
                 },
             );
             db.available_channels.insert(
                 format!("{}~x86", major),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x86", v),
+                    version: format!("{}+0.x86", v),
                 },
             );
         } else if target_arch == "x86" {
             db.available_channels.insert(
                 format!("{}", major),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x86", v),
+                    version: format!("{}+0.x86", v),
                 },
             );
             db.available_channels.insert(
                 format!("{}~x86", major),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x86", v),
+                    version: format!("{}+0.x86", v),
                 },
             );
         } else if target_arch == "aarch64" {
@@ -399,32 +399,32 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
                 db.available_channels.insert(
                     format!("{}", major),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x86", v),
+                        version: format!("{}+0.x86", v),
                     },
                 );
                 db.available_channels.insert(
                     format!("{}~x64", major),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x64", v),
+                        version: format!("{}+0.x64", v),
                     },
                 );
                 db.available_channels.insert(
                     format!("{}~x86", major),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x86", v),
+                        version: format!("{}+0.x86", v),
                     },
                 );
             } else if target_os == "linux" {
                 db.available_channels.insert(
                     format!("{}", major),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~aarch64", v),
+                        version: format!("{}+0.aarch64", v),
                     },
                 );
                 db.available_channels.insert(
                     format!("{}~aarch64", major),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~aarch64", v),
+                        version: format!("{}+0.aarch64", v),
                     },
                 );
             } else if target_os == "macos" {
@@ -432,21 +432,21 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
                     db.available_channels.insert(
                         format!("{}", major),
                         JuliaupVersionDBChannel {
-                            version: format!("{}+0~aarch64", v),
+                            version: format!("{}+0.aarch64", v),
                         },
                     );
                 } else {
                     db.available_channels.insert(
                         format!("{}", major),
                         JuliaupVersionDBChannel {
-                            version: format!("{}+0~x64", v),
+                            version: format!("{}+0.x64", v),
                         },
                     );    
                 }
                 db.available_channels.insert(
                     format!("{}~x64", major),
                     JuliaupVersionDBChannel {
-                        version: format!("{}+0~x64", v),
+                        version: format!("{}+0.x64", v),
                     },
                 );
 
@@ -455,14 +455,14 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
                     db.available_channels.insert(
                         format!("{}~aarch64", major),
                         JuliaupVersionDBChannel {
-                            version: format!("{}+0~aarch64", Version::new(1,7,2)),
+                            version: format!("{}+0.aarch64", Version::new(1,7,2)),
                         },
                     );
                 } else if v >= &&Version::new(1,7, 0) {
                     db.available_channels.insert(
                         format!("{}~aarch64", major),
                         JuliaupVersionDBChannel {
-                            version: format!("{}+0~aarch64", v),
+                            version: format!("{}+0.aarch64", v),
                         },
                     );
                 }
@@ -484,75 +484,75 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
         db.available_channels.insert(
             "release".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x64", release_version),
+                version: format!("{}+0.x64", release_version),
             },
         );
         db.available_channels.insert(
             "release~x64".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x64", release_version),
+                version: format!("{}+0.x64", release_version),
             },
         );
         db.available_channels.insert(
             "release~x86".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", release_version),
+                version: format!("{}+0.x86", release_version),
             },
         );
 
         db.available_channels.insert(
             "lts".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x64", lts_version),
+                version: format!("{}+0.x64", lts_version),
             },
         );
         db.available_channels.insert(
             "lts~x64".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x64", lts_version),
+                version: format!("{}+0.x64", lts_version),
             },
         );
         db.available_channels.insert(
             "lts~x86".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", lts_version),
+                version: format!("{}+0.x86", lts_version),
             },
         );
         db.available_channels.insert(
             "beta".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x64", beta_version),
+                version: format!("{}+0.x64", beta_version),
             },
         );
         db.available_channels.insert(
             "beta~x64".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x64", beta_version),
+                version: format!("{}+0.x64", beta_version),
             },
         );
         db.available_channels.insert(
             "beta~x86".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", beta_version),
+                version: format!("{}+0.x86", beta_version),
             },
         );
 
         db.available_channels.insert(
             "rc".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x64", rc_version),
+                version: format!("{}+0.x64", rc_version),
             },
         );
         db.available_channels.insert(
             "rc~x64".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x64", rc_version),
+                version: format!("{}+0.x64", rc_version),
             },
         );
         db.available_channels.insert(
             "rc~x86".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", rc_version),
+                version: format!("{}+0.x86", rc_version),
             },
         );
     } else if target_arch == "aarch64" {
@@ -560,52 +560,52 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
             db.available_channels.insert(
                 "release".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", release_version),
+                    version: format!("{}+0.aarch64", release_version),
                 },
             );
             db.available_channels.insert(
                 "release~aarch64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", release_version),
+                    version: format!("{}+0.aarch64", release_version),
                 },
             );
 
             db.available_channels.insert(
                 "lts".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", lts_version),
+                    version: format!("{}+0.aarch64", lts_version),
                 },
             );
             db.available_channels.insert(
                 "lts~aarch64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", lts_version),
+                    version: format!("{}+0.aarch64", lts_version),
                 },
             );
 
             db.available_channels.insert(
                 "beta".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", beta_version),
+                    version: format!("{}+0.aarch64", beta_version),
                 },
             );
             db.available_channels.insert(
                 "beta~aarch64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", beta_version),
+                    version: format!("{}+0.aarch64", beta_version),
                 },
             );
 
             db.available_channels.insert(
                 "rc".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", rc_version),
+                    version: format!("{}+0.aarch64", rc_version),
                 },
             );
             db.available_channels.insert(
                 "rc~aarch64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", rc_version),
+                    version: format!("{}+0.aarch64", rc_version),
                 },
             );
         }
@@ -613,20 +613,20 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
             db.available_channels.insert(
                 "release".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", release_version),
+                    version: format!("{}+0.x64", release_version),
                 },
             );
             db.available_channels.insert(
                 "release~x64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", release_version),
+                    version: format!("{}+0.x64", release_version),
                 },
             );
             db.available_channels.insert(
                 "release~aarch64".to_string(),
                 JuliaupVersionDBChannel {
-                    // version: format!("{}+0~aarch64", release_version),
-                    version: format!("{}+0~aarch64", Version::new(1,7,2)), // TODO Remove this and go back to the previous line once we have a new aarch64 build again
+                    // version: format!("{}+0.aarch64", release_version),
+                    version: format!("{}+0.aarch64", Version::new(1,7,2)), // TODO Remove this and go back to the previous line once we have a new aarch64 build again
                 },
             );
 
@@ -634,51 +634,51 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
             db.available_channels.insert(
                 "lts".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", lts_version),
+                    version: format!("{}+0.x64", lts_version),
                 },
             );
             db.available_channels.insert(
                 "lts~x64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", lts_version),
+                    version: format!("{}+0.x64", lts_version),
                 },
             );
 
             db.available_channels.insert(
                 "beta".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", beta_version),
+                    version: format!("{}+0.aarch64", beta_version),
                 },
             );
             db.available_channels.insert(
                 "beta~x64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", beta_version),
+                    version: format!("{}+0.x64", beta_version),
                 },
             );
             db.available_channels.insert(
                 "beta~aarch64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", beta_version),
+                    version: format!("{}+0.aarch64", beta_version),
                 },
             );
 
             db.available_channels.insert(
                 "rc".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", rc_version),
+                    version: format!("{}+0.aarch64", rc_version),
                 },
             );
             db.available_channels.insert(
                 "rc~x64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", rc_version),
+                    version: format!("{}+0.x64", rc_version),
                 },
             );
             db.available_channels.insert(
                 "rc~aarch64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~aarch64", rc_version),
+                    version: format!("{}+0.aarch64", rc_version),
                 },
             );  
         }
@@ -686,52 +686,52 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
             db.available_channels.insert(
                 "release".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", release_version),
+                    version: format!("{}+0.x64", release_version),
                 },
             );
             db.available_channels.insert(
                 "release~x64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", release_version),
+                    version: format!("{}+0.x64", release_version),
                 },
             );
 
             db.available_channels.insert(
                 "lts".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", lts_version),
+                    version: format!("{}+0.x64", lts_version),
                 },
             );
             db.available_channels.insert(
                 "lts~x64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", lts_version),
+                    version: format!("{}+0.x64", lts_version),
                 },
             );
 
             db.available_channels.insert(
                 "beta".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", beta_version),
+                    version: format!("{}+0.x64", beta_version),
                 },
             );
             db.available_channels.insert(
                 "beta~x64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", beta_version),
+                    version: format!("{}+0.x64", beta_version),
                 },
             );
 
             db.available_channels.insert(
                 "rc".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", rc_version),
+                    version: format!("{}+0.x64", rc_version),
                 },
             );
             db.available_channels.insert(
                 "rc~x64".to_string(),
                 JuliaupVersionDBChannel {
-                    version: format!("{}+0~x64", rc_version),
+                    version: format!("{}+0.x64", rc_version),
                 },
             );
         }
@@ -739,52 +739,52 @@ fn produce_version_db() -> Result<JuliaupVersionDB> {
         db.available_channels.insert(
             "release".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", release_version),
+                version: format!("{}+0.x86", release_version),
             },
         );
         db.available_channels.insert(
             "release~x86".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", release_version),
+                version: format!("{}+0.x86", release_version),
             },
         );
 
         db.available_channels.insert(
             "lts".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", lts_version),
+                version: format!("{}+0.x86", lts_version),
             },
         );
         db.available_channels.insert(
             "lts~x86".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", lts_version),
+                version: format!("{}+0.x86", lts_version),
             },
         );
 
         db.available_channels.insert(
             "beta".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", beta_version),
+                version: format!("{}+0.x86", beta_version),
             },
         );
         db.available_channels.insert(
             "beta~x86".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", beta_version),
+                version: format!("{}+0.x86", beta_version),
             },
         );
 
         db.available_channels.insert(
             "rc".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", rc_version),
+                version: format!("{}+0.x86", rc_version),
             },
         );
         db.available_channels.insert(
             "rc~x86".to_string(),
             JuliaupVersionDBChannel {
-                version: format!("{}+0~x86", rc_version),
+                version: format!("{}+0.x86", rc_version),
             },
         );
     } else {


### PR DESCRIPTION
Fixes #290 and starts to fix #140.

The strings we use to identify a specific version now are like `1.8.0-rc2+0.x64`, and that then translates into folder names on disc like `julia-1.8.0-rc2+0.x64`.

The general idea is that we supply two pieces of build metadata in the semver, separated by a `.`: 1) our own build number (always 0 at the moment, but this allows us to replace all shipped binaries if we need to) and 2) the platform string.

Channel names are unaffected by this, i.e. they still read like `release~x64` etc.

@pfitzseb and @KristofferC does that make sense? @KristofferC that still does not use the `Version` type in the code, but once we have changed the identifiers everywhere, we should be able to make that change also sometime down the road.