### PR TITLE
Add support for non-interactive install

### DIFF
--- a/deploy/shellscript/juliaup-init.sh
+++ b/deploy/shellscript/juliaup-init.sh
@@ -87,12 +87,12 @@ main() {
     fi
 
     # check if we have to use /dev/tty to prompt the user
-    # local _y=no
+    local _y=no
     local need_tty=yes
     for arg in "$@"; do
         case "$arg" in
             "-h"|"--help")      usage; exit 0       ;;
-            # "-y"|"--yes")       _y=yes; need_tty=no ;; # skip prompt; no need for /dev/tty
+            "-y"|"--yes")       _y=yes; need_tty=no ;; # skip prompt; no need for /dev/tty
             *)                                      ;;
         esac
     done
@@ -131,9 +131,9 @@ main() {
     _ttyname="/dev/$(ps -p $$ -o tty= | xargs)"
 
     if [ "$need_tty" = "yes" ]; then
-        ignore "$_file" THISISREPLACEDWITHCHANNELCONFIGINGITHUBWORKFLOW < "$_ttyname"
+        ignore "$_file" THISISREPLACEDWITHCHANNELCONFIGINGITHUBWORKFLOW "$@" < "$_ttyname"
     else
-        ignore "$_file" THISISREPLACEDWITHCHANNELCONFIGINGITHUBWORKFLOW
+        ignore "$_file" THISISREPLACEDWITHCHANNELCONFIGINGITHUBWORKFLOW "$@"
     fi
     local _retval=$?
 

--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -91,7 +91,10 @@ fn is_juliaup_installed() -> bool {
 #[clap(name="Juliainstaller", version)]
 /// The Julia Installer
 struct Juliainstaller {
-    /// Juliaup channel
+    /// Channel
+    #[clap(long, default_value = "release")]
+    channel: String,
+    /// Juliaup self channel
     #[clap(long, default_value = "release")]
     juliaupchannel: String,
     /// Disable confirmation prompt
@@ -158,7 +161,7 @@ pub fn main() -> Result<()> {
     use anyhow::{anyhow, Context};
     use console::{Style, style};
     use dialoguer::{theme::{ColorfulTheme, Theme, SimpleTheme}, Confirm, Select};
-    use juliaup::{get_juliaup_target, utils::get_juliaserver_base_url, get_own_version, operations::{download_extract_sans_parent, find_shell_scripts_to_be_modified}, config_file::{JuliaupSelfConfig}, command_initial_setup_from_launcher::run_command_initial_setup_from_launcher, command_selfchannel::run_command_selfchannel, global_paths::get_paths};
+    use juliaup::{get_juliaup_target, utils::get_juliaserver_base_url, get_own_version, operations::{download_extract_sans_parent, find_shell_scripts_to_be_modified}, config_file::{JuliaupSelfConfig}, command_initial_setup_from_launcher::run_command_initial_setup_from_launcher, command_selfchannel::run_command_selfchannel, global_paths::get_paths, command_add::run_command_add, command_default::run_command_default};
 
     human_panic::setup_panic!(human_panic::Metadata {
         name: "Juliainstaller".into(),
@@ -358,7 +361,11 @@ pub fn main() -> Result<()> {
     run_command_config_symlinks(Some(install_choices.symlinks), true, &paths).unwrap();
     run_command_selfchannel(args.juliaupchannel, &paths).unwrap();
 
-    run_command_initial_setup_from_launcher(&paths)?;
+    run_command_add(&args.channel, &paths)
+        .with_context(|| "Failed to run `run_command_add`.")?;
+
+    run_command_default(&args.channel, &paths)
+        .with_context(|| "Failed to run `run_command_default`.")?;
 
     let symlink_path = juliaupselfbin.join("julia");
 

--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -161,7 +161,7 @@ pub fn main() -> Result<()> {
     use anyhow::{anyhow, Context};
     use console::{Style, style};
     use dialoguer::{theme::{ColorfulTheme, Theme, SimpleTheme}, Confirm, Select};
-    use juliaup::{get_juliaup_target, utils::get_juliaserver_base_url, get_own_version, operations::{download_extract_sans_parent, find_shell_scripts_to_be_modified}, config_file::{JuliaupSelfConfig}, command_initial_setup_from_launcher::run_command_initial_setup_from_launcher, command_selfchannel::run_command_selfchannel, global_paths::get_paths, command_add::run_command_add, command_default::run_command_default};
+    use juliaup::{get_juliaup_target, utils::get_juliaserver_base_url, get_own_version, operations::{download_extract_sans_parent, find_shell_scripts_to_be_modified}, config_file::{JuliaupSelfConfig}, command_selfchannel::run_command_selfchannel, global_paths::get_paths, command_add::run_command_add, command_default::run_command_default};
 
     human_panic::setup_panic!(human_panic::Metadata {
         name: "Juliainstaller".into(),


### PR DESCRIPTION
This adds support for a `-y` (or `--yes`) parameter that disables all interactivity in the installer and just uses the default values. Also adds a `--channel beta` flag so that one can install a specific channel.