### PR TITLE
Start win standalone setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,11 @@ jobs:
       matrix:
         label: [
           x86_64-pc-windows-msvc-windowsstore,
+          x86_64-pc-windows-msvc-standalone,
           x86_64-apple-darwin,
           x86_64-unknown-linux-gnu,
           i686-pc-windows-msvc-windowsstore,
+          i686-pc-windows-msvc-standalone,
           i686-unknown-linux-gnu, 
           aarch64-unknown-linux-gnu,
           aarch64-apple-darwin
@@ -29,6 +31,10 @@ jobs:
             target: x86_64-pc-windows-msvc
             os: windows
             features: windowsstore
+          - label: x86_64-pc-windows-msvc-standalone
+            target: x86_64-pc-windows-msvc
+            os: windows
+            features: selfupdate
           - label: x86_64-apple-darwin
             target: x86_64-apple-darwin
             os: macos
@@ -41,6 +47,10 @@ jobs:
             target: i686-pc-windows-msvc
             os: windows
             features: windowsstore
+          - label: i686-pc-windows-msvc-standalone
+            target: i686-pc-windows-msvc
+            os: windows
+            features: selfupdate
           - label: i686-unknown-linux-gnu
             target: i686-unknown-linux-gnu
             os: ubuntu
@@ -121,16 +131,26 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - name: Download Windows x86 juliaup artifact
+    - name: Download Windows x86 Store juliaup artifact
       uses: actions/download-artifact@v3
       with:
         name: juliaup-i686-pc-windows-msvc-windowsstore
         path: target/i686-pc-windows-msvc-windowsstore
-    - name: Download Windows x64 juliaup artifact
+    - name: Download Windows x86 Standalone juliaup artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: juliaup-i686-pc-windows-msvc-standalone
+        path: target/i686-pc-windows-msvc-standalone
+    - name: Download Windows x64 Store juliaup artifact
       uses: actions/download-artifact@v3
       with:
         name: juliaup-x86_64-pc-windows-msvc-windowsstore
         path: target/x86_64-pc-windows-msvc-windowsstore
+    - name: Download Windows x64 Standalonejuliaup artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: juliaup-x86_64-pc-windows-msvc-standalone
+        path: target/x86_64-pc-windows-msvc-standalone
     - name: Download Linux x64 juliaup artifact
       uses: actions/download-artifact@v3
       with:
@@ -182,8 +202,14 @@ jobs:
         cd target/i686-pc-windows-msvc-windowsstore
         zip ../../public/bin/juliaup-${{ env.VERSION }}-i686-pc-windows-msvc-windowsstore.zip ./*
 
+        cd target/i686-pc-windows-msvc-standalone
+        tar -czvf ../../public/bin/juliaup-${{ env.VERSION }}-i686-pc-windows-msvc-standalone.tar.gz .
+
         cd ../../target/x86_64-pc-windows-msvc-windowsstore
         zip ../../public/bin/juliaup-${{ env.VERSION }}-x86_64-pc-windows-msvc-windowsstore.zip ./*
+
+        cd ../../target/x86_64-pc-windows-msvc-standalone
+        tar -czvf ../../public/bin/juliaup-${{ env.VERSION }}-x86_64-pc-windows-msvc-standalone.tar.gz .
 
         cd ../../target/x86_64-unknown-linux-gnu
         tar -czvf ../../public/bin/juliaup-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz .
@@ -332,6 +358,16 @@ jobs:
       with:
         name: juliainstaller-aarch64-apple-darwin
         path: target/aarch64-apple-darwin
+    - name: Download installer artifacts for x86_64-pc-windows-msvc-standalone
+      uses: actions/download-artifact@v3
+      with:
+        name: juliainstaller-x86_64-pc-windows-msvc-standalone
+        path: target/x86_64-pc-windows-msvc-standalone
+    - name: Download installer artifacts for i686-pc-windows-msvc-standalone
+      uses: actions/download-artifact@v3
+      with:
+        name: juliainstaller-i686-pc-windows-msvc-standalone
+        path: target/i686-pc-windows-msvc-standalone
     - name: Rename and move juliainstaller
       run: |
         ls target
@@ -341,6 +377,9 @@ jobs:
         mv target/i686-unknown-linux-gnu/juliainstaller public/bin/juliainstaller-${{ env.VERSION }}-i686-unknown-linux-gnu
         mv target/aarch64-unknown-linux-gnu/juliainstaller public/bin/juliainstaller-${{ env.VERSION }}-aarch64-unknown-linux-gnu
         mv target/aarch64-apple-darwin/juliainstaller public/bin/juliainstaller-${{ env.VERSION }}-aarch64-apple-darwin
+        mv target/x86_64-pc-windows-msvc-standalone/juliainstaller public/bin/juliainstaller-${{ env.VERSION }}-x86_64-pc-windows-msvc-standalone
+        mv target/i686-pc-windows-msvc-standalone/juliainstaller public/bin/juliainstaller-${{ env.VERSION }}-i686-pc-windows-msvc-standalone
+
     - name: Upload to S3
       uses: jakejarvis/s3-sync-action@master
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,7 @@ dependencies = [
  "serde_derive",
  "termcolor",
  "toml",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -704,6 +704,7 @@ dependencies = [
  "thiserror",
  "ureq",
  "url",
+ "uuid 1.1.2",
  "windows",
  "winres",
 ]
@@ -907,6 +908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "predicates"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +983,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1383,6 +1420,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom",
+ "rand",
+ "uuid-macro-internal",
+]
+
+[[package]]
+name = "uuid-macro-internal"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548f7181a5990efa50237abb7ebca410828b57a8955993334679f8b50b35c97d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ log = "0.4.14"
 env_logger = "0.9.0"
 dialoguer = "0.10.0"
 shellexpand = "2.1.0"
+uuid = {version = "1.1.2", features = ["v4", "fast-rng", "macro-diagnostics"]}
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.38.0", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_System_Console", "Services_Store", "Foundation", "Foundation_Collections"] }

--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 
 
-#[cfg(feature = "selfupdate")]
+#[cfg(all(not(windows), feature = "selfupdate"))]
 fn run_individual_config_wizard(install_choices: &mut InstallChoices, theme: &dialoguer::theme::ColorfulTheme) -> Result<Option<()>> {
 
     use std::path::PathBuf;
@@ -73,7 +73,7 @@ fn run_individual_config_wizard(install_choices: &mut InstallChoices, theme: &di
     Ok(Some(()))
 }
 
-#[cfg(feature = "selfupdate")]
+#[cfg(all(not(windows), feature = "selfupdate"))]
 fn is_juliaup_installed() -> bool {
     use std::process::Stdio;
 
@@ -96,7 +96,7 @@ struct Juliainstaller {
     juliaupchannel: String,
 }
 
-#[cfg(feature = "selfupdate")]
+#[cfg(all(not(windows), feature = "selfupdate"))]
 struct InstallChoices {
     backgroundselfupdate: i64,
     startupselfupdate: i64,
@@ -106,7 +106,7 @@ struct InstallChoices {
     modifypath_files: Vec<std::path::PathBuf>,
 }
 
-#[cfg(feature = "selfupdate")]
+#[cfg(all(not(windows), feature = "selfupdate"))]
 fn print_install_choices(install_choices: &InstallChoices) -> Result<()> {
     use console::style;
 
@@ -149,7 +149,7 @@ fn print_install_choices(install_choices: &InstallChoices) -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "selfupdate")]
+#[cfg(all(not(windows), feature = "selfupdate"))]
 pub fn main() -> Result<()> {
     use std::io::Seek;
     use anyhow::{anyhow, Context};
@@ -363,7 +363,7 @@ pub fn main() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "selfupdate"))]
+#[cfg(any(windows, not(feature = "selfupdate")))]
 pub fn main() -> Result<()> {
     panic!("This should never run.");
 }

--- a/src/command_selfuninstall.rs
+++ b/src/command_selfuninstall.rs
@@ -5,7 +5,9 @@ use anyhow::Result;
 pub fn run_command_selfuninstall(paths: &crate::global_paths::GlobalPaths) -> Result<()> {
     use dialoguer::Confirm;
 
-    use crate::{command_config_backgroundselfupdate::run_command_config_backgroundselfupdate, command_config_startupselfupdate::run_command_config_startupselfupdate, command_config_modifypath::run_command_config_modifypath, command_config_symlinks::run_command_config_symlinks};
+    use crate::{command_config_backgroundselfupdate::run_command_config_backgroundselfupdate, command_config_startupselfupdate::run_command_config_startupselfupdate, command_config_modifypath::run_command_config_modifypath};
+    #[cfg(not(windows))]
+    use crate::command_config_symlinks::run_command_config_symlinks;
 
     let choice = Confirm::new()
         .with_prompt("Do you really want to uninstall Julia?")
@@ -34,11 +36,14 @@ pub fn run_command_selfuninstall(paths: &crate::global_paths::GlobalPaths) -> Re
         Err(_) => eprintln!(" Failed.")
     };
 
-    eprint!("Removing symlinks.");
-    match run_command_config_symlinks(Some(false), true, &paths) {
-        Ok(_) => eprintln!(" Success."),
-        Err(_) => eprintln!(" Failed.")
-    };
+    #[cfg(not(windows))]
+    {
+        eprint!("Removing symlinks.");
+        match run_command_config_symlinks(Some(false), true, &paths) {
+            Ok(_) => eprintln!(" Success."),
+            Err(_) => eprintln!(" Failed.")
+        };
+    }
 
     eprint!("Deleting Juliaup home folder {:?}.", paths.juliauphome);
     match std::fs::remove_dir_all(&paths.juliauphome) {


### PR DESCRIPTION
Fixes #343.

Incomplete list of things that still need to be done:
- [ ] Put things on `PATH`.
- [ ] Figure out how to handle `julialauncher` -> `julia`.
- [ ] Add uninstall option to standard Windows hooks.
- [ ] Add to start menu.
- [ ] Create install script.
- [ ] Fix `juliainstaller` on Windows.