### PR TITLE
Add more cli parameters for automated install

### DIFF
--- a/deploy/shellscript/juliaup-init.sh
+++ b/deploy/shellscript/juliaup-init.sh
@@ -37,7 +37,7 @@ USAGE:
 
 FLAGS:
     -y, --yes                   Disable confirmation prompt.
-        --no-add-to-path        Don't add to user PATH environment variable
+        --add-to-path           Add to user PATH environment variable
     -h, --help                  Prints help information
         --background-selfupdate Background self-update interval
         --startup-selfupdate    Statup self-update interval

--- a/deploy/shellscript/juliaup-init.sh
+++ b/deploy/shellscript/juliaup-init.sh
@@ -38,10 +38,9 @@ USAGE:
 FLAGS:
     -y, --yes                   Disable confirmation prompt.
         --add-to-path           Add to user PATH environment variable
-    -h, --help                  Prints help information
         --background-selfupdate Background self-update interval
         --startup-selfupdate    Startup self-update interval
-
+    -h, --help                  Prints help information
 
 OPTIONS:
     -p, --path              Custom install path

--- a/deploy/shellscript/juliaup-init.sh
+++ b/deploy/shellscript/juliaup-init.sh
@@ -36,9 +36,12 @@ USAGE:
     juliaup-init [FLAGS] [OPTIONS]
 
 FLAGS:
-    -y, --yes               Disable confirmation prompt.
-        --no-add-to-path    Don't add to user PATH environment variable
-    -h, --help              Prints help information
+    -y, --yes                   Disable confirmation prompt.
+        --no-add-to-path        Don't add to user PATH environment variable
+    -h, --help                  Prints help information
+        --background-selfupdate Background self-update interval
+        --startup-selfupdate    Statup self-update interval
+
 
 OPTIONS:
     -p, --path              Custom install path

--- a/deploy/shellscript/juliaup-init.sh
+++ b/deploy/shellscript/juliaup-init.sh
@@ -40,7 +40,7 @@ FLAGS:
         --add-to-path           Add to user PATH environment variable
     -h, --help                  Prints help information
         --background-selfupdate Background self-update interval
-        --startup-selfupdate    Statup self-update interval
+        --startup-selfupdate    Startup self-update interval
 
 
 OPTIONS:

--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use clap::Parser;
 use clap::builder::BoolishValueParser;
+use clap::Parser;
 
 #[cfg(feature = "selfupdate")]
 fn run_individual_config_wizard(
@@ -137,7 +137,7 @@ struct Juliainstaller {
     background_selfupdate_interval: i64,
     /// Manually specify the statup self-update interval
     #[clap(long = "startup-selfupdate", default_value_t = 1440)]
-    startup_selfupdate_interval: i64
+    startup_selfupdate_interval: i64,
 }
 
 #[cfg(feature = "selfupdate")]
@@ -211,7 +211,6 @@ fn print_install_choices(install_choices: &InstallChoices) -> Result<()> {
 
 #[cfg(feature = "selfupdate")]
 pub fn main() -> Result<()> {
-    use std::path::PathBuf;
     use anyhow::{anyhow, Context};
     use console::{style, Style};
     use dialoguer::{
@@ -229,6 +228,7 @@ pub fn main() -> Result<()> {
         utils::get_juliaserver_base_url,
     };
     use std::io::Seek;
+    use std::path::PathBuf;
 
     human_panic::setup_panic!(human_panic::Metadata {
         name: "Juliainstaller".into(),

--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -103,9 +103,9 @@ struct Juliainstaller {
     /// Specify alternate path for Juliaup
     #[clap(short = 'p', long = "path", default_value = "")]
     alternate_path: String,
-    /// Disable adding the Juliaup dir to the PATH
-    #[clap(long = "no-add-to-path")]
-    disable_add_to_path: bool,
+    /// Control adding the Juliaup dir to the PATH
+    #[clap(long = "add-to-path", default_value = "yes")]
+    add_to_path: String,
     /// Manually specify the background self-update interval
     #[clap(long = "background-selfupdate", default_value = "0")]
     background_selfupdate_interval: String,
@@ -193,6 +193,15 @@ pub fn main() -> Result<()> {
         return Err(anyhow!("To install Julia in non-interactive mode pass the -y parameter."))
     }
 
+    if ! (args.add_to_path.eq("yes") || args.add_to_path.eq("no")) {
+        return Err(
+            anyhow!(
+                "--add-to-path can be either 'yes' or 'no', you entered: '{}'",
+                args.add_to_path
+            )
+        )
+    }
+
     let theme: Box<dyn Theme> = if atty::is(atty::Stream::Stdout) {
         Box::new(ColorfulTheme {
             values_style: Style::new().yellow().dim(),
@@ -250,7 +259,7 @@ pub fn main() -> Result<()> {
         backgroundselfupdate: args.background_selfupdate_interval.parse().unwrap(),
         startupselfupdate: args.startup_selfupdate_interval.parse().unwrap(),
         symlinks: false,
-        modifypath: ! args.disable_add_to_path,
+        modifypath: args.add_to_path.eq("yes"),
         install_location: dirs::home_dir()
             .ok_or(anyhow!("Could not determine the path of the user home directory."))?
             .join(".juliaup"),


### PR DESCRIPTION
Added some more CLI flags that allow for an automated install to a custom location. Flags added are:
1. `--path` the location where to install Juliaup to
2. `--add-to-path` when set, do not append `.bashrc` etc addind Juliaup to PATH
3. `--background-selfupdate` and `--startup-selfupdate` update intervals

This PR allows Juliaup to be used as an administrative tool -- where it:
1. can't be installed to the home directory (it might be invoked by a setup tool running as a privileged/admin user)
2. mustn't mess with local config files (such as bashrc)
3. shouldn't automagically update itself

As an example, this it how I plan to use it at NERSC:
1. Install into a global location (set by modulefiles):
```
JULIA_DEPOT_PATH=/path/to/global/shared/depot ./juliainstaller --path=/models/bin/path --add-to-path=no --background-selfupdate=0 --startup-selfupdate=0 --yes
```
2. Use juliaup to download julia versions (no more wget+untar!!!)