### PR TITLE
Use system certificates on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1370,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "rustls",
+ "rustls-native-certs",
  "url",
  "webpki",
  "webpki-roots",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ ureq = { version = "2", features = ["native-tls"] }
 native-tls = "0.2.10"
 
 [target.'cfg(all(not(macos),not(windows)))'.dependencies]
-ureq = "2"
+ureq = { version = "2", features = ["native-certs"] }
 
 [build-dependencies]
 anyhow = "1"


### PR DESCRIPTION
Fixes #363.

This does NOT implement a special case for Debian based distributions. I looked into doing that, but it was way more involved than I thought it would be and I think the likelihood that I would make some mistake in trying to implement that is too high. The problem is that `ureq` has a conditional compile to either use the Mozilla list or the system cert list, but one can't have both easily. So I would have to vendor code from ureq in this crate here, and then we would need to make sure we track changes to that upstream, and especially with security sensitive stuff that seems like a really bad idea to me.

So, the main question is: are we ok to use the system cert list on Linux always, even on Linux? I think Julia is doing the same in the package manager, so maybe this is just all ok?

@StefanKarpinski, I'll defer to you to make a call on this one.