### PR TITLE
Start implementing a fallback for tls on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,8 @@ dependencies = [
  "native-tls",
  "normpath",
  "predicates",
+ "rustls",
+ "rustls-native-certs",
  "semver",
  "serde",
  "serde_json",
@@ -704,6 +706,7 @@ dependencies = [
  "thiserror",
  "ureq",
  "url",
+ "webpki-roots",
  "windows",
  "winres",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ native-tls = "0.2.10"
 
 [target.'cfg(all(not(macos),not(windows)))'.dependencies]
 ureq = { version = "2", features = ["native-certs"] }
+rustls = "0.20"
+rustls-native-certs = "0.6"
+webpki-roots = "0.22"
 
 [build-dependencies]
 anyhow = "1"


### PR DESCRIPTION
Fixes #335.

UPDATE: This PR is on hold for now, I might get back to it at some later point, but for now we are using `rustls` with webpki certificates on Linux.