### PR TITLE
add win arm64 build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ codegen-units = 1
 [dependencies]
 clap = { version = "4.0.15", features = ["derive"] }
 dirs = "4"
-serde = {version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1"
 anyhow = "1"
@@ -32,7 +32,7 @@ url = "2"
 cli-table = "0.4"
 itertools = "0.10"
 cluFlock = "1.2.5"
-chrono = {version = "0.4", features = ["serde"]}
+chrono = { version = "0.4", features = ["serde"] }
 human-panic = "1.0.3"
 log = "0.4.14"
 env_logger = "0.9.0"
@@ -41,7 +41,16 @@ shellexpand = "2.1.0"
 env_proxy = "0.4.1"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.43.0", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_System_Console", "Services_Store", "Foundation", "Foundation_Collections", "Web_Http", "Storage_Streams",] }
+windows = { version = "0.43.0", features = [
+    "Win32_Foundation",
+    "Win32_UI_Shell",
+    "Win32_System_Console",
+    "Services_Store",
+    "Foundation",
+    "Foundation_Collections",
+    "Web_Http",
+    "Storage_Streams",
+] }
 
 [target.'cfg(macos)'.dependencies]
 ureq = { version = "2", features = ["native-tls"] }
@@ -50,10 +59,14 @@ native-tls = "0.2.10"
 [target.'cfg(all(not(macos),not(windows)))'.dependencies]
 ureq = { version = "2", features = ["native-certs"] }
 
+[target.'cfg(all(target_os="windows",target_arch="arm"))']
+[patch.crates-io]
+ring = { git = "https://github.com/awakecoding/ring", branch = "0.16.20_alpha" }
+
 [build-dependencies]
 anyhow = "1"
 itertools = "0.10"
-serde = {version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1"
 built = "0.5.1"
@@ -73,8 +86,14 @@ windowsappinstaller = []
 dummy = []
 
 [package.metadata.msix]
-winstoremsix = { file = "deploy/msix/PackagingLayout.xml", variables = [{name = "FlatBundle", value="false"}, {name = "IdentityPublisher", value = "CN=7FB784C5-4411-4067-914E-A7B06CC00FFC"}] }
-winappinstallermsix = { file = "deploy/msix/PackagingLayout.xml", variables = [{name = "FlatBundle", value="true"}, {name = "IdentityPublisher", value = "CN=&quot;JULIA COMPUTING, INC.&quot;, O=&quot;JULIA COMPUTING, INC.&quot;, S=Massachusetts, C=US"}] }
+winstoremsix = { file = "deploy/msix/PackagingLayout.xml", variables = [
+    { name = "FlatBundle", value = "false" },
+    { name = "IdentityPublisher", value = "CN=7FB784C5-4411-4067-914E-A7B06CC00FFC" },
+] }
+winappinstallermsix = { file = "deploy/msix/PackagingLayout.xml", variables = [
+    { name = "FlatBundle", value = "true" },
+    { name = "IdentityPublisher", value = "CN=&quot;JULIA COMPUTING, INC.&quot;, O=&quot;JULIA COMPUTING, INC.&quot;, S=Massachusetts, C=US" },
+] }
 
 [package.metadata.winappinstaller]
 winappinstaller = "deploy/winappinstaller/Julia.appinstaller"

--- a/versiondb/versiondb-aarch64-pc-windows-msvc.json
+++ b/versiondb/versiondb-aarch64-pc-windows-msvc.json
@@ -1,0 +1,1039 @@
+{
+    "AvailableVersions": {
+        "0.7.0+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/0.7/julia-0.7.0-win32.tar.gz"
+        },
+        "0.7.0+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/0.7/julia-0.7.0-win64.tar.gz"
+        },
+        "1.0.0+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.0/julia-1.0.0-win32.tar.gz"
+        },
+        "1.0.0+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.0/julia-1.0.0-win64.tar.gz"
+        },
+        "1.0.1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.0/julia-1.0.1-win32.tar.gz"
+        },
+        "1.0.1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.0/julia-1.0.1-win64.tar.gz"
+        },
+        "1.0.2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.0/julia-1.0.2-win32.tar.gz"
+        },
+        "1.0.2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.0/julia-1.0.2-win64.tar.gz"
+        },
+        "1.0.3+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.0/julia-1.0.3-win32.tar.gz"
+        },
+        "1.0.3+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.0/julia-1.0.3-win64.tar.gz"
+        },
+        "1.0.4+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.0/julia-1.0.4-win32.tar.gz"
+        },
+        "1.0.4+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.0/julia-1.0.4-win64.tar.gz"
+        },
+        "1.0.5+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.0/julia-1.0.5-win32.tar.gz"
+        },
+        "1.0.5+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.0/julia-1.0.5-win64.tar.gz"
+        },
+        "1.1.0+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.1/julia-1.1.0-win32.tar.gz"
+        },
+        "1.1.0+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.1/julia-1.1.0-win64.tar.gz"
+        },
+        "1.1.1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.1/julia-1.1.1-win32.tar.gz"
+        },
+        "1.1.1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.1/julia-1.1.1-win64.tar.gz"
+        },
+        "1.2.0+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.2/julia-1.2.0-win32.tar.gz"
+        },
+        "1.2.0+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.2/julia-1.2.0-win64.tar.gz"
+        },
+        "1.3.0+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.3/julia-1.3.0-win32.tar.gz"
+        },
+        "1.3.0+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.3/julia-1.3.0-win64.tar.gz"
+        },
+        "1.3.1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.3/julia-1.3.1-win32.tar.gz"
+        },
+        "1.3.1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.3/julia-1.3.1-win64.tar.gz"
+        },
+        "1.4.0+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.4/julia-1.4.0-win32.tar.gz"
+        },
+        "1.4.0+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.4/julia-1.4.0-win64.tar.gz"
+        },
+        "1.4.1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.4/julia-1.4.1-win32.tar.gz"
+        },
+        "1.4.1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.4/julia-1.4.1-win64.tar.gz"
+        },
+        "1.4.2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.4/julia-1.4.2-win32.tar.gz"
+        },
+        "1.4.2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.4/julia-1.4.2-win64.tar.gz"
+        },
+        "1.5.0-beta1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.5/julia-1.5.0-beta1-win32.tar.gz"
+        },
+        "1.5.0-beta1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.5/julia-1.5.0-beta1-win64.tar.gz"
+        },
+        "1.5.0-rc1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.5/julia-1.5.0-rc1-win32.tar.gz"
+        },
+        "1.5.0-rc1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.5/julia-1.5.0-rc1-win64.tar.gz"
+        },
+        "1.5.0-rc2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.5/julia-1.5.0-rc2-win32.tar.gz"
+        },
+        "1.5.0-rc2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.5/julia-1.5.0-rc2-win64.tar.gz"
+        },
+        "1.5.0+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.5/julia-1.5.0-win32.tar.gz"
+        },
+        "1.5.0+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.5/julia-1.5.0-win64.tar.gz"
+        },
+        "1.5.1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.5/julia-1.5.1-win32.tar.gz"
+        },
+        "1.5.1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.5/julia-1.5.1-win64.tar.gz"
+        },
+        "1.5.2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.5/julia-1.5.2-win32.tar.gz"
+        },
+        "1.5.2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.5/julia-1.5.2-win64.tar.gz"
+        },
+        "1.5.3+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.5/julia-1.5.3-win32.tar.gz"
+        },
+        "1.5.3+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.5/julia-1.5.3-win64.tar.gz"
+        },
+        "1.5.4+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.5/julia-1.5.4-win32.tar.gz"
+        },
+        "1.5.4+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.5/julia-1.5.4-win64.tar.gz"
+        },
+        "1.6.0-beta1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.0-beta1-win32.tar.gz"
+        },
+        "1.6.0-beta1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.0-beta1-win64.tar.gz"
+        },
+        "1.6.0-rc1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.0-rc1-win32.tar.gz"
+        },
+        "1.6.0-rc1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.0-rc1-win64.tar.gz"
+        },
+        "1.6.0-rc2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.0-rc2-win32.tar.gz"
+        },
+        "1.6.0-rc2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.0-rc2-win64.tar.gz"
+        },
+        "1.6.0-rc3+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.0-rc3-win32.tar.gz"
+        },
+        "1.6.0-rc3+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.0-rc3-win64.tar.gz"
+        },
+        "1.6.0+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.0-win32.tar.gz"
+        },
+        "1.6.0+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.0-win64.tar.gz"
+        },
+        "1.6.1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.1-win32.tar.gz"
+        },
+        "1.6.1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.1-win64.tar.gz"
+        },
+        "1.6.2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.2-win32.tar.gz"
+        },
+        "1.6.2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.2-win64.tar.gz"
+        },
+        "1.6.3+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.3-win32.tar.gz"
+        },
+        "1.6.3+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.3-win64.tar.gz"
+        },
+        "1.6.4+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.4-win32.tar.gz"
+        },
+        "1.6.4+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.4-win64.tar.gz"
+        },
+        "1.6.5+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.5-win32.tar.gz"
+        },
+        "1.6.5+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.5-win64.tar.gz"
+        },
+        "1.6.6+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.6-win32.tar.gz"
+        },
+        "1.6.6+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.6-win64.tar.gz"
+        },
+        "1.6.7+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.6/julia-1.6.7-win32.tar.gz"
+        },
+        "1.6.7+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.6/julia-1.6.7-win64.tar.gz"
+        },
+        "1.7.0-beta1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.7/julia-1.7.0-beta1-win32.tar.gz"
+        },
+        "1.7.0-beta1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.7/julia-1.7.0-beta1-win64.tar.gz"
+        },
+        "1.7.0-beta2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.7/julia-1.7.0-beta2-win32.tar.gz"
+        },
+        "1.7.0-beta2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.7/julia-1.7.0-beta2-win64.tar.gz"
+        },
+        "1.7.0-beta3+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.7/julia-1.7.0-beta3-win32.tar.gz"
+        },
+        "1.7.0-beta3+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.7/julia-1.7.0-beta3-win64.tar.gz"
+        },
+        "1.7.0-beta4+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.7/julia-1.7.0-beta4-win32.tar.gz"
+        },
+        "1.7.0-beta4+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.7/julia-1.7.0-beta4-win64.tar.gz"
+        },
+        "1.7.0-rc1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.7/julia-1.7.0-rc1-win32.tar.gz"
+        },
+        "1.7.0-rc1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.7/julia-1.7.0-rc1-win64.tar.gz"
+        },
+        "1.7.0-rc2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.7/julia-1.7.0-rc2-win32.tar.gz"
+        },
+        "1.7.0-rc2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.7/julia-1.7.0-rc2-win64.tar.gz"
+        },
+        "1.7.0-rc3+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.7/julia-1.7.0-rc3-win32.tar.gz"
+        },
+        "1.7.0-rc3+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.7/julia-1.7.0-rc3-win64.tar.gz"
+        },
+        "1.7.0+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.7/julia-1.7.0-win32.tar.gz"
+        },
+        "1.7.0+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.7/julia-1.7.0-win64.tar.gz"
+        },
+        "1.7.1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.7/julia-1.7.1-win32.tar.gz"
+        },
+        "1.7.1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.7/julia-1.7.1-win64.tar.gz"
+        },
+        "1.7.2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.7/julia-1.7.2-win32.tar.gz"
+        },
+        "1.7.2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.7/julia-1.7.2-win64.tar.gz"
+        },
+        "1.7.3+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.7/julia-1.7.3-win32.tar.gz"
+        },
+        "1.7.3+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.7/julia-1.7.3-win64.tar.gz"
+        },
+        "1.8.0-beta1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.8/julia-1.8.0-beta1-win32.tar.gz"
+        },
+        "1.8.0-beta1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.8/julia-1.8.0-beta1-win64.tar.gz"
+        },
+        "1.8.0-beta2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.8/julia-1.8.0-beta2-win32.tar.gz"
+        },
+        "1.8.0-beta2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.8/julia-1.8.0-beta2-win64.tar.gz"
+        },
+        "1.8.0-beta3+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.8/julia-1.8.0-beta3-win32.tar.gz"
+        },
+        "1.8.0-beta3+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.8/julia-1.8.0-beta3-win64.tar.gz"
+        },
+        "1.8.0-rc1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.8/julia-1.8.0-rc1-win32.tar.gz"
+        },
+        "1.8.0-rc1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.8/julia-1.8.0-rc1-win64.tar.gz"
+        },
+        "1.8.0-rc2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.8/julia-1.8.0-rc2-win32.tar.gz"
+        },
+        "1.8.0-rc2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.8/julia-1.8.0-rc2-win64.tar.gz"
+        },
+        "1.8.0-rc3+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.8/julia-1.8.0-rc3-win32.tar.gz"
+        },
+        "1.8.0-rc3+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.8/julia-1.8.0-rc3-win64.tar.gz"
+        },
+        "1.8.0-rc4+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.8/julia-1.8.0-rc4-win32.tar.gz"
+        },
+        "1.8.0-rc4+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.8/julia-1.8.0-rc4-win64.tar.gz"
+        },
+        "1.8.0+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.8/julia-1.8.0-win32.tar.gz"
+        },
+        "1.8.0+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.8/julia-1.8.0-win64.tar.gz"
+        },
+        "1.8.1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.8/julia-1.8.1-win32.tar.gz"
+        },
+        "1.8.1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.8/julia-1.8.1-win64.tar.gz"
+        },
+        "1.8.2+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.8/julia-1.8.2-win32.tar.gz"
+        },
+        "1.8.2+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.8/julia-1.8.2-win64.tar.gz"
+        },
+        "1.8.3+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.8/julia-1.8.3-win32.tar.gz"
+        },
+        "1.8.3+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.8/julia-1.8.3-win64.tar.gz"
+        },
+        "1.9.0-alpha1+0.x86.w64.mingw32": {
+            "UrlPath": "bin/winnt/x86/1.9/julia-1.9.0-alpha1-win32.tar.gz"
+        },
+        "1.9.0-alpha1+0.x64.w64.mingw32": {
+            "UrlPath": "bin/winnt/x64/1.9/julia-1.9.0-alpha1-win64.tar.gz"
+        }
+    },
+    "AvailableChannels": {
+        "0": {
+            "Version": "0.7.0+0.x64.w64.mingw32"
+        },
+        "0.7": {
+            "Version": "0.7.0+0.x64.w64.mingw32"
+        },
+        "0.7.0": {
+            "Version": "0.7.0+0.x64.w64.mingw32"
+        },
+        "0.7.0~x64": {
+            "Version": "0.7.0+0.x64.w64.mingw32"
+        },
+        "0.7.0~x86": {
+            "Version": "0.7.0+0.x86.w64.mingw32"
+        },
+        "0.7~x64": {
+            "Version": "0.7.0+0.x64.w64.mingw32"
+        },
+        "0.7~x86": {
+            "Version": "0.7.0+0.x86.w64.mingw32"
+        },
+        "0~x64": {
+            "Version": "0.7.0+0.x64.w64.mingw32"
+        },
+        "0~x86": {
+            "Version": "0.7.0+0.x86.w64.mingw32"
+        },
+        "1": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "1.0": {
+            "Version": "1.0.5+0.x64.w64.mingw32"
+        },
+        "1.0.0": {
+            "Version": "1.0.0+0.x64.w64.mingw32"
+        },
+        "1.0.0~x64": {
+            "Version": "1.0.0+0.x64.w64.mingw32"
+        },
+        "1.0.0~x86": {
+            "Version": "1.0.0+0.x86.w64.mingw32"
+        },
+        "1.0.1": {
+            "Version": "1.0.1+0.x64.w64.mingw32"
+        },
+        "1.0.1~x64": {
+            "Version": "1.0.1+0.x64.w64.mingw32"
+        },
+        "1.0.1~x86": {
+            "Version": "1.0.1+0.x86.w64.mingw32"
+        },
+        "1.0.2": {
+            "Version": "1.0.2+0.x64.w64.mingw32"
+        },
+        "1.0.2~x64": {
+            "Version": "1.0.2+0.x64.w64.mingw32"
+        },
+        "1.0.2~x86": {
+            "Version": "1.0.2+0.x86.w64.mingw32"
+        },
+        "1.0.3": {
+            "Version": "1.0.3+0.x64.w64.mingw32"
+        },
+        "1.0.3~x64": {
+            "Version": "1.0.3+0.x64.w64.mingw32"
+        },
+        "1.0.3~x86": {
+            "Version": "1.0.3+0.x86.w64.mingw32"
+        },
+        "1.0.4": {
+            "Version": "1.0.4+0.x64.w64.mingw32"
+        },
+        "1.0.4~x64": {
+            "Version": "1.0.4+0.x64.w64.mingw32"
+        },
+        "1.0.4~x86": {
+            "Version": "1.0.4+0.x86.w64.mingw32"
+        },
+        "1.0.5": {
+            "Version": "1.0.5+0.x64.w64.mingw32"
+        },
+        "1.0.5~x64": {
+            "Version": "1.0.5+0.x64.w64.mingw32"
+        },
+        "1.0.5~x86": {
+            "Version": "1.0.5+0.x86.w64.mingw32"
+        },
+        "1.0~x64": {
+            "Version": "1.0.5+0.x64.w64.mingw32"
+        },
+        "1.0~x86": {
+            "Version": "1.0.5+0.x86.w64.mingw32"
+        },
+        "1.1": {
+            "Version": "1.1.1+0.x64.w64.mingw32"
+        },
+        "1.1.0": {
+            "Version": "1.1.0+0.x64.w64.mingw32"
+        },
+        "1.1.0~x64": {
+            "Version": "1.1.0+0.x64.w64.mingw32"
+        },
+        "1.1.0~x86": {
+            "Version": "1.1.0+0.x86.w64.mingw32"
+        },
+        "1.1.1": {
+            "Version": "1.1.1+0.x64.w64.mingw32"
+        },
+        "1.1.1~x64": {
+            "Version": "1.1.1+0.x64.w64.mingw32"
+        },
+        "1.1.1~x86": {
+            "Version": "1.1.1+0.x86.w64.mingw32"
+        },
+        "1.1~x64": {
+            "Version": "1.1.1+0.x64.w64.mingw32"
+        },
+        "1.1~x86": {
+            "Version": "1.1.1+0.x86.w64.mingw32"
+        },
+        "1.2": {
+            "Version": "1.2.0+0.x64.w64.mingw32"
+        },
+        "1.2.0": {
+            "Version": "1.2.0+0.x64.w64.mingw32"
+        },
+        "1.2.0~x64": {
+            "Version": "1.2.0+0.x64.w64.mingw32"
+        },
+        "1.2.0~x86": {
+            "Version": "1.2.0+0.x86.w64.mingw32"
+        },
+        "1.2~x64": {
+            "Version": "1.2.0+0.x64.w64.mingw32"
+        },
+        "1.2~x86": {
+            "Version": "1.2.0+0.x86.w64.mingw32"
+        },
+        "1.3": {
+            "Version": "1.3.1+0.x64.w64.mingw32"
+        },
+        "1.3.0": {
+            "Version": "1.3.0+0.x64.w64.mingw32"
+        },
+        "1.3.0~x64": {
+            "Version": "1.3.0+0.x64.w64.mingw32"
+        },
+        "1.3.0~x86": {
+            "Version": "1.3.0+0.x86.w64.mingw32"
+        },
+        "1.3.1": {
+            "Version": "1.3.1+0.x64.w64.mingw32"
+        },
+        "1.3.1~x64": {
+            "Version": "1.3.1+0.x64.w64.mingw32"
+        },
+        "1.3.1~x86": {
+            "Version": "1.3.1+0.x86.w64.mingw32"
+        },
+        "1.3~x64": {
+            "Version": "1.3.1+0.x64.w64.mingw32"
+        },
+        "1.3~x86": {
+            "Version": "1.3.1+0.x86.w64.mingw32"
+        },
+        "1.4": {
+            "Version": "1.4.2+0.x64.w64.mingw32"
+        },
+        "1.4.0": {
+            "Version": "1.4.0+0.x64.w64.mingw32"
+        },
+        "1.4.0~x64": {
+            "Version": "1.4.0+0.x64.w64.mingw32"
+        },
+        "1.4.0~x86": {
+            "Version": "1.4.0+0.x86.w64.mingw32"
+        },
+        "1.4.1": {
+            "Version": "1.4.1+0.x64.w64.mingw32"
+        },
+        "1.4.1~x64": {
+            "Version": "1.4.1+0.x64.w64.mingw32"
+        },
+        "1.4.1~x86": {
+            "Version": "1.4.1+0.x86.w64.mingw32"
+        },
+        "1.4.2": {
+            "Version": "1.4.2+0.x64.w64.mingw32"
+        },
+        "1.4.2~x64": {
+            "Version": "1.4.2+0.x64.w64.mingw32"
+        },
+        "1.4.2~x86": {
+            "Version": "1.4.2+0.x86.w64.mingw32"
+        },
+        "1.4~x64": {
+            "Version": "1.4.2+0.x64.w64.mingw32"
+        },
+        "1.4~x86": {
+            "Version": "1.4.2+0.x86.w64.mingw32"
+        },
+        "1.5": {
+            "Version": "1.5.4+0.x64.w64.mingw32"
+        },
+        "1.5.0": {
+            "Version": "1.5.0+0.x64.w64.mingw32"
+        },
+        "1.5.0-beta1": {
+            "Version": "1.5.0-beta1+0.x64.w64.mingw32"
+        },
+        "1.5.0-beta1~x64": {
+            "Version": "1.5.0-beta1+0.x64.w64.mingw32"
+        },
+        "1.5.0-beta1~x86": {
+            "Version": "1.5.0-beta1+0.x86.w64.mingw32"
+        },
+        "1.5.0-rc1": {
+            "Version": "1.5.0-rc1+0.x64.w64.mingw32"
+        },
+        "1.5.0-rc1~x64": {
+            "Version": "1.5.0-rc1+0.x64.w64.mingw32"
+        },
+        "1.5.0-rc1~x86": {
+            "Version": "1.5.0-rc1+0.x86.w64.mingw32"
+        },
+        "1.5.0-rc2": {
+            "Version": "1.5.0-rc2+0.x64.w64.mingw32"
+        },
+        "1.5.0-rc2~x64": {
+            "Version": "1.5.0-rc2+0.x64.w64.mingw32"
+        },
+        "1.5.0-rc2~x86": {
+            "Version": "1.5.0-rc2+0.x86.w64.mingw32"
+        },
+        "1.5.0~x64": {
+            "Version": "1.5.0+0.x64.w64.mingw32"
+        },
+        "1.5.0~x86": {
+            "Version": "1.5.0+0.x86.w64.mingw32"
+        },
+        "1.5.1": {
+            "Version": "1.5.1+0.x64.w64.mingw32"
+        },
+        "1.5.1~x64": {
+            "Version": "1.5.1+0.x64.w64.mingw32"
+        },
+        "1.5.1~x86": {
+            "Version": "1.5.1+0.x86.w64.mingw32"
+        },
+        "1.5.2": {
+            "Version": "1.5.2+0.x64.w64.mingw32"
+        },
+        "1.5.2~x64": {
+            "Version": "1.5.2+0.x64.w64.mingw32"
+        },
+        "1.5.2~x86": {
+            "Version": "1.5.2+0.x86.w64.mingw32"
+        },
+        "1.5.3": {
+            "Version": "1.5.3+0.x64.w64.mingw32"
+        },
+        "1.5.3~x64": {
+            "Version": "1.5.3+0.x64.w64.mingw32"
+        },
+        "1.5.3~x86": {
+            "Version": "1.5.3+0.x86.w64.mingw32"
+        },
+        "1.5.4": {
+            "Version": "1.5.4+0.x64.w64.mingw32"
+        },
+        "1.5.4~x64": {
+            "Version": "1.5.4+0.x64.w64.mingw32"
+        },
+        "1.5.4~x86": {
+            "Version": "1.5.4+0.x86.w64.mingw32"
+        },
+        "1.5~x64": {
+            "Version": "1.5.4+0.x64.w64.mingw32"
+        },
+        "1.5~x86": {
+            "Version": "1.5.4+0.x86.w64.mingw32"
+        },
+        "1.6": {
+            "Version": "1.6.7+0.x64.w64.mingw32"
+        },
+        "1.6.0": {
+            "Version": "1.6.0+0.x64.w64.mingw32"
+        },
+        "1.6.0-beta1": {
+            "Version": "1.6.0-beta1+0.x64.w64.mingw32"
+        },
+        "1.6.0-beta1~x64": {
+            "Version": "1.6.0-beta1+0.x64.w64.mingw32"
+        },
+        "1.6.0-beta1~x86": {
+            "Version": "1.6.0-beta1+0.x86.w64.mingw32"
+        },
+        "1.6.0-rc1": {
+            "Version": "1.6.0-rc1+0.x64.w64.mingw32"
+        },
+        "1.6.0-rc1~x64": {
+            "Version": "1.6.0-rc1+0.x64.w64.mingw32"
+        },
+        "1.6.0-rc1~x86": {
+            "Version": "1.6.0-rc1+0.x86.w64.mingw32"
+        },
+        "1.6.0-rc2": {
+            "Version": "1.6.0-rc2+0.x64.w64.mingw32"
+        },
+        "1.6.0-rc2~x64": {
+            "Version": "1.6.0-rc2+0.x64.w64.mingw32"
+        },
+        "1.6.0-rc2~x86": {
+            "Version": "1.6.0-rc2+0.x86.w64.mingw32"
+        },
+        "1.6.0-rc3": {
+            "Version": "1.6.0-rc3+0.x64.w64.mingw32"
+        },
+        "1.6.0-rc3~x64": {
+            "Version": "1.6.0-rc3+0.x64.w64.mingw32"
+        },
+        "1.6.0-rc3~x86": {
+            "Version": "1.6.0-rc3+0.x86.w64.mingw32"
+        },
+        "1.6.0~x64": {
+            "Version": "1.6.0+0.x64.w64.mingw32"
+        },
+        "1.6.0~x86": {
+            "Version": "1.6.0+0.x86.w64.mingw32"
+        },
+        "1.6.1": {
+            "Version": "1.6.1+0.x64.w64.mingw32"
+        },
+        "1.6.1~x64": {
+            "Version": "1.6.1+0.x64.w64.mingw32"
+        },
+        "1.6.1~x86": {
+            "Version": "1.6.1+0.x86.w64.mingw32"
+        },
+        "1.6.2": {
+            "Version": "1.6.2+0.x64.w64.mingw32"
+        },
+        "1.6.2~x64": {
+            "Version": "1.6.2+0.x64.w64.mingw32"
+        },
+        "1.6.2~x86": {
+            "Version": "1.6.2+0.x86.w64.mingw32"
+        },
+        "1.6.3": {
+            "Version": "1.6.3+0.x64.w64.mingw32"
+        },
+        "1.6.3~x64": {
+            "Version": "1.6.3+0.x64.w64.mingw32"
+        },
+        "1.6.3~x86": {
+            "Version": "1.6.3+0.x86.w64.mingw32"
+        },
+        "1.6.4": {
+            "Version": "1.6.4+0.x64.w64.mingw32"
+        },
+        "1.6.4~x64": {
+            "Version": "1.6.4+0.x64.w64.mingw32"
+        },
+        "1.6.4~x86": {
+            "Version": "1.6.4+0.x86.w64.mingw32"
+        },
+        "1.6.5": {
+            "Version": "1.6.5+0.x64.w64.mingw32"
+        },
+        "1.6.5~x64": {
+            "Version": "1.6.5+0.x64.w64.mingw32"
+        },
+        "1.6.5~x86": {
+            "Version": "1.6.5+0.x86.w64.mingw32"
+        },
+        "1.6.6": {
+            "Version": "1.6.6+0.x64.w64.mingw32"
+        },
+        "1.6.6~x64": {
+            "Version": "1.6.6+0.x64.w64.mingw32"
+        },
+        "1.6.6~x86": {
+            "Version": "1.6.6+0.x86.w64.mingw32"
+        },
+        "1.6.7": {
+            "Version": "1.6.7+0.x64.w64.mingw32"
+        },
+        "1.6.7~x64": {
+            "Version": "1.6.7+0.x64.w64.mingw32"
+        },
+        "1.6.7~x86": {
+            "Version": "1.6.7+0.x86.w64.mingw32"
+        },
+        "1.6~x64": {
+            "Version": "1.6.7+0.x64.w64.mingw32"
+        },
+        "1.6~x86": {
+            "Version": "1.6.7+0.x86.w64.mingw32"
+        },
+        "1.7": {
+            "Version": "1.7.3+0.x64.w64.mingw32"
+        },
+        "1.7.0": {
+            "Version": "1.7.0+0.x64.w64.mingw32"
+        },
+        "1.7.0-beta1": {
+            "Version": "1.7.0-beta1+0.x64.w64.mingw32"
+        },
+        "1.7.0-beta1~x64": {
+            "Version": "1.7.0-beta1+0.x64.w64.mingw32"
+        },
+        "1.7.0-beta1~x86": {
+            "Version": "1.7.0-beta1+0.x86.w64.mingw32"
+        },
+        "1.7.0-beta2": {
+            "Version": "1.7.0-beta2+0.x64.w64.mingw32"
+        },
+        "1.7.0-beta2~x64": {
+            "Version": "1.7.0-beta2+0.x64.w64.mingw32"
+        },
+        "1.7.0-beta2~x86": {
+            "Version": "1.7.0-beta2+0.x86.w64.mingw32"
+        },
+        "1.7.0-beta3": {
+            "Version": "1.7.0-beta3+0.x64.w64.mingw32"
+        },
+        "1.7.0-beta3~x64": {
+            "Version": "1.7.0-beta3+0.x64.w64.mingw32"
+        },
+        "1.7.0-beta3~x86": {
+            "Version": "1.7.0-beta3+0.x86.w64.mingw32"
+        },
+        "1.7.0-beta4": {
+            "Version": "1.7.0-beta4+0.x64.w64.mingw32"
+        },
+        "1.7.0-beta4~x64": {
+            "Version": "1.7.0-beta4+0.x64.w64.mingw32"
+        },
+        "1.7.0-beta4~x86": {
+            "Version": "1.7.0-beta4+0.x86.w64.mingw32"
+        },
+        "1.7.0-rc1": {
+            "Version": "1.7.0-rc1+0.x64.w64.mingw32"
+        },
+        "1.7.0-rc1~x64": {
+            "Version": "1.7.0-rc1+0.x64.w64.mingw32"
+        },
+        "1.7.0-rc1~x86": {
+            "Version": "1.7.0-rc1+0.x86.w64.mingw32"
+        },
+        "1.7.0-rc2": {
+            "Version": "1.7.0-rc2+0.x64.w64.mingw32"
+        },
+        "1.7.0-rc2~x64": {
+            "Version": "1.7.0-rc2+0.x64.w64.mingw32"
+        },
+        "1.7.0-rc2~x86": {
+            "Version": "1.7.0-rc2+0.x86.w64.mingw32"
+        },
+        "1.7.0-rc3": {
+            "Version": "1.7.0-rc3+0.x64.w64.mingw32"
+        },
+        "1.7.0-rc3~x64": {
+            "Version": "1.7.0-rc3+0.x64.w64.mingw32"
+        },
+        "1.7.0-rc3~x86": {
+            "Version": "1.7.0-rc3+0.x86.w64.mingw32"
+        },
+        "1.7.0~x64": {
+            "Version": "1.7.0+0.x64.w64.mingw32"
+        },
+        "1.7.0~x86": {
+            "Version": "1.7.0+0.x86.w64.mingw32"
+        },
+        "1.7.1": {
+            "Version": "1.7.1+0.x64.w64.mingw32"
+        },
+        "1.7.1~x64": {
+            "Version": "1.7.1+0.x64.w64.mingw32"
+        },
+        "1.7.1~x86": {
+            "Version": "1.7.1+0.x86.w64.mingw32"
+        },
+        "1.7.2": {
+            "Version": "1.7.2+0.x64.w64.mingw32"
+        },
+        "1.7.2~x64": {
+            "Version": "1.7.2+0.x64.w64.mingw32"
+        },
+        "1.7.2~x86": {
+            "Version": "1.7.2+0.x86.w64.mingw32"
+        },
+        "1.7.3": {
+            "Version": "1.7.3+0.x64.w64.mingw32"
+        },
+        "1.7.3~x64": {
+            "Version": "1.7.3+0.x64.w64.mingw32"
+        },
+        "1.7.3~x86": {
+            "Version": "1.7.3+0.x86.w64.mingw32"
+        },
+        "1.7~x64": {
+            "Version": "1.7.3+0.x64.w64.mingw32"
+        },
+        "1.7~x86": {
+            "Version": "1.7.3+0.x86.w64.mingw32"
+        },
+        "1.8": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "1.8.0": {
+            "Version": "1.8.0+0.x64.w64.mingw32"
+        },
+        "1.8.0-beta1": {
+            "Version": "1.8.0-beta1+0.x64.w64.mingw32"
+        },
+        "1.8.0-beta1~x64": {
+            "Version": "1.8.0-beta1+0.x64.w64.mingw32"
+        },
+        "1.8.0-beta1~x86": {
+            "Version": "1.8.0-beta1+0.x86.w64.mingw32"
+        },
+        "1.8.0-beta2": {
+            "Version": "1.8.0-beta2+0.x64.w64.mingw32"
+        },
+        "1.8.0-beta2~x64": {
+            "Version": "1.8.0-beta2+0.x64.w64.mingw32"
+        },
+        "1.8.0-beta2~x86": {
+            "Version": "1.8.0-beta2+0.x86.w64.mingw32"
+        },
+        "1.8.0-beta3": {
+            "Version": "1.8.0-beta3+0.x64.w64.mingw32"
+        },
+        "1.8.0-beta3~x64": {
+            "Version": "1.8.0-beta3+0.x64.w64.mingw32"
+        },
+        "1.8.0-beta3~x86": {
+            "Version": "1.8.0-beta3+0.x86.w64.mingw32"
+        },
+        "1.8.0-rc1": {
+            "Version": "1.8.0-rc1+0.x64.w64.mingw32"
+        },
+        "1.8.0-rc1~x64": {
+            "Version": "1.8.0-rc1+0.x64.w64.mingw32"
+        },
+        "1.8.0-rc1~x86": {
+            "Version": "1.8.0-rc1+0.x86.w64.mingw32"
+        },
+        "1.8.0-rc2": {
+            "Version": "1.8.0-rc2+0.x64.w64.mingw32"
+        },
+        "1.8.0-rc2~x64": {
+            "Version": "1.8.0-rc2+0.x64.w64.mingw32"
+        },
+        "1.8.0-rc2~x86": {
+            "Version": "1.8.0-rc2+0.x86.w64.mingw32"
+        },
+        "1.8.0-rc3": {
+            "Version": "1.8.0-rc3+0.x64.w64.mingw32"
+        },
+        "1.8.0-rc3~x64": {
+            "Version": "1.8.0-rc3+0.x64.w64.mingw32"
+        },
+        "1.8.0-rc3~x86": {
+            "Version": "1.8.0-rc3+0.x86.w64.mingw32"
+        },
+        "1.8.0-rc4": {
+            "Version": "1.8.0-rc4+0.x64.w64.mingw32"
+        },
+        "1.8.0-rc4~x64": {
+            "Version": "1.8.0-rc4+0.x64.w64.mingw32"
+        },
+        "1.8.0-rc4~x86": {
+            "Version": "1.8.0-rc4+0.x86.w64.mingw32"
+        },
+        "1.8.0~x64": {
+            "Version": "1.8.0+0.x64.w64.mingw32"
+        },
+        "1.8.0~x86": {
+            "Version": "1.8.0+0.x86.w64.mingw32"
+        },
+        "1.8.1": {
+            "Version": "1.8.1+0.x64.w64.mingw32"
+        },
+        "1.8.1~x64": {
+            "Version": "1.8.1+0.x64.w64.mingw32"
+        },
+        "1.8.1~x86": {
+            "Version": "1.8.1+0.x86.w64.mingw32"
+        },
+        "1.8.2": {
+            "Version": "1.8.2+0.x64.w64.mingw32"
+        },
+        "1.8.2~x64": {
+            "Version": "1.8.2+0.x64.w64.mingw32"
+        },
+        "1.8.2~x86": {
+            "Version": "1.8.2+0.x86.w64.mingw32"
+        },
+        "1.8.3": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "1.8.3~x64": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "1.8.3~x86": {
+            "Version": "1.8.3+0.x86.w64.mingw32"
+        },
+        "1.8~x64": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "1.8~x86": {
+            "Version": "1.8.3+0.x86.w64.mingw32"
+        },
+        "1.9": {
+            "Version": "1.9.0-alpha1+0.x64.w64.mingw32"
+        },
+        "1.9.0-alpha1": {
+            "Version": "1.9.0-alpha1+0.x64.w64.mingw32"
+        },
+        "1.9.0-alpha1~x64": {
+            "Version": "1.9.0-alpha1+0.x64.w64.mingw32"
+        },
+        "1.9.0-alpha1~x86": {
+            "Version": "1.9.0-alpha1+0.x86.w64.mingw32"
+        },
+        "1.9~x64": {
+            "Version": "1.9.0-alpha1+0.x64.w64.mingw32"
+        },
+        "1.9~x86": {
+            "Version": "1.9.0-alpha1+0.x86.w64.mingw32"
+        },
+        "1~x64": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "1~x86": {
+            "Version": "1.8.3+0.x86.w64.mingw32"
+        },
+        "alpha": {
+            "Version": "1.9.0-alpha1+0.x64.w64.mingw32"
+        },
+        "alpha~x64": {
+            "Version": "1.9.0-alpha1+0.x64.w64.mingw32"
+        },
+        "alpha~x86": {
+            "Version": "1.9.0-alpha1+0.x86.w64.mingw32"
+        },
+        "beta": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "beta~x64": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "beta~x86": {
+            "Version": "1.8.3+0.x86.w64.mingw32"
+        },
+        "lts": {
+            "Version": "1.6.7+0.x64.w64.mingw32"
+        },
+        "lts~x64": {
+            "Version": "1.6.7+0.x64.w64.mingw32"
+        },
+        "lts~x86": {
+            "Version": "1.6.7+0.x86.w64.mingw32"
+        },
+        "rc": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "rc~x64": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "rc~x86": {
+            "Version": "1.8.3+0.x86.w64.mingw32"
+        },
+        "release": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "release~x64": {
+            "Version": "1.8.3+0.x64.w64.mingw32"
+        },
+        "release~x86": {
+            "Version": "1.8.3+0.x86.w64.mingw32"
+        }
+    },
+    "Version": "1.0.11"
+}


### PR DESCRIPTION
Need some workaround of `ring` dependency to build and run on windows arm64.