### PR TITLE
Fix mismatch types

### DIFF
--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -222,7 +222,7 @@ pub fn main() -> Result<()> {
         install_location: dirs::home_dir()
             .ok_or(anyhow!("Could not determine the path of the user home directory."))?
             .join(".juliaup"),
-        modifypath_files: find_shell_scripts_to_be_modified(true),
+        modifypath_files: find_shell_scripts_to_be_modified(true)?,
     };
 
     print_install_choices(&install_choices)?;


### PR DESCRIPTION
Running `cargo build --release --feature selfupdate` will have a mismatch type error in line 225 in `src/bin/juliainstaller.rs`. Just a small fix.