### PR TITLE
Fixed typo `uopdate`

### DIFF
--- a/src/command_selfupdate.rs
+++ b/src/command_selfupdate.rs
@@ -11,7 +11,7 @@ pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
     use crate::{get_juliaup_target, get_own_version};
 
     update_version_db(paths)
-        .with_context(|| "Failed to uopdate versions db.")?;
+        .with_context(|| "Failed to update versions db.")?;
 
     let mut config_file =
         load_mut_config_db(paths).with_context(|| "`selfupdate` command failed to load configuration db.")?;
@@ -77,7 +77,7 @@ pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
     use windows::{core::Interface,Win32::{System::Console::GetConsoleWindow, UI::Shell::IInitializeWithWindow}};
 
     update_version_db(paths)
-        .with_context(|| "Failed to uopdate versions db.")?;
+        .with_context(|| "Failed to update versions db.")?;
 
     let update_manager = windows::Services::Store::StoreContext::GetDefault()    
         .with_context(|| "Failed to get the store context.")?;
@@ -116,6 +116,6 @@ pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
 #[cfg(not(any(feature = "windowsstore", feature = "selfupdate")))]
 pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
     update_version_db(paths)
-        .with_context(|| "Failed to uopdate versions db.")?;
+        .with_context(|| "Failed to update versions db.")?;
     Ok(())
 }

--- a/src/command_update.rs
+++ b/src/command_update.rs
@@ -50,7 +50,7 @@ fn update_channel(config_db: &mut JuliaupConfig, channel: &String, version_db: &
 
 pub fn run_command_update(channel: Option<String>, paths: &GlobalPaths) -> Result<()> {
     update_version_db(paths)
-        .with_context(|| "Failed to uopdate versions db.")?;
+        .with_context(|| "Failed to update versions db.")?;
 
     let version_db =
         load_versions_db(paths).with_context(|| "`update` command failed to load versions db.")?;


### PR DESCRIPTION
Found this typo an reported it [here](https://github.com/JuliaLang/juliaup/issues/535#issue-1510343156).
Fixes https://github.com/JuliaLang/juliaup/issues/535 and closes https://github.com/JuliaLang/juliaup/pull/537