### PR TITLE
(cargo-release) start next development iteration 1.7.27-alpha.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "juliaup"
-version = "1.7.26"
+version = "1.7.27-alpha.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "juliaup"
-version = "1.7.26"
+version = "1.7.27-alpha.0"
 edition = "2021"
 default-run = "juliaup"
 publish = false


### PR DESCRIPTION
I guess this should wait for the v1.7.26 release and build to be approved and succeed https://github.com/JuliaLang/juliaup/actions/runs/3505204189