### PR TITLE
(cargo-release) version 1.7.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "juliaup"
-version = "1.7.26-alpha.0"
+version = "1.7.26"
 edition = "2021"
 default-run = "juliaup"
 publish = false


### PR DESCRIPTION
~Blocked by https://github.com/JuliaLang/juliaup/pull/437~

@davidanthoff given the number of people waiting for 1.8.3 I'll go ahead with this. I suspect there are additional steps for the windows store? https://github.com/JuliaLang/juliaup/issues/440