### PR TITLE
Wolthom/feature/use proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_proxy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a5019be18538406a43b5419a5501461f0c8b49ea7dfda0cfc32f4e51fc44be1"
+dependencies = [
+ "log",
+ "url",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +675,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "env_logger",
+ "env_proxy",
  "flate2",
  "fs_extra",
  "human-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ log = "0.4.14"
 env_logger = "0.9.0"
 dialoguer = "0.10.0"
 shellexpand = "2.1.0"
+env_proxy = "0.4.1"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.38.0", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_System_Console", "Services_Store", "Foundation", "Foundation_Collections"] }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -43,7 +43,10 @@ where
 }
 
 fn get_proxy(url: &str) -> Option<Result<ureq::Proxy>> {
+    trace!("identifying proxy for url: {url}");
+    use log::trace;
     let proxy_url = env_proxy::for_url_str(url).to_string();
+    trace!("identified proxy: {:?}", proxy_url);
 
     // Option<Result<...>> is returned to handle both cases:
     //      1. No proxy URL is specified => None

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -86,7 +86,7 @@ pub fn get_ureq_agent(url: &str) -> Result<ureq::Agent> {
 }
 
 pub fn download_extract_sans_parent(url: &str, target_path: &Path, levels_to_skip: usize) -> Result<()> {
-    let agent = get_ureq_agent()
+    let agent = get_ureq_agent(url)
         .with_context(|| format!("Failed to construct download agent."))?;
     
     let response = agent.get(url)
@@ -115,7 +115,7 @@ pub fn download_extract_sans_parent(url: &str, target_path: &Path, levels_to_ski
 }
 
 pub fn download_juliaup_version(url: &str) -> Result<Version> {
-    let agent = get_ureq_agent()
+    let agent = get_ureq_agent(url)
         .with_context(|| format!("Failed to construct download agent."))?;
     
     let response = agent.get(url)


### PR DESCRIPTION
This PR uses the `env_proxy` crate (as suggested in #274) to respect environment variables setting a proxy.
Typically, corporate laptops may require this feature (such as my work laptop).

Because wrongly configured proxies may lead to weird errors (e.g. DNS resolution errors or refused connections) with suboptimal error messages, I added logging traces to the proxy-resolution in case debugging is required. The logging statements are in a separate commit and can be removed if preferred.

Right now, this is only tested on an Ubuntu notebook. Later today, I will verify that this settings works on a Windows behind a corporate firewall. With the current release, `juliaup` does not work on said laptop.