### PR TITLE
Manage the installation folder path through env variable.

### DIFF
--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -119,6 +119,10 @@ fn print_install_choices(install_choices: &InstallChoices) -> Result<()> {
     println!("");
     println!("  {}", install_choices.install_location.join("bin").to_string_lossy());
     println!("");
+    println!("This can be modified with the JULIAUP_SELF_HOME environmental variable.");
+    println!("");
+    println!("Julia versions installed through juliaup will be installed in the default julia folder ~/.julia/juliaup,");
+    println!("or, if specified, in $JULIA_DEPOT_PATH/juliaup");
 
     if install_choices.modifypath {
         println!("This path will then be added to your {} environment variable by", style("PATH").bold());

--- a/src/command_selfupdate.rs
+++ b/src/command_selfupdate.rs
@@ -54,11 +54,7 @@ pub fn run_command_selfupdate(paths: &crate::global_paths::GlobalPaths) -> Resul
         let new_juliaup_url = juliaupserver_base.join(&download_url_path)
                 .with_context(|| format!("Failed to construct a valid url from '{}' and '{}'.", juliaupserver_base, download_url_path))?;
 
-        let my_own_path = std::env::current_exe()
-            .with_context(|| "Could not determine the path of the running exe.")?;
-
-        let my_own_folder = my_own_path.parent()
-            .ok_or_else(|| anyhow!("Could not determine parent."))?;
+        let my_own_folder = paths.juliaupselfhome.join("bin");
 
         eprintln!("Found new version {} on channel {}.", version, juliaup_channel);
 

--- a/src/global_paths.rs
+++ b/src/global_paths.rs
@@ -1,12 +1,9 @@
 use std::path::PathBuf;
-use anyhow::{Result,bail,anyhow};
-#[cfg(feature = "selfupdate")]
-use anyhow::Context;
+use anyhow::{Result,bail,anyhow, Context};
 pub struct GlobalPaths {
     pub juliauphome: PathBuf,
     pub juliaupconfig: PathBuf,
     pub lockfile: PathBuf,
-    #[cfg(feature = "selfupdate")]
     pub juliaupselfhome: PathBuf,
     #[cfg(feature = "selfupdate")]
     pub juliaupselfconfig: PathBuf,
@@ -28,12 +25,12 @@ fn get_juliaup_home_path() -> Result<PathBuf> {
             path.join("juliaup")
         }
         Err(_) => {
-    let path = dirs::home_dir()
-        .ok_or(anyhow!(
-            "Could not determine the path of the user home directory."
-        ))?
-        .join(".julia")
-        .join("juliaup");
+            let path = dirs::home_dir()
+            .ok_or(anyhow!(
+                "Could not determine the path of the user home directory."
+            ))?
+            .join(".julia")
+            .join("juliaup");
 
             if !path.is_absolute() {
                 bail!(
@@ -49,29 +46,43 @@ fn get_juliaup_home_path() -> Result<PathBuf> {
     Ok(path)
 }
 
+fn get_juliaup_selfhome_path() -> Result<PathBuf> {
+    let entry_sep = if std::env::consts::OS == "windows" {';'} else {':'};
+
+    let selfpath = match std::env::var("JULIAUP_SELF_HOME") {
+        Ok(val) => {
+            let path = PathBuf::from(val.to_string().split(entry_sep).next().unwrap());
+            if !path.is_absolute() { bail!("The `JULIAUP_SELF_HOME` environment variable contains a value that resolves to an an invalid path `{}`.", path.display()); };
+
+            path
+        }
+        Err(_) => {
+            let my_own_path = std::env::current_exe()
+                .with_context(|| anyhow!("Could not determine the path of the running exe."))?;
+            my_own_path
+                .parent()
+                .ok_or_else(|| anyhow!("Failed to get path of folder of own executable."))?
+                .parent()
+                .ok_or_else(|| anyhow!("Failed to get parent path of folder of own executable."))?
+                .to_path_buf()
+        }
+    };
+
+    Ok(selfpath)
+}
+
 pub fn get_paths() -> Result<GlobalPaths> {
+
     let juliauphome = get_juliaup_home_path()?;
 
-    #[cfg(feature = "selfupdate")]
-    let my_own_path = std::env::current_exe()
-        .with_context(|| "Could not determine the path of the running exe.")?;
-
-    #[cfg(feature = "selfupdate")]
-    let juliaupselfbin = my_own_path.parent()
-        .ok_or_else(|| anyhow!("Could not determine parent."))?
-        .to_path_buf();
-
     let juliaupconfig = juliauphome.join("juliaup.json");
-    
+
     let lockfile = juliauphome.join(".juliaup-lock");
 
+    let juliaupselfhome = get_juliaup_selfhome_path()?;
+
     #[cfg(feature = "selfupdate")]
-    let juliaupselfhome = my_own_path
-        .parent()
-        .ok_or_else(|| anyhow!("Failed to get path of folder of own executable."))?
-        .parent()
-        .ok_or_else(|| anyhow!("Failed to get parent path of folder of own executable."))?
-        .to_path_buf();
+    let juliaupselfbin = juliaselfhome.join("bin");
 
     #[cfg(feature = "selfupdate")]
     let juliaupselfconfig = juliaupselfhome
@@ -81,7 +92,6 @@ pub fn get_paths() -> Result<GlobalPaths> {
         juliauphome,
         juliaupconfig,
         lockfile,
-        #[cfg(feature = "selfupdate")]
         juliaupselfhome,
         #[cfg(feature = "selfupdate")]
         juliaupselfconfig,

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -248,10 +248,9 @@ pub fn install_version(
     // that we don't ship a bundled version for some platforms.
     let platform = get_arch()?;
     let full_version_string_of_bundled_version = format!("{}~{}", get_bundled_julia_full_version(), platform);
-    let my_own_path = std::env::current_exe()?;
-    let path_of_bundled_version = my_own_path
-        .parent()
-        .unwrap() // unwrap OK because we can't get a path that does not have a parent
+
+    let path_of_bundled_version = paths.juliaupselfhome
+        .join("bin")
         .join("BundledJulia");
 
     let child_target_foldername = format!("julia-{}", fullversion);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,35 +19,22 @@ pub fn get_juliaserver_base_url() -> Result<Url> {
 pub fn get_bin_dir() -> Result<PathBuf> {
     let entry_sep = if std::env::consts::OS == "windows" {';'} else {':'};
 
-    let path = match std::env::var("JULIAUP_BIN_DIR") {
+    let path = match std::env::var("JULIAUP_SELF_HOME") {
         Ok(val) => {
             let path = PathBuf::from(val.to_string().split(entry_sep).next().unwrap()); // We can unwrap here because even when we split an empty string we should get a first element.
 
             if !path.is_absolute() {
-                bail!("The `JULIAUP_BIN_DIR` environment variable contains a value that resolves to an an invalid path `{}`.", path.display());
+                bail!("The `JULIAUP_SELF_HOME` environment variable contains a value that resolves to an an invalid path `{}`.", path.display());
             };
 
-            path
+            path.join("bin")
         }
         Err(_) => {
-            let mut path = std::env::current_exe()
+            let path = std::env::current_exe()
                 .with_context(|| "Could not determine the path of the running exe.")?
                 .parent()
                 .ok_or_else(|| anyhow!("Could not determine parent."))?
                 .to_path_buf();
-
-            if let Some(home_dir) = dirs::home_dir() {
-                if !path.starts_with(&home_dir) {
-                    path = home_dir.join(".local").join("bin");
-
-                    if !path.is_absolute() {
-                        bail!(
-                            "The system returned an invalid home directory path `{}`.",
-                            path.display()
-                        );
-                    };
-                }
-            }
 
             path
         },


### PR DESCRIPTION
This started from #406. 
While the install location of the various julia versions can be customised through the `JULIA_DEPOT_PATH` env var, the self installation folder was not, and instead the program relied on the current position of the running executable (or symlink to it).
This PR introduces the env var `JULIAUP_SELF_HOME` which controls the paths to the juliaup binaries and selfconfiguration files. 

To avoid too much book keeping to manage an eventual custom location, I disabled the logic for letting the user type the location itself, and instead only rely on setting up the right env variable, similarly to how rustup does.
 