### PR TITLE
Configure for target_os, not nonexistant family

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ env_proxy = "0.4.1"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.43.0", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_System_Console", "Services_Store", "Foundation", "Foundation_Collections", "Web_Http", "Storage_Streams",] }
 
-[target.'cfg(macos)'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 ureq = { version = "2", features = ["native-tls"] }
 native-tls = "0.2.10"
 
-[target.'cfg(all(not(macos),not(windows)))'.dependencies]
+[target.'cfg(all(not(target_os = "macos"),not(windows)))'.dependencies]
 ureq = { version = "2", features = ["native-certs"] }
 
 [build-dependencies]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -56,7 +56,7 @@ fn get_proxy(url: &str) -> Option<Result<ureq::Proxy>> {
     })
 }
 
-#[cfg(not(any(windows, macos)))]
+#[cfg(not(any(windows, target_os = "macos")))]
 pub fn get_ureq_agent(url: &str) -> Result<ureq::Agent> {
     let agent = match get_proxy(url) {
         Some(proxy) => ureq::AgentBuilder::new().proxy(proxy?).build(),
@@ -66,7 +66,7 @@ pub fn get_ureq_agent(url: &str) -> Result<ureq::Agent> {
     Ok(agent)
 }
 
-#[cfg(macos)]
+#[cfg(target_os = "macos")]
 pub fn get_ureq_agent(url: &str) -> Result<ureq::Agent> {
     use native_tls::TlsConnector;
     use std::sync::Arc;


### PR DESCRIPTION
`cfg(macos)` is invalid, because `macos` is not a target family, but a target os. This causes the cfg to be ignored.
See more here:
https://rust-lang.github.io/rust-clippy/master/index.html#mismatched_target_os