### PR TITLE
Add usage tip on accessing added julia versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ Here are some of the things you can do with `juliaup`:
 - `juliaup self update` installs the latest version, which is necessary if new releases reach the beta channel, etc.
 - `juliaup` shows you what other commands are available.
 
-To launch the Julia version in channel `release`, run `julia +release` in your terminal.
-
 The available system provided channels are:
 - `release`: always points to the latest stable version.
 - `lts`: always points to the latest long term supported version.
@@ -84,6 +82,12 @@ The available system provided channels are:
 - major version channels, e.g. `1`.
 
 All of these channels can be combined with the `~x86`, `~x64` or `~aarch64` suffix to download a specific platform version.
+
+## Using installed julia versions
+
+To launch the default Julia version simply run `julia` in your terminal.
+
+To launch a specific Julia version, say in channel `release`, run `julia +release`.
 
 ## Juliaup server
 

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -33,7 +33,7 @@ enum Juliaup {
     Default {
         channel: String
     },
-    /// Add a specific Julia version or channel to your system
+    /// Add a specific Julia version or channel to your system. Access via `julia +{channel}` i.e. `julia +1.6`
     Add {
         channel: String
     },


### PR DESCRIPTION
It took me quite a long time to find out how to do the very basic thing of using an added julia version other than default.

So this adds it to the help, and highlights it in the readme.