### PR TITLE
Go back to ~/.juliaup as the default install location

### DIFF
--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -221,8 +221,7 @@ pub fn main() -> Result<()> {
         modifypath: true,
         install_location: dirs::home_dir()
             .ok_or(anyhow!("Could not determine the path of the user home directory."))?
-            .join(".julia")
-            .join("juliaup"),
+            .join(".juliaup"),
         modifypath_files: find_shell_scripts_to_be_modified(true)?,
     };
 


### PR DESCRIPTION
This reverts https://github.com/JuliaLang/juliaup/pull/329 because I think in hindsight that was a mistake and the original behavior was better.

The primary problem is that if we install Juliaup itself into `.julia` in the standalone case, we create his weird asymmetry to the cases where we use a system package manager to install Juliaup. In the latter case, Juliaup is going to be installed _somewhere_ on the system that is package manager specific, i.e. Windows Store puts it somewhere, brew puts it somewhere else etc. Things will just be a heck of a lot easier if the content of `.julia/juliaup` is always the same, regardless of how Juliaup itself was installed.

Things that will be better:
- It will be easier to switch between a standalone and system package manager installation of Juliaup.
- The whole interpretation of `JULIA_DEPOT` gets _much_ cleaner. Juliaup right now respects that, _except_ in the standalone version it doesn't use it for itself, which is super weird.
- Uninstall/delete things are clearer.

Medium term my hope is that we can use system package managers for Juliaup itself on as many systems as possible and have the standalone version fade more and more into the background in any case.