### PR TITLE
Modify startup scripts as byte vectors instead of strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +766,7 @@ dependencies = [
  "fs_extra",
  "human-panic",
  "indicatif",
+ "indoc",
  "itertools",
  "log",
  "native-tls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "atty",
+ "bstr 1.0.1",
  "built",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ env_logger = "0.9.0"
 dialoguer = "0.10.0"
 shellexpand = "2.1.0"
 env_proxy = "0.4.1"
+bstr = "1.0.1"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.43.0", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_System_Console", "Services_Store", "Foundation", "Foundation_Collections", "Web_Http", "Storage_Streams",] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ winres = "0.1"
 [dev-dependencies]
 assert_cmd = "2"
 assert_fs = "1"
+indoc = "1.0.7"
 predicates = "2.1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ dialoguer = "0.10.0"
 shellexpand = "2.1.0"
 env_proxy = "0.4.1"
 bstr = "1.0.1"
+indoc = "1.0.7"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.43.0", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_System_Console", "Services_Store", "Foundation", "Foundation_Collections", "Web_Http", "Storage_Streams",] }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,4 +1,3 @@
-#![rustfmt_skip]
 use crate::config_file::JuliaupConfig;
 use crate::config_file::JuliaupConfigChannel;
 use crate::config_file::JuliaupConfigVersion;
@@ -7,8 +6,7 @@ use crate::global_paths::GlobalPaths;
 use crate::jsonstructs_versionsdb::JuliaupVersionDB;
 use crate::utils::get_juliaserver_base_url;
 use crate::utils::get_bin_dir;
-use anyhow::bail;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{bail, anyhow, Context, Result};
 use bstr::ByteSlice;
 use console::style;
 use flate2::read::GzDecoder;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,4 +1,4 @@
-        use crate::config_file::JuliaupConfig;
+use crate::config_file::JuliaupConfig;
 use crate::config_file::JuliaupConfigChannel;
 use crate::config_file::JuliaupConfigVersion;
 use crate::get_bundled_julia_version;
@@ -573,15 +573,13 @@ pub fn uninstall_background_selfupdate() -> Result<()> {
 
 const S_MARKER: &[u8] = b"# >>> juliaup initialize >>>";
 const E_MARKER: &[u8] = b"# <<< juliaup initialize <<<";
+const HEADER: &[u8] = b"\n\n# !! Contents within this block are managed by juliaup !!\n\n";
 
 fn get_shell_script_juliaup_content(bin_path: &Path, path: &Path) -> Vec<u8> {
     let mut result: Vec<u8> = Vec::new();
 
     result.extend_from_slice(S_MARKER);
-    result.extend_from_slice(b"\n");
-    result.extend_from_slice(b"\n");
-    result.extend_from_slice(b"# !! Contents within this block are managed by juliaup !!\n");
-    result.extend_from_slice(b"\n");
+    result.extend_from_slice(HEADER);
     if path.file_name().unwrap()==".zshrc" {
         result.extend_from_slice(b"path=('");
         result.extend_from_slice(bin_path.as_os_str().as_bytes());
@@ -593,8 +591,7 @@ fn get_shell_script_juliaup_content(bin_path: &Path, path: &Path) -> Vec<u8> {
         result.extend_from_slice(bin_path.as_os_str().as_bytes());
         result.extend_from_slice(b":*);; *)\n");
         result.extend_from_slice(b"    export PATH=");
-        result.extend_from_slice(bin_path.as_os_str().as_bytes());
-        result.extend_from_slice(b"${{PATH:+:${{PATH}}}};;\n");
+        result.extend_from_slice(bin_path.as_os_str().as_bytes()); result.extend_from_slice(b"${{PATH:+:${{PATH}}}};;\n");
         result.extend_from_slice(b"esac\n");    
     }
     result.extend_from_slice(b"\n");

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -662,9 +662,11 @@ fn add_path_to_specific_file(bin_path: &PathBuf, path: PathBuf) -> Result<()> {
     file.read_to_end(&mut buffer)
         .with_context(|| format!("Failed to read data from file {}.", path.display()))?;
 
-    let existing_code_pos = match_markers(&buffer)?;
+    let existing_code_pos = match_markers(&buffer)
+        .with_context(|| format!("Error occured while searching juliaup shell startup script section in {}", path.display()))?;
 
-    let new_content = get_shell_script_juliaup_content(bin_path, &path)?;
+    let new_content = get_shell_script_juliaup_content(bin_path, &path)
+        .with_context(|| format!("Error occured while generating juliaup shell startup script section for {}", path.display()))?;
 
     match existing_code_pos {
         Some(pos) => {
@@ -696,7 +698,8 @@ fn remove_path_from_specific_file(path: PathBuf) -> Result<()> {
 
     file.read_to_end(&mut buffer)?;
 
-    let existing_code_pos = match_markers(&buffer)?;
+    let existing_code_pos = match_markers(&buffer)
+        .with_context(|| format!("Error occured while searching juliaup shell startup script section in {}", path.display()))?;
 
     if let Some(pos) = existing_code_pos {
         buffer.replace_range(pos.0..pos.1, "");

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -670,9 +670,9 @@ fn remove_path_from_specific_file(path: PathBuf) -> Result<()> {
     let mut file = std::fs::OpenOptions::new().read(true).write(true).open(&path)
     .with_context(|| format!("Failed to open file: {}", path.display()))?;
 
-    let mut buffer = String::new();
+    let mut buffer: Vec<u8> = Vec::new();
 
-    file.read_to_string(&mut buffer)?;
+    file.read_to_end(&mut buffer)?;
 
     let existing_code_pos = match_markers(&buffer, true)?;
 
@@ -683,7 +683,7 @@ fn remove_path_from_specific_file(path: PathBuf) -> Result<()> {
 
         file.set_len(0).unwrap();
 
-        file.write_all(buffer.as_bytes()).unwrap();
+        file.write_all(&buffer).unwrap();
 
         file.sync_all().unwrap();
     }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -581,23 +581,32 @@ fn get_shell_script_juliaup_content(bin_path: &Path, path: &Path) -> Vec<u8> {
     result.extend_from_slice(S_MARKER);
     result.extend_from_slice(HEADER);
     if path.file_name().unwrap()==".zshrc" {
-        result.extend_from_slice(b"path=('");
-        result.extend_from_slice(bin_path.as_os_str().as_bytes());
-        result.extend_from_slice(b"' $path)\n");
-        result.extend_from_slice(b"export PATH\n");
+        append_zsh_content(&mut result, bin_path);
     }
     else {
-        result.extend_from_slice(b"case \":$PATH:\" in *:");
-        result.extend_from_slice(bin_path.as_os_str().as_bytes());
-        result.extend_from_slice(b":*);; *)\n");
-        result.extend_from_slice(b"    export PATH=");
-        result.extend_from_slice(bin_path.as_os_str().as_bytes()); result.extend_from_slice(b"${{PATH:+:${{PATH}}}};;\n");
-        result.extend_from_slice(b"esac\n");    
+        append_sh_content(&mut result, bin_path);
     }
     result.extend_from_slice(b"\n");
     result.extend_from_slice(E_MARKER);
 
     result
+}
+
+fn append_zsh_content(buf: &mut Vec<u8>, p: &Path) {
+    buf.extend_from_slice(b"path=('");
+    buf.extend_from_slice(p.as_os_str().as_bytes());
+    buf.extend_from_slice(b"' $path)\n");
+    buf.extend_from_slice(b"export PATH\n");
+}
+
+fn append_sh_content(buf: &mut Vec<u8>, p: &Path) {
+    buf.extend_from_slice(b"case \":$PATH:\" in *:");
+    buf.extend_from_slice(p.as_os_str().as_bytes());
+    buf.extend_from_slice(b":*);; *)\n");
+    buf.extend_from_slice(b"    export PATH=");
+    buf.extend_from_slice(p.as_os_str().as_bytes());
+    buf.extend_from_slice(b"${{PATH:+:${{PATH}}}};;\n");
+    buf.extend_from_slice(b"esac\n");    
 }
 
 fn match_markers(buffer: &[u8]) -> Result<Option<(usize,usize)>> {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -19,6 +19,7 @@ use indoc::formatdoc;
 use std::io::BufReader;
 use std::io::Seek;
 use std::io::Write;
+#[cfg(not(windows))]
 use std::os::unix::prelude::OsStrExt;
 use std::{
     io::Read,

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -581,7 +581,7 @@ fn get_shell_script_juliaup_content(bin_path: &Path, path: &Path) -> Result<Vec<
 
     let bin_path_str = match bin_path.to_str() {
         Some(s) => s,
-        None =>  bail!("Could not crate UTF-8 string from passed-in binary application path. Currently only valid UTF-8 paths are supported"),
+        None =>  bail!("Could not create UTF-8 string from passed-in binary application path. Currently only valid UTF-8 paths are supported"),
     };
 
     result.extend_from_slice(S_MARKER);


### PR DESCRIPTION
This PR is intended to fix #433 by matching on and replacing pure byte streams. This way, the assumption of valid UTF-8 data in the startup files is loosened. A typical case where this could cause issues is when operating system paths that are not valid UTF-8 data are used. 