### PR TITLE
launcher: replace parent process on supported platforms.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ reqwest = { version = "0.11.18", default-features = false, features = ["blocking
 reqwest = { version = "0.11.18", default-features = false, features = ["blocking", "rustls-tls-native-roots", "socks"] }
 
 [target.'cfg(not(windows))'.dependencies]
-nix = "0.27.1"
+nix = { version = "0.27.1", features = ["process"] }
 
 [build-dependencies]
 anyhow = "1.0.72"

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -15,8 +15,6 @@ use normpath::PathExt;
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::path::PathBuf;
-#[cfg(windows)]
-use std::process::Command;
 
 #[derive(thiserror::Error, Debug)]
 #[error("{msg}")]

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -301,10 +301,6 @@ fn run_app() -> Result<i32> {
         }
     }
 
-    // We set a Ctrl-C handler here that just doesn't do anything, as we want the Julia child
-    // process to handle things.
-    ctrlc::set_handler(|| ()).with_context(|| "Failed to set the Ctrl-C handler.")?;
-
     // On *nix platforms we replace the current process with the Julia one.
     // This simplifies use in e.g. debuggers, but requires that we fork off
     // a subprocess to do the selfupdate and versiondb update.
@@ -350,6 +346,11 @@ fn run_app() -> Result<i32> {
                     // any typical daemon-y things (like detaching the TTY)
                     // so that any error output is still visible.
 
+                    // We set a Ctrl-C handler here that just doesn't do anything, as we want the Julia child
+                    // process to handle things.
+                    ctrlc::set_handler(|| ())
+                        .with_context(|| "Failed to set the Ctrl-C handler.")?;
+
                     run_versiondb_update(&config_file)
                         .with_context(|| "Failed to run version db update")?;
 
@@ -366,6 +367,10 @@ fn run_app() -> Result<i32> {
     // On other platforms (i.e., Windows) we just spawn a subprocess
     #[cfg(windows)]
     {
+        // We set a Ctrl-C handler here that just doesn't do anything, as we want the Julia child
+        // process to handle things.
+        ctrlc::set_handler(|| ()).with_context(|| "Failed to set the Ctrl-C handler.")?;
+
         let mut child_process = std::process::Command::new(julia_path)
             .args(&new_args)
             .spawn()


### PR DESCRIPTION
This simplifies use of juliaup with, e.g., debuggers. Database updates are executed in a forked process.

There's a couple of tricky aspects:
- not everything is safe to `fork`; essentially `julialauncher` may not become multithreaded for this to work
- ~because we replace the parent process without waiting for the child, there'll be a zombie `julialauncher` process until the parent terminates~

I don't think these are dealbreakers, but it's probably worth discussing.

Untested on Windows as cross-compilation doesn't work for `juliaup` (due to the `build.rs`).
I'm also a Rust newbie so the code probably can be improved.

cc @vchuravy @staticfloat 

Fixes https://github.com/JuliaLang/juliaup/issues/552, fixes https://github.com/JuliaLang/juliaup/issues/607, fixes https://github.com/JuliaLang/juliaup/issues/645