### PR TITLE
Fix a bug during remove of PATH on Mac

### DIFF
--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -223,7 +223,7 @@ pub fn main() -> Result<()> {
             .ok_or(anyhow!("Could not determine the path of the user home directory."))?
             .join(".julia")
             .join("juliaup"),
-        modifypath_files: find_shell_scripts_to_be_modified()?,
+        modifypath_files: find_shell_scripts_to_be_modified(true)?,
     };
 
     print_install_choices(&install_choices)?;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -520,7 +520,7 @@ fn remove_path_from_specific_file(path: PathBuf) -> Result<()> {
     Ok(())
 }
 
-pub fn find_shell_scripts_to_be_modified() -> Result<Vec<PathBuf>> {
+pub fn find_shell_scripts_to_be_modified(add_case: bool) -> Result<Vec<PathBuf>> {
     let home_dir = dirs::home_dir().unwrap();
 
     let paths_to_test: Vec<PathBuf> = vec![
@@ -534,7 +534,7 @@ pub fn find_shell_scripts_to_be_modified() -> Result<Vec<PathBuf>> {
     let result = paths_to_test
         .iter()
         .filter(|p| p.exists() ||
-            (p.file_name().unwrap()==".zshrc" && std::env::consts::OS == "macos") // On MacOS, always edit .zshrc as that is the default shell
+            (add_case && p.file_name().unwrap()==".zshrc" && std::env::consts::OS == "macos") // On MacOS, always edit .zshrc as that is the default shell, but only when we add things
         )
         .map(|p|p.clone())
         .collect();
@@ -543,7 +543,7 @@ pub fn find_shell_scripts_to_be_modified() -> Result<Vec<PathBuf>> {
 }
 
 pub fn add_binfolder_to_path_in_shell_scripts(bin_path: &PathBuf) -> Result<()> {
-    let paths = find_shell_scripts_to_be_modified()?;
+    let paths = find_shell_scripts_to_be_modified(true)?;
 
     paths.into_iter().for_each(|p| {
         add_path_to_specific_file(bin_path, p).unwrap();
@@ -553,7 +553,7 @@ pub fn add_binfolder_to_path_in_shell_scripts(bin_path: &PathBuf) -> Result<()> 
 }
 
 pub fn remove_binfolder_from_path_in_shell_scripts() -> Result<()> {
-    let paths = find_shell_scripts_to_be_modified()?;
+    let paths = find_shell_scripts_to_be_modified(false)?;
 
     paths.into_iter().for_each(|p| {
         remove_path_from_specific_file(p).unwrap();


### PR DESCRIPTION
Fixes #356.

The problem is that we used a list of files to modify on remove from path that included the ZHS file even if it doesn't exist. 

Including that file during add to path makes sense, even if it doesn't exist, because that is the default on Mac, but on remove we should only include it if it exists.