### PR TITLE
run cargo format on all files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,31 +8,38 @@ extern crate winres;
 mod jsonstructs_versionsdb;
 
 use anyhow::Result;
+use serde_json::Value;
 use std::env;
 use std::fs::File;
-use std::path::PathBuf;
 use std::path::Path;
-use serde_json::Value;
+use std::path::PathBuf;
 
 fn main() -> Result<()> {
     let target_platform = std::env::var("TARGET").unwrap();
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    let db_path = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("versiondb").join(format!("versiondb-{}.json", target_platform));
+    let db_path = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("versiondb")
+        .join(format!("versiondb-{}.json", target_platform));
 
     let version_db_path = out_path.join("versionsdb.json");
     std::fs::copy(&db_path, &version_db_path).unwrap();
 
     let file = File::open(&db_path)?;
     let data: Value = serde_json::from_reader(file)?;
-    let bundled_version_as_string: String = data["AvailableChannels"]["release"]["Version"].to_string();
+    let bundled_version_as_string: String =
+        data["AvailableChannels"]["release"]["Version"].to_string();
     let bundled_dbversion_as_string: String = data["Version"].to_string();
     let bundled_version_path = Path::new(&out_path).join("bundled_version.rs");
     std::fs::write(
         &bundled_version_path,
-        format!("pub const BUNDLED_JULIA_VERSION: &str = {}; pub const BUNDLED_DB_VERSION: &str = {};", bundled_version_as_string, bundled_dbversion_as_string)
-    ).unwrap();
+        format!(
+            "pub const BUNDLED_JULIA_VERSION: &str = {}; pub const BUNDLED_DB_VERSION: &str = {};",
+            bundled_version_as_string, bundled_dbversion_as_string
+        ),
+    )
+    .unwrap();
 
     #[cfg(windows)]
     {
@@ -44,10 +51,11 @@ fn main() -> Result<()> {
     let various_constants_path = Path::new(&out_path).join("various_constants.rs");
     std::fs::write(
         &various_constants_path,
-        format!("pub const JULIAUP_TARGET: &str = \"{}\";", &target_platform)
-    ).unwrap();
+        format!("pub const JULIAUP_TARGET: &str = \"{}\";", &target_platform),
+    )
+    .unwrap();
 
     built::write_built_file().expect("Failed to acquire build-time information");
-    
+
     Ok(())
 }

--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -1,28 +1,33 @@
 use anyhow::Result;
 use clap::Parser;
 
-
 #[cfg(feature = "selfupdate")]
-fn run_individual_config_wizard(install_choices: &mut InstallChoices, theme: & dyn dialoguer::theme::Theme) -> Result<Option<()>> {
-
+fn run_individual_config_wizard(
+    install_choices: &mut InstallChoices,
+    theme: &dyn dialoguer::theme::Theme,
+) -> Result<Option<()>> {
     use std::path::PathBuf;
 
-    use dialoguer::{Input, Confirm};
+    use dialoguer::{Confirm, Input};
     use log::trace;
 
-    trace!("install_location pre inside the prompt function {:?}", install_choices.install_location);
+    trace!(
+        "install_location pre inside the prompt function {:?}",
+        install_choices.install_location
+    );
 
     let new_install_location = Input::with_theme(theme)
-        .with_prompt("Enter the folder where you want to install Juliaup")        
+        .with_prompt("Enter the folder where you want to install Juliaup")
         .validate_with(|input: &String| match input.parse::<PathBuf>() {
-                Ok(_) => Ok(()),
-                Err(_) => Err("Not a valid input".to_owned())
+            Ok(_) => Ok(()),
+            Err(_) => Err("Not a valid input".to_owned()),
         })
-        .with_initial_text(install_choices.install_location.to_string_lossy().clone())        
+        .with_initial_text(install_choices.install_location.to_string_lossy().clone())
         .interact_text()?;
 
     let new_install_location = shellexpand::tilde(&new_install_location)
-        .parse::<PathBuf>().unwrap();
+        .parse::<PathBuf>()
+        .unwrap();
 
     let new_modifypath = match Confirm::with_theme(theme)
         .with_prompt("Do you want to add the Julia binaries to your PATH by manipulating various shell startup scripts?")
@@ -35,34 +40,53 @@ fn run_individual_config_wizard(install_choices: &mut InstallChoices, theme: & d
     let new_symlinks = match Confirm::with_theme(theme)
         .with_prompt("Do you want to add channel specific symlinks?")
         .default(install_choices.symlinks)
-        .interact_opt()? {
-            Some(value) => value,
-            None => return Ok(None)
-        };
+        .interact_opt()?
+    {
+        Some(value) => value,
+        None => return Ok(None),
+    };
 
     let new_startupselfupdate = Input::with_theme(theme)
-        .with_prompt("Enter minutes between check for new version at julia startup, use 0 to disable")
+        .with_prompt(
+            "Enter minutes between check for new version at julia startup, use 0 to disable",
+        )
         .validate_with(|input: &String| -> Result<(), &str> {
             match input.parse::<i64>() {
-                Ok(val) => if val>=0 {Ok(())} else {Err("Not a valid input")},
-                Err(_) => Err("Not a valid input")
+                Ok(val) => {
+                    if val >= 0 {
+                        Ok(())
+                    } else {
+                        Err("Not a valid input")
+                    }
+                }
+                Err(_) => Err("Not a valid input"),
             }
         })
         .default(install_choices.startupselfupdate.to_string())
         .interact_text()?
-        .parse::<i64>().unwrap();
+        .parse::<i64>()
+        .unwrap();
 
     let new_backgroundselfupdate = Input::with_theme(theme)
-        .with_prompt("Enter minutes between check for new version by a background task, use 0 to disable")
+        .with_prompt(
+            "Enter minutes between check for new version by a background task, use 0 to disable",
+        )
         .validate_with(|input: &String| -> Result<(), &str> {
             match input.parse::<i64>() {
-                Ok(val) => if val>=0 {Ok(())} else {Err("Not a valid input")},
-                Err(_) => Err("Not a valid input")
+                Ok(val) => {
+                    if val >= 0 {
+                        Ok(())
+                    } else {
+                        Err("Not a valid input")
+                    }
+                }
+                Err(_) => Err("Not a valid input"),
             }
         })
         .default(install_choices.backgroundselfupdate.to_string())
         .interact_text()?
-        .parse::<i64>().unwrap();
+        .parse::<i64>()
+        .unwrap();
 
     install_choices.install_location = new_install_location;
     install_choices.modifypath = new_modifypath;
@@ -88,7 +112,7 @@ fn is_juliaup_installed() -> bool {
 }
 
 #[derive(Parser)]
-#[clap(name="Juliainstaller", version)]
+#[clap(name = "Juliainstaller", version)]
 /// The Julia Installer
 struct Juliainstaller {
     /// Default channel
@@ -99,7 +123,7 @@ struct Juliainstaller {
     juliaup_channel: String,
     /// Disable confirmation prompt
     #[clap(short = 'y', long = "yes")]
-    disable_confirmation_prompt: bool
+    disable_confirmation_prompt: bool,
 }
 
 #[cfg(feature = "selfupdate")]
@@ -120,14 +144,27 @@ fn print_install_choices(install_choices: &InstallChoices) -> Result<()> {
     println!();
     println!("  {}", install_choices.install_location.to_string_lossy());
     println!();
-    println!("The {}, {} and other commands will be added to", style("julia").bold(), style("juliaup").bold());
+    println!(
+        "The {}, {} and other commands will be added to",
+        style("julia").bold(),
+        style("juliaup").bold()
+    );
     println!("Juliaup's bin directory, located at:");
     println!();
-    println!("  {}", install_choices.install_location.join("bin").to_string_lossy());
+    println!(
+        "  {}",
+        install_choices
+            .install_location
+            .join("bin")
+            .to_string_lossy()
+    );
     println!();
 
     if install_choices.modifypath {
-        println!("This path will then be added to your {} environment variable by", style("PATH").bold());
+        println!(
+            "This path will then be added to your {} environment variable by",
+            style("PATH").bold()
+        );
         println!("modifying the profile files located at:");
         println!();
         for p in &install_choices.modifypath_files {
@@ -136,13 +173,16 @@ fn print_install_choices(install_choices: &InstallChoices) -> Result<()> {
         println!();
     }
 
-    if install_choices.backgroundselfupdate>0 {
+    if install_choices.backgroundselfupdate > 0 {
         println!("The installer will configure a CRON job that checks for updates of");
-        println!("Juliaup itself. This CRON job will run every {} seconds.", install_choices.backgroundselfupdate);
+        println!(
+            "Juliaup itself. This CRON job will run every {} seconds.",
+            install_choices.backgroundselfupdate
+        );
         println!();
     }
 
-    if install_choices.startupselfupdate>0 {
+    if install_choices.startupselfupdate > 0 {
         println!("Julia will look for a new version of Juliaup itself every {} minutes when you start julia.", install_choices.startupselfupdate);
         println!();
     }
@@ -157,11 +197,23 @@ fn print_install_choices(install_choices: &InstallChoices) -> Result<()> {
 
 #[cfg(feature = "selfupdate")]
 pub fn main() -> Result<()> {
-    use std::io::Seek;
     use anyhow::{anyhow, Context};
-    use console::{Style, style};
-    use dialoguer::{theme::{ColorfulTheme, Theme, SimpleTheme}, Confirm, Select};
-    use juliaup::{get_juliaup_target, utils::get_juliaserver_base_url, get_own_version, operations::{download_extract_sans_parent, find_shell_scripts_to_be_modified}, config_file::{JuliaupSelfConfig}, command_selfchannel::run_command_selfchannel, global_paths::get_paths, command_add::run_command_add, command_default::run_command_default};
+    use console::{style, Style};
+    use dialoguer::{
+        theme::{ColorfulTheme, SimpleTheme, Theme},
+        Confirm, Select,
+    };
+    use juliaup::{
+        command_add::run_command_add,
+        command_default::run_command_default,
+        command_selfchannel::run_command_selfchannel,
+        config_file::JuliaupSelfConfig,
+        get_juliaup_target, get_own_version,
+        global_paths::get_paths,
+        operations::{download_extract_sans_parent, find_shell_scripts_to_be_modified},
+        utils::get_juliaserver_base_url,
+    };
+    use std::io::Seek;
 
     human_panic::setup_panic!(human_panic::Metadata {
         name: "Juliainstaller".into(),
@@ -170,14 +222,18 @@ pub fn main() -> Result<()> {
         homepage: "https://github.com/JuliaLang/juliaup".into(),
     });
 
-    let env = env_logger::Env::new().filter("JULIAUP_LOG").write_style("JULIAUP_LOG_STYLE");
+    let env = env_logger::Env::new()
+        .filter("JULIAUP_LOG")
+        .write_style("JULIAUP_LOG_STYLE");
     env_logger::init_from_env(env);
 
     info!("Parsing command line arguments.");
     let args = Juliainstaller::parse();
 
     if !args.disable_confirmation_prompt && atty::isnt(atty::Stream::Stdin) {
-        return Err(anyhow!("To install Julia in non-interactive mode pass the -y parameter."))
+        return Err(anyhow!(
+            "To install Julia in non-interactive mode pass the -y parameter."
+        ));
     }
 
     let theme: Box<dyn Theme> = if atty::is(atty::Stream::Stdout) {
@@ -185,16 +241,19 @@ pub fn main() -> Result<()> {
             values_style: Style::new().yellow().dim(),
             ..ColorfulTheme::default()
         })
-    }
-    else {
+    } else {
         Box::new(SimpleTheme)
     };
 
-    let mut paths = get_paths()
-        .with_context(|| "Trying to load all global paths.")?;
+    let mut paths = get_paths().with_context(|| "Trying to load all global paths.")?;
 
-    use juliaup::{command_config_backgroundselfupdate::run_command_config_backgroundselfupdate, command_config_startupselfupdate::run_command_config_startupselfupdate, command_config_modifypath::run_command_config_modifypath, command_config_symlinks::run_command_config_symlinks};
-    use log::{info, trace, debug};
+    use juliaup::{
+        command_config_backgroundselfupdate::run_command_config_backgroundselfupdate,
+        command_config_modifypath::run_command_config_modifypath,
+        command_config_startupselfupdate::run_command_config_startupselfupdate,
+        command_config_symlinks::run_command_config_symlinks,
+    };
+    use log::{debug, info, trace};
 
     println!("{}", style("Welcome to Julia!").bold());
     println!();
@@ -202,7 +261,7 @@ pub fn main() -> Result<()> {
     if is_juliaup_installed() {
         println!("It seems that Juliaup is already installed on this system. Please remove the previous installation of Juliaup before you try to install a new version.");
 
-        return Ok(())
+        return Ok(());
     }
 
     println!("This will download and install the official Julia Language distribution");
@@ -215,11 +274,12 @@ pub fn main() -> Result<()> {
 
         if args.disable_confirmation_prompt {
             println!();
-            println!("Please remove the existing Juliaup configuration file or use interactive mode.");
+            println!(
+                "Please remove the existing Juliaup configuration file or use interactive mode."
+            );
 
             return Ok(());
-        }
-        else {
+        } else {
             let continue_with_setup = Confirm::with_theme(theme.as_ref())
                 .with_prompt("Do you want to continue with the installation and overwrite the existing Juliaup configuration file?")
                 .default(true)
@@ -239,7 +299,9 @@ pub fn main() -> Result<()> {
         symlinks: false,
         modifypath: true,
         install_location: dirs::home_dir()
-            .ok_or(anyhow!("Could not determine the path of the user home directory."))?
+            .ok_or(anyhow!(
+                "Could not determine the path of the user home directory."
+            ))?
             .join(".juliaup"),
         modifypath_files: find_shell_scripts_to_be_modified(true)
             .with_context(|| "Failed to identify the shell scripts that need to be modified.")?,
@@ -247,7 +309,10 @@ pub fn main() -> Result<()> {
 
     print_install_choices(&install_choices)?;
 
-    println!("You can uninstall at any time with {} and these", style("juliaup self uninstall").bold());
+    println!(
+        "You can uninstall at any time with {} and these",
+        style("juliaup self uninstall").bold()
+    );
     println!("changes will be reverted.");
     println!();
 
@@ -255,12 +320,12 @@ pub fn main() -> Result<()> {
         debug!("Next running the prompt for default choices");
 
         let answer_default = Select::with_theme(theme.as_ref())
-                .with_prompt("Do you want to install with these default configuration choices?")
-                .item("Proceed with installation")
-                .item("Customize installation")
-                .item("Cancel installation")
-                .default(0)
-                .interact()?;
+            .with_prompt("Do you want to install with these default configuration choices?")
+            .item("Proceed with installation")
+            .item("Customize installation")
+            .item("Cancel installation")
+            .default(0)
+            .interact()?;
 
         trace!("choice is {:?}", answer_default);
 
@@ -273,7 +338,7 @@ pub fn main() -> Result<()> {
                 run_individual_config_wizard(&mut install_choices, theme.as_ref())?;
 
                 print_install_choices(&install_choices)?;
-        
+
                 let confirmcustom = Select::with_theme(theme.as_ref())
                     .with_prompt("Do you want to install with these custom configuration choices?")
                     .item("Proceed with installation")
@@ -283,16 +348,14 @@ pub fn main() -> Result<()> {
                     .interact()?;
 
                 trace!("homedir is {:?}", install_choices.install_location);
-        
+
                 if confirmcustom == 0 {
                     break;
-                }
-                else if confirmcustom == 2 {
+                } else if confirmcustom == 2 {
                     return Ok(());
                 }
             }
-        }
-        else if answer_default == 2 {
+        } else if answer_default == 2 {
             return Ok(());
         }
     }
@@ -312,16 +375,22 @@ pub fn main() -> Result<()> {
 
     let juliaup_target = get_juliaup_target();
 
-    let juliaupserver_base = get_juliaserver_base_url()
-        .with_context(|| "Failed to get Juliaup server base URL.")?;
+    let juliaupserver_base =
+        get_juliaserver_base_url().with_context(|| "Failed to get Juliaup server base URL.")?;
 
     let version = get_own_version().unwrap();
     // let version = semver::Version::parse("1.5.29").unwrap();
 
     let download_url_path = format!("juliaup/bin/juliaup-{}-{}.tar.gz", version, juliaup_target);
 
-    let new_juliaup_url = juliaupserver_base.join(&download_url_path)
-        .with_context(|| format!("Failed to construct a valid url from '{}' and '{}'.", juliaupserver_base, download_url_path))?;
+    let new_juliaup_url = juliaupserver_base
+        .join(&download_url_path)
+        .with_context(|| {
+            format!(
+                "Failed to construct a valid url from '{}' and '{}'.",
+                juliaupserver_base, download_url_path
+            )
+        })?;
 
     download_extract_sans_parent(&new_juliaup_url.to_string(), &juliaupselfbin, 0)?;
 
@@ -336,27 +405,39 @@ pub fn main() -> Result<()> {
 
         let self_config_path = install_choices.install_location.join("juliaupself.json");
 
-        let mut self_file = std::fs::OpenOptions::new().create(true).write(true).open(&self_config_path)
+        let mut self_file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&self_config_path)
             .with_context(|| "Failed to open juliaup config file.")?;
 
-        self_file.rewind()
+        self_file
+            .rewind()
             .with_context(|| "Failed to rewind self config file for write.")?;
 
-        self_file.set_len(0)
-            .with_context(|| "Failed to set len to 0 for self config file before writing new content.")?;
+        self_file.set_len(0).with_context(|| {
+            "Failed to set len to 0 for self config file before writing new content."
+        })?;
 
         serde_json::to_writer_pretty(&self_file, &new_selfconfig_data)
             .with_context(|| format!("Failed to write self configuration file."))?;
 
-        self_file.sync_all()
-            .with_context(|| "Failed to write config data to disc.")?;     
-            
+        self_file
+            .sync_all()
+            .with_context(|| "Failed to write config data to disc.")?;
+
         paths.juliaupselfbin = juliaupselfbin.clone();
         paths.juliaupselfconfig = self_config_path.clone();
     }
 
-    run_command_config_backgroundselfupdate(Some(install_choices.backgroundselfupdate), true, &paths).unwrap();
-    run_command_config_startupselfupdate(Some(install_choices.startupselfupdate), true, &paths).unwrap();
+    run_command_config_backgroundselfupdate(
+        Some(install_choices.backgroundselfupdate),
+        true,
+        &paths,
+    )
+    .unwrap();
+    run_command_config_startupselfupdate(Some(install_choices.startupselfupdate), true, &paths)
+        .unwrap();
     run_command_config_modifypath(Some(install_choices.modifypath), true, &paths).unwrap();
     run_command_config_symlinks(Some(install_choices.symlinks), true, &paths).unwrap();
     run_command_selfchannel(args.juliaup_channel, &paths).unwrap();
@@ -369,15 +450,24 @@ pub fn main() -> Result<()> {
 
     let symlink_path = juliaupselfbin.join("julia");
 
-    std::os::unix::fs::symlink(juliaupselfbin.join("julialauncher"), &symlink_path)
-        .with_context(|| format!("failed to create symlink `{}`.", symlink_path.to_string_lossy()))?;
+    std::os::unix::fs::symlink(juliaupselfbin.join("julialauncher"), &symlink_path).with_context(
+        || {
+            format!(
+                "failed to create symlink `{}`.",
+                symlink_path.to_string_lossy()
+            )
+        },
+    )?;
 
     println!("Julia was successfully installed on your system.");
 
     if install_choices.modifypath {
         println!();
         println!("Depending on which shell you are using, run one of the following");
-        println!("commands to reload the {} environment variable:", style("PATH").bold());
+        println!(
+            "commands to reload the {} environment variable:",
+            style("PATH").bold()
+        );
         println!();
         for p in &install_choices.modifypath_files {
             println!("  . {}", p.to_string_lossy());

--- a/src/command_api.rs
+++ b/src/command_api.rs
@@ -4,8 +4,8 @@ use crate::global_paths::GlobalPaths;
 use crate::utils::parse_versionstring;
 use anyhow::{bail, Context, Result};
 use normpath::PathExt;
-use serde::{Deserialize, Serialize};
 use semver::Version;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct JuliaupChannelInfo {
@@ -39,9 +39,9 @@ pub fn run_command_api(command: &str, paths: &GlobalPaths) -> Result<()> {
         other_versions: Vec::new(),
     };
 
-    let config_file =
-        load_config_db(paths)
-        .with_context(|| "Failed to load configuration file while running the getconfig1 API command.")?;
+    let config_file = load_config_db(paths).with_context(|| {
+        "Failed to load configuration file while running the getconfig1 API command."
+    })?;
 
     for (key, value) in config_file.data.installed_channels {
         let curr = match value {
@@ -72,8 +72,7 @@ pub fn run_command_api(command: &str, paths: &GlobalPaths) -> Result<()> {
                     None => bail!("The channel '{}' is configured as a system channel, but no such channel exists in the versions database.", key)
                 }
             }
-            JuliaupConfigChannel::LinkedChannel { command, args } => 
-            {
+            JuliaupConfigChannel::LinkedChannel { command, args } => {
                 let mut new_args: Vec<String> = Vec::new();
 
                 for i in args.as_ref().unwrap() {
@@ -82,7 +81,9 @@ pub fn run_command_api(command: &str, paths: &GlobalPaths) -> Result<()> {
 
                 new_args.push("--version".to_string());
 
-                let res = std::process::Command::new(&command).args(&new_args).output();
+                let res = std::process::Command::new(&command)
+                    .args(&new_args)
+                    .output();
 
                 match res {
                     Ok(output) => {
@@ -91,10 +92,11 @@ pub fn run_command_api(command: &str, paths: &GlobalPaths) -> Result<()> {
                         let trimmed_string = std::str::from_utf8(&output.stdout).unwrap().trim();
 
                         if !trimmed_string.starts_with(expected_version_prefix) {
-                            continue
+                            continue;
                         }
 
-                        let version = Version::parse(&trimmed_string[expected_version_prefix.len()..])?;
+                        let version =
+                            Version::parse(&trimmed_string[expected_version_prefix.len()..])?;
 
                         JuliaupChannelInfo {
                             name: key.clone(),
@@ -103,10 +105,10 @@ pub fn run_command_api(command: &str, paths: &GlobalPaths) -> Result<()> {
                             version: version.to_string(),
                             arch: "".to_string(),
                         }
-                    },
-                    Err(_) => continue
+                    }
+                    Err(_) => continue,
                 }
-            },
+            }
         };
 
         match config_file.data.default {

--- a/src/command_config_backgroundselfupdate.rs
+++ b/src/command_config_backgroundselfupdate.rs
@@ -2,11 +2,14 @@
 use anyhow::Result;
 
 #[cfg(feature = "selfupdate")]
-pub fn run_command_config_backgroundselfupdate(value: Option<i64>, quiet: bool, paths: &crate::global_paths::GlobalPaths) -> Result<()> {
+pub fn run_command_config_backgroundselfupdate(
+    value: Option<i64>,
+    quiet: bool,
+    paths: &crate::global_paths::GlobalPaths,
+) -> Result<()> {
+    use crate::config_file::{load_config_db, load_mut_config_db, save_config_db};
     use crate::operations::{install_background_selfupdate, uninstall_background_selfupdate};
-    use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
     use anyhow::{bail, Context};
-
 
     match value {
         Some(value) => {
@@ -16,10 +19,10 @@ pub fn run_command_config_backgroundselfupdate(value: Option<i64>, quiet: bool, 
 
             let mut config_file = load_mut_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
-    
+
             let mut value_changed = false;
 
-            let value = if value==0 {None} else {Some(value)};
+            let value = if value == 0 { None } else { Some(value) };
 
             if value != config_file.self_data.background_selfupdate_interval {
                 config_file.self_data.background_selfupdate_interval = value;
@@ -29,7 +32,7 @@ pub fn run_command_config_backgroundselfupdate(value: Option<i64>, quiet: bool, 
                 match value {
                     Some(value) => {
                         install_background_selfupdate(value).unwrap();
-                    },
+                    }
                     None => {
                         uninstall_background_selfupdate().unwrap();
                     }
@@ -41,19 +44,24 @@ pub fn run_command_config_backgroundselfupdate(value: Option<i64>, quiet: bool, 
 
             if !quiet {
                 if value_changed {
-                    eprintln!("Property 'backgroundselfupdateinterval' set to '{}'", match value {
-                        Some(value) => value,
-                        None => 0
-                    });
-                }
-                else {
-                    eprintln!("Property 'backgroundselfupdateinterval' is already set to '{}'", match value {
-                        Some(value) => value,
-                        None => 0
-                    });
+                    eprintln!(
+                        "Property 'backgroundselfupdateinterval' set to '{}'",
+                        match value {
+                            Some(value) => value,
+                            None => 0,
+                        }
+                    );
+                } else {
+                    eprintln!(
+                        "Property 'backgroundselfupdateinterval' is already set to '{}'",
+                        match value {
+                            Some(value) => value,
+                            None => 0,
+                        }
+                    );
                 }
             }
-        },
+        }
         None => {
             let config_file = load_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
@@ -63,7 +71,7 @@ pub fn run_command_config_backgroundselfupdate(value: Option<i64>, quiet: bool, 
                     "Property 'backgroundselfupdateinterval' set to '{}'",
                     match config_file.self_data.background_selfupdate_interval {
                         Some(value) => value,
-                        None => 0
+                        None => 0,
                     }
                 );
             }

--- a/src/command_config_modifypath.rs
+++ b/src/command_config_modifypath.rs
@@ -1,14 +1,20 @@
 #[cfg(feature = "selfupdate")]
-pub fn run_command_config_modifypath(value: Option<bool>, quiet: bool, paths: &crate::global_paths::GlobalPaths) -> anyhow::Result<()> {
-    use crate::operations::{add_binfolder_to_path_in_shell_scripts, remove_binfolder_from_path_in_shell_scripts};
-    use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
+pub fn run_command_config_modifypath(
+    value: Option<bool>,
+    quiet: bool,
+    paths: &crate::global_paths::GlobalPaths,
+) -> anyhow::Result<()> {
+    use crate::config_file::{load_config_db, load_mut_config_db, save_config_db};
+    use crate::operations::{
+        add_binfolder_to_path_in_shell_scripts, remove_binfolder_from_path_in_shell_scripts,
+    };
     use anyhow::Context;
 
     match value {
         Some(value) => {
             let mut config_file = load_mut_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
-    
+
             let mut value_changed = false;
 
             if value != config_file.self_data.modify_path {
@@ -19,8 +25,7 @@ pub fn run_command_config_modifypath(value: Option<bool>, quiet: bool, paths: &c
 
             if value {
                 add_binfolder_to_path_in_shell_scripts(&paths.juliaupselfbin)?;
-            }
-            else {
+            } else {
                 remove_binfolder_from_path_in_shell_scripts()?;
             }
 
@@ -30,18 +35,20 @@ pub fn run_command_config_modifypath(value: Option<bool>, quiet: bool, paths: &c
             if !quiet {
                 if value_changed {
                     eprintln!("Property 'modifypath' set to '{}'", value);
-                }
-                else {
+                } else {
                     eprintln!("Property 'modifypath' is already set to '{}'", value);
                 }
             }
-        },
+        }
         None => {
             let config_file = load_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {
-                eprintln!("Property 'modifypath' set to '{}'", config_file.self_data.modify_path);
+                eprintln!(
+                    "Property 'modifypath' set to '{}'",
+                    config_file.self_data.modify_path
+                );
             }
         }
     };

--- a/src/command_config_startupselfupdate.rs
+++ b/src/command_config_startupselfupdate.rs
@@ -2,8 +2,12 @@
 use anyhow::Result;
 
 #[cfg(feature = "selfupdate")]
-pub fn run_command_config_startupselfupdate(value: Option<i64>, quiet: bool, paths: &crate::global_paths::GlobalPaths) -> Result<()> {
-    use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
+pub fn run_command_config_startupselfupdate(
+    value: Option<i64>,
+    quiet: bool,
+    paths: &crate::global_paths::GlobalPaths,
+) -> Result<()> {
+    use crate::config_file::{load_config_db, load_mut_config_db, save_config_db};
     use anyhow::{bail, Context};
 
     match value {
@@ -14,10 +18,10 @@ pub fn run_command_config_startupselfupdate(value: Option<i64>, quiet: bool, pat
 
             let mut config_file = load_mut_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
-    
+
             let mut value_changed = false;
 
-            let value = if value==0 {None} else {Some(value)};
+            let value = if value == 0 { None } else { Some(value) };
 
             if value != config_file.self_data.startup_selfupdate_interval {
                 config_file.self_data.startup_selfupdate_interval = value;
@@ -30,19 +34,24 @@ pub fn run_command_config_startupselfupdate(value: Option<i64>, quiet: bool, pat
 
             if !quiet {
                 if value_changed {
-                    eprintln!("Property 'startupselfupdateinterval' set to '{}'", match value {
-                        Some(value) => value,
-                        None => 0
-                    });
-                }
-                else {
-                    eprintln!("Property 'startupselfupdateinterval' is already set to '{}'", match value {
-                        Some(value) => value,
-                        None => 0
-                    });
+                    eprintln!(
+                        "Property 'startupselfupdateinterval' set to '{}'",
+                        match value {
+                            Some(value) => value,
+                            None => 0,
+                        }
+                    );
+                } else {
+                    eprintln!(
+                        "Property 'startupselfupdateinterval' is already set to '{}'",
+                        match value {
+                            Some(value) => value,
+                            None => 0,
+                        }
+                    );
                 }
             }
-        },
+        }
         None => {
             let config_file = load_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
@@ -52,7 +61,7 @@ pub fn run_command_config_startupselfupdate(value: Option<i64>, quiet: bool, pat
                     "Property 'startupselfupdateinterval' set to '{}'",
                     match config_file.self_data.startup_selfupdate_interval {
                         Some(value) => value,
-                        None => 0
+                        None => 0,
                     }
                 );
             }

--- a/src/command_config_symlinks.rs
+++ b/src/command_config_symlinks.rs
@@ -2,8 +2,12 @@
 use anyhow::Result;
 
 #[cfg(not(windows))]
-pub fn run_command_config_symlinks(value: Option<bool>, quiet: bool, paths: &crate::global_paths::GlobalPaths) -> Result<()> {
-    use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
+pub fn run_command_config_symlinks(
+    value: Option<bool>,
+    quiet: bool,
+    paths: &crate::global_paths::GlobalPaths,
+) -> Result<()> {
+    use crate::config_file::{load_config_db, load_mut_config_db, save_config_db};
     use crate::operations::{create_symlink, remove_symlink};
     use anyhow::Context;
 
@@ -11,7 +15,7 @@ pub fn run_command_config_symlinks(value: Option<bool>, quiet: bool, paths: &cra
         Some(value) => {
             let mut config_file = load_mut_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
-    
+
             let mut value_changed = false;
 
             if value != config_file.data.settings.create_channel_symlinks {
@@ -21,8 +25,7 @@ pub fn run_command_config_symlinks(value: Option<bool>, quiet: bool, paths: &cra
                 for (channel_name, channel) in &config_file.data.installed_channels {
                     if value {
                         create_symlink(channel, &format!("julia-{}", channel_name), paths)?;
-                    }
-                    else {
+                    } else {
                         remove_symlink(&format!("julia-{}", channel_name))?;
                     }
                 }
@@ -34,18 +37,20 @@ pub fn run_command_config_symlinks(value: Option<bool>, quiet: bool, paths: &cra
             if !quiet {
                 if value_changed {
                     eprintln!("Property 'channelsymlinks' set to '{}'", value);
-                }
-                else {
+                } else {
                     eprintln!("Property 'channelsymlinks' is already set to '{}'", value);
                 }
             }
-        },
+        }
         None => {
             let config_file = load_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {
-                eprintln!("Property 'channelsymlinks' set to '{}'", config_file.data.settings.create_channel_symlinks);
+                eprintln!(
+                    "Property 'channelsymlinks' set to '{}'",
+                    config_file.data.settings.create_channel_symlinks
+                );
             }
         }
     };

--- a/src/command_config_versionsdbupdate.rs
+++ b/src/command_config_versionsdbupdate.rs
@@ -1,7 +1,11 @@
+use crate::config_file::{load_config_db, load_mut_config_db, save_config_db};
 use anyhow::{bail, Context, Result};
-use crate::config_file::{load_mut_config_db, save_config_db, load_config_db};
 
-pub fn run_command_config_versionsdbupdate(value: Option<i64>, quiet: bool, paths: &crate::global_paths::GlobalPaths) -> Result<()> {
+pub fn run_command_config_versionsdbupdate(
+    value: Option<i64>,
+    quiet: bool,
+    paths: &crate::global_paths::GlobalPaths,
+) -> Result<()> {
     match value {
         Some(value) => {
             if value < 0 {
@@ -10,7 +14,7 @@ pub fn run_command_config_versionsdbupdate(value: Option<i64>, quiet: bool, path
 
             let mut config_file = load_mut_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
-    
+
             let mut value_changed = false;
 
             if value != config_file.data.settings.versionsdb_update_interval {
@@ -25,19 +29,23 @@ pub fn run_command_config_versionsdbupdate(value: Option<i64>, quiet: bool, path
             if !quiet {
                 if value_changed {
                     eprintln!("Property 'versionsdbupdateinterval' set to '{}'", value);
-                }
-                else {
-                    eprintln!("Property 'versionsdbupdateinterval' is already set to '{}'", value);
+                } else {
+                    eprintln!(
+                        "Property 'versionsdbupdateinterval' is already set to '{}'",
+                        value
+                    );
                 }
             }
-        },
+        }
         None => {
             let config_file = load_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {
                 eprintln!(
-                    "Property 'versionsdbupdateinterval' set to '{}'", config_file.data.settings.versionsdb_update_interval);
+                    "Property 'versionsdbupdateinterval' set to '{}'",
+                    config_file.data.settings.versionsdb_update_interval
+                );
             }
         }
     };

--- a/src/command_default.rs
+++ b/src/command_default.rs
@@ -1,5 +1,5 @@
-use crate::{config_file::*, global_paths::GlobalPaths};
 use crate::versions_file::load_versions_db;
+use crate::{config_file::*, global_paths::GlobalPaths};
 use anyhow::{bail, Context, Result};
 
 pub fn run_command_default(channel: &str, paths: &GlobalPaths) -> Result<()> {
@@ -7,11 +7,16 @@ pub fn run_command_default(channel: &str, paths: &GlobalPaths) -> Result<()> {
         .with_context(|| "`default` command failed to load configuration data.")?;
 
     if !config_file.data.installed_channels.contains_key(channel) {
-        let version_db = load_versions_db(paths).with_context(|| "`default` command failed to load versions db.")?;
+        let version_db = load_versions_db(paths)
+            .with_context(|| "`default` command failed to load versions db.")?;
         if !version_db.available_channels.contains_key(channel) {
             bail!("'{}' is not a valid Julia version.", channel);
         } else {
-            bail!("'{}' is not an installed Julia version, run `juliaup add {}` first.", channel, channel);
+            bail!(
+                "'{}' is not an installed Julia version, run `juliaup add {}` first.",
+                channel,
+                channel
+            );
         }
     }
 

--- a/src/command_gc.rs
+++ b/src/command_gc.rs
@@ -1,6 +1,6 @@
+use crate::config_file::{load_mut_config_db, save_config_db};
 use crate::global_paths::GlobalPaths;
 use crate::operations::garbage_collect_versions;
-use crate::config_file::{save_config_db, load_mut_config_db};
 use anyhow::{Context, Result};
 
 pub fn run_command_gc(paths: &GlobalPaths) -> Result<()> {

--- a/src/command_info.rs
+++ b/src/command_info.rs
@@ -1,44 +1,55 @@
 use std::io::BufReader;
 
 use crate::config_file::load_config_db;
-use crate::{get_juliaup_target, get_own_version};
-use crate::{global_paths::GlobalPaths, get_bundled_dbversion};
-use anyhow::{Result, bail, Context};
 use crate::jsonstructs_versionsdb::JuliaupVersionDB;
 use crate::operations::download_juliaup_version;
 use crate::utils::get_juliaserver_base_url;
+use crate::{get_bundled_dbversion, global_paths::GlobalPaths};
+use crate::{get_juliaup_target, get_own_version};
+use anyhow::{bail, Context, Result};
 
 pub fn run_command_info(paths: &GlobalPaths) -> Result<()> {
     #[cfg(feature = "selfupdate")]
-    let config_file =
-        load_config_db(paths).with_context(|| "`run_command_update_version_db` command failed to load configuration db.")?;
+    let config_file = load_config_db(paths).with_context(|| {
+        "`run_command_update_version_db` command failed to load configuration db."
+    })?;
 
     #[cfg(feature = "selfupdate")]
     let juliaup_channel = match &config_file.self_data.juliaup_channel {
         Some(juliaup_channel) => juliaup_channel.to_string(),
-        None => "release".to_string()
+        None => "release".to_string(),
     };
 
     #[cfg(not(feature = "selfupdate"))]
-    let _config_file =
-        load_config_db(paths).with_context(|| "`run_command_update_version_db` command failed to load configuration db.")?;
+    let _config_file = load_config_db(paths).with_context(|| {
+        "`run_command_update_version_db` command failed to load configuration db."
+    })?;
 
     // TODO Figure out how we can learn about the correctn Juliaup channel here
     #[cfg(not(feature = "selfupdate"))]
     let juliaup_channel = "release".to_string();
 
-    let juliaupserver_base = get_juliaserver_base_url()
-            .with_context(|| "Failed to get Juliaup server base URL.")?;
-            
+    let juliaupserver_base =
+        get_juliaserver_base_url().with_context(|| "Failed to get Juliaup server base URL.")?;
+
     let dbversion_url_path = match juliaup_channel.as_str() {
         "release" => "juliaup/RELEASECHANNELDBVERSION",
         "releasepreview" => "juliaup/RELEASEPREVIEWCHANNELDBVERSION",
         "dev" => "juliaup/DEVCHANNELDBVERSION",
-        _ => bail!("Juliaup is configured to a channel named '{}' that does not exist.", &juliaup_channel)
+        _ => bail!(
+            "Juliaup is configured to a channel named '{}' that does not exist.",
+            &juliaup_channel
+        ),
     };
 
-    let dbversion_url = juliaupserver_base.join(dbversion_url_path)
-        .with_context(|| format!("Failed to construct a valid url from '{}' and '{}'.", juliaupserver_base, dbversion_url_path))?;
+    let dbversion_url = juliaupserver_base
+        .join(dbversion_url_path)
+        .with_context(|| {
+            format!(
+                "Failed to construct a valid url from '{}' and '{}'.",
+                juliaupserver_base, dbversion_url_path
+            )
+        })?;
 
     let online_dbversion = download_juliaup_version(dbversion_url.as_ref())
         .with_context(|| "Failed to download current version db version.")?;
@@ -46,11 +57,16 @@ pub fn run_command_info(paths: &GlobalPaths) -> Result<()> {
     let bundled_dbversion = get_bundled_dbversion()
         .with_context(|| "Failed to determine the bundled version db version.")?;
 
-    let local_dbversion = match std::fs::OpenOptions::new().read(true).open(&paths.versiondb) {
+    let local_dbversion = match std::fs::OpenOptions::new()
+        .read(true)
+        .open(&paths.versiondb)
+    {
         Ok(file) => {
             let reader = BufReader::new(&file);
 
-            if let Ok(versiondb) = serde_json::from_reader::<BufReader<&std::fs::File>, JuliaupVersionDB>(reader) {
+            if let Ok(versiondb) =
+                serde_json::from_reader::<BufReader<&std::fs::File>, JuliaupVersionDB>(reader)
+            {
                 if let Ok(version) = semver::Version::parse(&versiondb.version) {
                     Some(version)
                 } else {
@@ -58,11 +74,9 @@ pub fn run_command_info(paths: &GlobalPaths) -> Result<()> {
                 }
             } else {
                 None
-            }                
+            }
         }
-        Err(_) => { 
-            None 
-        }
+        Err(_) => None,
     };
 
     println!("Juliaup version: {}", get_own_version().unwrap());
@@ -70,6 +84,6 @@ pub fn run_command_info(paths: &GlobalPaths) -> Result<()> {
     println!("Bundled version db: {}", bundled_dbversion);
     println!("Online version db: {}", online_dbversion);
     println!("Local version db: {:?}", local_dbversion);
-   
+
     Ok(())
 }

--- a/src/command_link.rs
+++ b/src/command_link.rs
@@ -1,17 +1,22 @@
-use crate::global_paths::GlobalPaths;
-use crate::versions_file::load_versions_db;
-use crate::config_file::{save_config_db, load_mut_config_db};
-use anyhow::{bail,Context,Result};
 use crate::config_file::JuliaupConfigChannel;
+use crate::config_file::{load_mut_config_db, save_config_db};
+use crate::global_paths::GlobalPaths;
 #[cfg(not(windows))]
 use crate::operations::create_symlink;
+use crate::versions_file::load_versions_db;
+use anyhow::{bail, Context, Result};
 
-pub fn run_command_link(channel: &str, file: &str, args: &[String], paths: &GlobalPaths) -> Result<()> {
+pub fn run_command_link(
+    channel: &str,
+    file: &str,
+    args: &[String],
+    paths: &GlobalPaths,
+) -> Result<()> {
     let mut config_file = load_mut_config_db(paths)
         .with_context(|| "`link` command failed to load configuration data.")?;
 
-    let versiondb_data = load_versions_db(paths)
-        .with_context(|| "`link` command failed to load versions db.")?;
+    let versiondb_data =
+        load_versions_db(paths).with_context(|| "`link` command failed to load versions db.")?;
 
     if config_file.data.installed_channels.contains_key(channel) {
         bail!("Channel name `{}` is already used.", channel)

--- a/src/command_list.rs
+++ b/src/command_list.rs
@@ -1,6 +1,9 @@
 use crate::{global_paths::GlobalPaths, versions_file::load_versions_db};
-use anyhow::{Context,Result};
-use cli_table::{ColorChoice,Table,format::{Border, Separator, HorizontalLine}, print_stdout, WithTitle};
+use anyhow::{Context, Result};
+use cli_table::{
+    format::{Border, HorizontalLine, Separator},
+    print_stdout, ColorChoice, Table, WithTitle,
+};
 use itertools::Itertools;
 
 #[derive(Table)]
@@ -15,27 +18,28 @@ pub fn run_command_list(paths: &GlobalPaths) -> Result<()> {
     let versiondb_data =
         load_versions_db(paths).with_context(|| "`list` command failed to load versions db.")?;
 
-    let rows_in_table: Vec<_> = versiondb_data.available_channels
+    let rows_in_table: Vec<_> = versiondb_data
+        .available_channels
         .iter()
         .map(|i| -> ChannelRow {
             ChannelRow {
                 name: i.0.to_string(),
-                version: i.1.version.clone()
-            }})
+                version: i.1.version.clone(),
+            }
+        })
         .sorted_by_key(|i| i.name.clone())
         .collect();
 
     print_stdout(
         rows_in_table
-        .with_title()
-        .color_choice(ColorChoice::Never)
-        .border(Border::builder().build())
-        .separator(
-            Separator::builder()
-            .title(Some(HorizontalLine::new('1', '2', '3', '-')))
-            .build()
-        )
-        
+            .with_title()
+            .color_choice(ColorChoice::Never)
+            .border(Border::builder().build())
+            .separator(
+                Separator::builder()
+                    .title(Some(HorizontalLine::new('1', '2', '3', '-')))
+                    .build(),
+            ),
     )?;
 
     Ok(())

--- a/src/command_remove.rs
+++ b/src/command_remove.rs
@@ -1,6 +1,10 @@
-use crate::{operations::garbage_collect_versions, config_file::{load_mut_config_db, save_config_db}, global_paths::GlobalPaths};
 #[cfg(not(windows))]
 use crate::operations::remove_symlink;
+use crate::{
+    config_file::{load_mut_config_db, save_config_db},
+    global_paths::GlobalPaths,
+    operations::garbage_collect_versions,
+};
 use anyhow::{bail, Context, Result};
 
 pub fn run_command_remove(channel: &str, paths: &GlobalPaths) -> Result<()> {
@@ -8,12 +12,18 @@ pub fn run_command_remove(channel: &str, paths: &GlobalPaths) -> Result<()> {
         .with_context(|| "`remove` command failed to load configuration data.")?;
 
     if !config_file.data.installed_channels.contains_key(channel) {
-        bail!("'{}' cannot be removed because it is currently not installed.", channel);
+        bail!(
+            "'{}' cannot be removed because it is currently not installed.",
+            channel
+        );
     }
 
     if let Some(ref default_value) = config_file.data.default {
-        if channel==default_value {
-            bail!("'{}' cannot be removed because it is currently configured as the default channel.", channel);
+        if channel == default_value {
+            bail!(
+                "'{}' cannot be removed because it is currently configured as the default channel.",
+                channel
+            );
         }
     }
 
@@ -24,8 +34,12 @@ pub fn run_command_remove(channel: &str, paths: &GlobalPaths) -> Result<()> {
 
     garbage_collect_versions(&mut config_file.data, paths)?;
 
-    save_config_db(&mut config_file)
-        .with_context(|| format!("Failed to save configuration file from `remove` command after '{}' was installed.", channel))?;
+    save_config_db(&mut config_file).with_context(|| {
+        format!(
+            "Failed to save configuration file from `remove` command after '{}' was installed.",
+            channel
+        )
+    })?;
 
     eprintln!("Julia '{}' successfully removed.", channel);
 

--- a/src/command_selfchannel.rs
+++ b/src/command_selfchannel.rs
@@ -2,8 +2,11 @@
 use anyhow::Result;
 
 #[cfg(feature = "selfupdate")]
-pub fn run_command_selfchannel(channel: String, paths: &crate::global_paths::GlobalPaths) -> Result<()> {
-    use crate::{config_file::{load_mut_config_db, save_config_db}};
+pub fn run_command_selfchannel(
+    channel: String,
+    paths: &crate::global_paths::GlobalPaths,
+) -> Result<()> {
+    use crate::config_file::{load_mut_config_db, save_config_db};
     use anyhow::{bail, Context};
 
     let mut config_file = load_mut_config_db(paths)

--- a/src/command_selfuninstall.rs
+++ b/src/command_selfuninstall.rs
@@ -5,7 +5,12 @@ use anyhow::Result;
 pub fn run_command_selfuninstall(paths: &crate::global_paths::GlobalPaths) -> Result<()> {
     use dialoguer::Confirm;
 
-    use crate::{command_config_backgroundselfupdate::run_command_config_backgroundselfupdate, command_config_startupselfupdate::run_command_config_startupselfupdate, command_config_modifypath::run_command_config_modifypath, command_config_symlinks::run_command_config_symlinks};
+    use crate::{
+        command_config_backgroundselfupdate::run_command_config_backgroundselfupdate,
+        command_config_modifypath::run_command_config_modifypath,
+        command_config_startupselfupdate::run_command_config_startupselfupdate,
+        command_config_symlinks::run_command_config_symlinks,
+    };
 
     let choice = Confirm::new()
         .with_prompt("Do you really want to uninstall Julia?")
@@ -19,31 +24,31 @@ pub fn run_command_selfuninstall(paths: &crate::global_paths::GlobalPaths) -> Re
     eprint!("Removing background self update task.");
     match run_command_config_backgroundselfupdate(Some(0), true, paths) {
         Ok(_) => eprintln!(" Success."),
-        Err(_) => eprintln!(" Failed.")
+        Err(_) => eprintln!(" Failed."),
     };
 
     eprint!("Removing startup self update configuration.");
     match run_command_config_startupselfupdate(Some(0), true, &paths) {
         Ok(_) => eprintln!(" Success."),
-        Err(_) => eprintln!(" Failed.")
+        Err(_) => eprintln!(" Failed."),
     };
 
     eprint!("Removing PATH modifications in startup scripts.");
     match run_command_config_modifypath(Some(false), true, &paths) {
         Ok(_) => eprintln!(" Success."),
-        Err(_) => eprintln!(" Failed.")
+        Err(_) => eprintln!(" Failed."),
     };
 
     eprint!("Removing symlinks.");
     match run_command_config_symlinks(Some(false), true, &paths) {
         Ok(_) => eprintln!(" Success."),
-        Err(_) => eprintln!(" Failed.")
+        Err(_) => eprintln!(" Failed."),
     };
 
     eprint!("Deleting Juliaup home folder {:?}.", paths.juliauphome);
     match std::fs::remove_dir_all(&paths.juliauphome) {
         Ok(_) => eprintln!(" Success."),
-        Err(_) => eprintln!(" Failed.")
+        Err(_) => eprintln!(" Failed."),
     };
 
     if paths.juliauphome != paths.juliaupselfhome {
@@ -56,48 +61,54 @@ pub fn run_command_selfuninstall(paths: &crate::global_paths::GlobalPaths) -> Re
         eprint!("Deleting julia symlink {:?}.", julia_symlink_path);
         match std::fs::remove_file(&julia_symlink_path) {
             Ok(_) => eprintln!(" Success."),
-            Err(_) => eprintln!(" Failed.")
+            Err(_) => eprintln!(" Failed."),
         };
 
         eprint!("Deleting julialauncher binary {:?}.", julialauncher_path);
         match std::fs::remove_file(&julialauncher_path) {
             Ok(_) => eprintln!(" Success."),
-            Err(_) => eprintln!(" Failed.")
+            Err(_) => eprintln!(" Failed."),
         };
 
         eprint!("Deleting juliaup binary {:?}.", juliaup_path);
         match std::fs::remove_file(&juliaup_path) {
             Ok(_) => eprintln!(" Success."),
-            Err(_) => eprintln!(" Failed.")
+            Err(_) => eprintln!(" Failed."),
         };
 
         if juliaup_binfolder_path.read_dir()?.next().is_none() {
-            eprint!("Deleting the Juliaup bin folder {:?}.", juliaup_binfolder_path);
+            eprint!(
+                "Deleting the Juliaup bin folder {:?}.",
+                juliaup_binfolder_path
+            );
             match std::fs::remove_dir(&juliaup_binfolder_path) {
                 Ok(_) => {
                     eprintln!(" Success.");
 
-                    eprint!("Deleting the Juliaup configuration file {:?}.", juliaup_config_path);
+                    eprint!(
+                        "Deleting the Juliaup configuration file {:?}.",
+                        juliaup_config_path
+                    );
                     match std::fs::remove_file(&juliaup_config_path) {
                         Ok(_) => eprintln!(" Success."),
-                        Err(_) => eprintln!(" Failed.")
+                        Err(_) => eprintln!(" Failed."),
                     };
 
                     if paths.juliaupselfhome.read_dir()?.next().is_none() {
                         eprint!("Deleting the Juliaup folder {:?}.", paths.juliaupselfhome);
                         match std::fs::remove_dir(&paths.juliaupselfhome) {
                             Ok(_) => eprintln!(" Success."),
-                            Err(_) => eprintln!(" Failed, skipping removal of the entire Juliaup folder.")
+                            Err(_) => {
+                                eprintln!(" Failed, skipping removal of the entire Juliaup folder.")
+                            }
                         };
-                    }
-                    else {
+                    } else {
                         eprintln!("The Juliaup folder {:?} is not empty, skipping removal of the entire Juliaup folder.", paths.juliaupselfhome);
                     }
-                },
-                Err(_) => eprintln!(" Failed, skipping removal of the entire Juliaup folder.")
+                }
+                Err(_) => eprintln!(" Failed, skipping removal of the entire Juliaup folder."),
             };
-        }
-        else {
+        } else {
             eprintln!("The Juliaup bin folder {:?} is not empty, skipping removal of the entire Juliaup folder.", juliaup_binfolder_path);
         }
     }

--- a/src/command_selfupdate.rs
+++ b/src/command_selfupdate.rs
@@ -1,69 +1,87 @@
-use anyhow::{Result, Context};
 use crate::global_paths::GlobalPaths;
 use crate::operations::update_version_db;
+use anyhow::{Context, Result};
 
 #[cfg(feature = "selfupdate")]
 pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
     use crate::config_file::{load_mut_config_db, save_config_db};
+    use crate::operations::{download_extract_sans_parent, download_juliaup_version};
     use crate::utils::get_juliaserver_base_url;
-    use anyhow::{bail, anyhow};
-    use crate::operations::{download_juliaup_version,download_extract_sans_parent};
     use crate::{get_juliaup_target, get_own_version};
+    use anyhow::{anyhow, bail};
 
-    update_version_db(paths)
-        .with_context(|| "Failed to update versions db.")?;
+    update_version_db(paths).with_context(|| "Failed to update versions db.")?;
 
-    let mut config_file =
-        load_mut_config_db(paths).with_context(|| "`selfupdate` command failed to load configuration db.")?;
+    let mut config_file = load_mut_config_db(paths)
+        .with_context(|| "`selfupdate` command failed to load configuration db.")?;
 
     let juliaup_channel = match &config_file.self_data.juliaup_channel {
         Some(juliaup_channel) => juliaup_channel.to_string(),
-        None => "release".to_string()
+        None => "release".to_string(),
     };
 
-    let juliaupserver_base = get_juliaserver_base_url()
-            .with_context(|| "Failed to get Juliaup server base URL.")?;
-            
+    let juliaupserver_base =
+        get_juliaserver_base_url().with_context(|| "Failed to get Juliaup server base URL.")?;
+
     let version_url_path = match juliaup_channel.as_str() {
         "release" => "juliaup/RELEASECHANNELVERSION",
         "releasepreview" => "juliaup/RELEASEPREVIEWCHANNELVERSION",
         "dev" => "juliaup/DEVCHANNELVERSION",
-        _ => bail!("Juliaup is configured to a channel named '{}' that does not exist.", &juliaup_channel)
+        _ => bail!(
+            "Juliaup is configured to a channel named '{}' that does not exist.",
+            &juliaup_channel
+        ),
     };
 
     eprintln!("Checking for self-updates");
 
-    let version_url = juliaupserver_base.join(version_url_path)
-        .with_context(|| format!("Failed to construct a valid url from '{}' and '{}'.", juliaupserver_base, version_url_path))?;
+    let version_url = juliaupserver_base.join(version_url_path).with_context(|| {
+        format!(
+            "Failed to construct a valid url from '{}' and '{}'.",
+            juliaupserver_base, version_url_path
+        )
+    })?;
 
     let version = download_juliaup_version(&version_url.to_string())?;
 
     config_file.self_data.last_selfupdate = Some(chrono::Utc::now());
 
-    save_config_db(&mut config_file)
-        .with_context(|| "Failed to save configuration file.")?;
+    save_config_db(&mut config_file).with_context(|| "Failed to save configuration file.")?;
 
-    if version==get_own_version().unwrap() {
-        eprintln!("Juliaup unchanged on channel '{}' - {}", juliaup_channel, version);
-    }
-    else {
+    if version == get_own_version().unwrap() {
+        eprintln!(
+            "Juliaup unchanged on channel '{}' - {}",
+            juliaup_channel, version
+        );
+    } else {
         let juliaup_target = get_juliaup_target();
 
-        let juliaupserver_base = get_juliaserver_base_url()
-                .with_context(|| "Failed to get Juliaup server base URL.")?;
+        let juliaupserver_base =
+            get_juliaserver_base_url().with_context(|| "Failed to get Juliaup server base URL.")?;
 
-        let download_url_path = format!("juliaup/bin/juliaup-{}-{}.tar.gz", version, juliaup_target);
+        let download_url_path =
+            format!("juliaup/bin/juliaup-{}-{}.tar.gz", version, juliaup_target);
 
-        let new_juliaup_url = juliaupserver_base.join(&download_url_path)
-                .with_context(|| format!("Failed to construct a valid url from '{}' and '{}'.", juliaupserver_base, download_url_path))?;
+        let new_juliaup_url = juliaupserver_base
+            .join(&download_url_path)
+            .with_context(|| {
+                format!(
+                    "Failed to construct a valid url from '{}' and '{}'.",
+                    juliaupserver_base, download_url_path
+                )
+            })?;
 
         let my_own_path = std::env::current_exe()
             .with_context(|| "Could not determine the path of the running exe.")?;
 
-        let my_own_folder = my_own_path.parent()
+        let my_own_folder = my_own_path
+            .parent()
             .ok_or_else(|| anyhow!("Could not determine parent."))?;
 
-        eprintln!("Found new version {} on channel {}.", version, juliaup_channel);
+        eprintln!(
+            "Found new version {} on channel {}.",
+            version, juliaup_channel
+        );
 
         download_extract_sans_parent(&new_juliaup_url.to_string(), &my_own_folder, 0)?;
         eprintln!("Updated Juliaup to version {}.", version);
@@ -74,37 +92,50 @@ pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
 
 #[cfg(feature = "windowsstore")]
 pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
-    use windows::{core::Interface,Win32::{System::Console::GetConsoleWindow, UI::Shell::IInitializeWithWindow}};
+    use windows::{
+        core::Interface,
+        Win32::{System::Console::GetConsoleWindow, UI::Shell::IInitializeWithWindow},
+    };
 
-    update_version_db(paths)
-        .with_context(|| "Failed to update versions db.")?;
+    update_version_db(paths).with_context(|| "Failed to update versions db.")?;
 
-    let update_manager = windows::Services::Store::StoreContext::GetDefault()    
+    let update_manager = windows::Services::Store::StoreContext::GetDefault()
         .with_context(|| "Failed to get the store context.")?;
 
-    let interop: IInitializeWithWindow = update_manager.cast()
+    let interop: IInitializeWithWindow = update_manager
+        .cast()
         .with_context(|| "Failed to cast the store context to IInitializeWithWindow.")?;
 
     unsafe {
         let x = GetConsoleWindow();
 
-        interop.Initialize(x)
+        interop
+            .Initialize(x)
             .with_context(|| "Call to IInitializeWithWindow.Initialize failed.")?;
     }
-    
-    let updates = update_manager.GetAppAndOptionalStorePackageUpdatesAsync()
+
+    let updates = update_manager
+        .GetAppAndOptionalStorePackageUpdatesAsync()
         .with_context(|| "Call to GetAppAndOptionalStorePackageUpdatesAsync failed.")?
         .get()
-        .with_context(|| "get on the return of GetAppAndOptionalStorePackageUpdatesAsync failed.")?;
+        .with_context(|| {
+            "get on the return of GetAppAndOptionalStorePackageUpdatesAsync failed."
+        })?;
 
-    if updates.Size().with_context(|| "Call to Size on update results failed.")? > 0 {
+    if updates
+        .Size()
+        .with_context(|| "Call to Size on update results failed.")?
+        > 0
+    {
         println!("An update is available.");
 
-        let download_operation = update_manager.RequestDownloadAndInstallStorePackageUpdatesAsync(&updates)
+        let download_operation = update_manager
+            .RequestDownloadAndInstallStorePackageUpdatesAsync(&updates)
             .with_context(|| "Call to RequestDownloadAndInstallStorePackageUpdatesAsync failed.")?;
 
-        download_operation.get()
-            .with_context(|| "get on result from RequestDownloadAndInstallStorePackageUpdatesAsync failed.")?;
+        download_operation.get().with_context(|| {
+            "get on result from RequestDownloadAndInstallStorePackageUpdatesAsync failed."
+        })?;
         // This code will not be reached if the user opts to install updates
     } else {
         println!("No updates available.");
@@ -115,7 +146,6 @@ pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
 
 #[cfg(not(any(feature = "windowsstore", feature = "selfupdate")))]
 pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
-    update_version_db(paths)
-        .with_context(|| "Failed to update versions db.")?;
+    update_version_db(paths).with_context(|| "Failed to update versions db.")?;
     Ok(())
 }

--- a/src/command_update.rs
+++ b/src/command_update.rs
@@ -1,34 +1,45 @@
-use crate::config_file::{JuliaupConfigChannel, load_mut_config_db, save_config_db};
-use crate::global_paths::GlobalPaths;
-use crate::operations::{install_version, update_version_db};
-use crate::jsonstructs_versionsdb::JuliaupVersionDB;
 use crate::config_file::JuliaupConfig;
-use crate::operations::garbage_collect_versions;
-use crate::versions_file::load_versions_db;
-use anyhow::{Context, Result,anyhow,bail};
+use crate::config_file::{load_mut_config_db, save_config_db, JuliaupConfigChannel};
+use crate::global_paths::GlobalPaths;
+use crate::jsonstructs_versionsdb::JuliaupVersionDB;
 #[cfg(not(windows))]
 use crate::operations::create_symlink;
+use crate::operations::garbage_collect_versions;
+use crate::operations::{install_version, update_version_db};
+use crate::versions_file::load_versions_db;
+use anyhow::{anyhow, bail, Context, Result};
 
-fn update_channel(config_db: &mut JuliaupConfig, channel: &String, version_db: &JuliaupVersionDB, ignore_non_updatable_channel: bool, paths: &GlobalPaths) -> Result<()> {    
-    let current_version = 
+fn update_channel(
+    config_db: &mut JuliaupConfig,
+    channel: &String,
+    version_db: &JuliaupVersionDB,
+    ignore_non_updatable_channel: bool,
+    paths: &GlobalPaths,
+) -> Result<()> {
+    let current_version =
         config_db.installed_channels.get(channel).ok_or_else(|| anyhow!("Trying to get the installed version for a channel that does not exist in the config database."))?;
 
     match current_version {
-        JuliaupConfigChannel::SystemChannel {version} => {
+        JuliaupConfigChannel::SystemChannel { version } => {
             let should_version = version_db.available_channels.get(channel);
 
             if let Some(should_version) = should_version {
                 if &should_version.version != version {
                     install_version(&should_version.version, config_db, version_db, paths)
-                        .with_context(|| format!("Failed to install '{}' while updating channel '{}'.", should_version.version, channel))?;
-    
+                        .with_context(|| {
+                            format!(
+                                "Failed to install '{}' while updating channel '{}'.",
+                                should_version.version, channel
+                            )
+                        })?;
+
                     config_db.installed_channels.insert(
                         channel.clone(),
                         JuliaupConfigChannel::SystemChannel {
                             version: should_version.version.clone(),
                         },
                     );
-    
+
                     #[cfg(not(windows))]
                     if config_db.settings.create_channel_symlinks {
                         create_symlink(
@@ -40,25 +51,34 @@ fn update_channel(config_db: &mut JuliaupConfig, channel: &String, version_db: &
                         )?;
                     }
                 }
-            }
-            else if ignore_non_updatable_channel {
+            } else if ignore_non_updatable_channel {
                 eprintln!("Skipping update for '{}' channel, it no longer exists in the version database.", channel);
+            } else {
+                bail!(
+                    "Failed to update '{}' because it no longer exists in the version database.",
+                    channel
+                );
             }
-            else {
-                bail!("Failed to update '{}' because it no longer exists in the version database.", channel);
-            }            
-        },
-        JuliaupConfigChannel::LinkedChannel {command: _, args: _} => if !ignore_non_updatable_channel {
-            bail!("Failed to update '{}' because it is a linked channel.", channel);
-        } else { }
+        }
+        JuliaupConfigChannel::LinkedChannel {
+            command: _,
+            args: _,
+        } => {
+            if !ignore_non_updatable_channel {
+                bail!(
+                    "Failed to update '{}' because it is a linked channel.",
+                    channel
+                );
+            } else {
+            }
+        }
     }
 
     Ok(())
 }
 
 pub fn run_command_update(channel: Option<String>, paths: &GlobalPaths) -> Result<()> {
-    update_version_db(paths)
-        .with_context(|| "Failed to update versions db.")?;
+    update_version_db(paths).with_context(|| "Failed to update versions db.")?;
 
     let version_db =
         load_versions_db(paths).with_context(|| "`update` command failed to load versions db.")?;
@@ -68,14 +88,16 @@ pub fn run_command_update(channel: Option<String>, paths: &GlobalPaths) -> Resul
 
     match channel {
         None => {
-            for (k,_) in config_file.data.installed_channels.clone() {
+            for (k, _) in config_file.data.installed_channels.clone() {
                 update_channel(&mut config_file.data, &k, &version_db, true, paths)?;
             }
-
-        },
+        }
         Some(channel) => {
             if !config_file.data.installed_channels.contains_key(&channel) {
-                bail!("'{}' cannot be updated because it is currently not installed.", channel);
+                bail!(
+                    "'{}' cannot be updated because it is currently not installed.",
+                    channel
+                );
             }
 
             update_channel(&mut config_file.data, &channel, &version_db, false, paths)?;

--- a/src/command_update_version_db.rs
+++ b/src/command_update_version_db.rs
@@ -1,9 +1,8 @@
 use crate::{global_paths::GlobalPaths, operations::update_version_db};
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 
 pub fn run_command_update_version_db(paths: &GlobalPaths) -> Result<()> {
-    update_version_db(paths)
-        .with_context(|| "Failed to update version db.")?;
-    
+    update_version_db(paths).with_context(|| "Failed to update version db.")?;
+
     Ok(())
 }

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -1,10 +1,10 @@
 use anyhow::{anyhow, bail, Context, Result};
-use cluFlock::{SharedFlock, FlockLock, ExclusiveFlock};
+use chrono::{DateTime, Utc};
+use cluFlock::{ExclusiveFlock, FlockLock, SharedFlock};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, ErrorKind, Seek, SeekFrom};
-use chrono::{DateTime,Utc};
 
 use crate::global_paths::GlobalPaths;
 
@@ -43,19 +43,27 @@ pub enum JuliaupConfigChannel {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct JuliaupConfigSettings {
-    #[serde(rename = "CreateChannelSymlinks", default, skip_serializing_if = "is_default")]
+    #[serde(
+        rename = "CreateChannelSymlinks",
+        default,
+        skip_serializing_if = "is_default"
+    )]
     pub create_channel_symlinks: bool,
-    #[serde(rename = "VersionsDbUpdateInterval", default = "default_versionsdb_update_interval", skip_serializing_if = "is_default_versionsdb_update_interval")]
+    #[serde(
+        rename = "VersionsDbUpdateInterval",
+        default = "default_versionsdb_update_interval",
+        skip_serializing_if = "is_default_versionsdb_update_interval"
+    )]
     pub versionsdb_update_interval: i64,
 }
 
 impl Default for JuliaupConfigSettings {
-    fn default() -> Self { 
+    fn default() -> Self {
         JuliaupConfigSettings {
             create_channel_symlinks: false,
             versionsdb_update_interval: default_versionsdb_update_interval(),
         }
-     }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -68,16 +76,25 @@ pub struct JuliaupConfig {
     pub installed_channels: HashMap<String, JuliaupConfigChannel>,
     #[serde(rename = "Settings", default)]
     pub settings: JuliaupConfigSettings,
-    #[serde(rename = "LastVersionDbUpdate", skip_serializing_if = "Option::is_none")]
-    pub last_version_db_update: Option<DateTime<Utc>>
+    #[serde(
+        rename = "LastVersionDbUpdate",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub last_version_db_update: Option<DateTime<Utc>>,
 }
 
 #[cfg(feature = "selfupdate")]
 #[derive(Serialize, Deserialize, Clone)]
 pub struct JuliaupSelfConfig {
-    #[serde(rename = "BackgroundSelfUpdateInterval", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "BackgroundSelfUpdateInterval",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub background_selfupdate_interval: Option<i64>,
-    #[serde(rename = "StartupSelfUpdateInterval", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "StartupSelfUpdateInterval",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub startup_selfupdate_interval: Option<i64>,
     #[serde(rename = "ModifyPath", default, skip_serializing_if = "is_default")]
     pub modify_path: bool,
@@ -94,55 +111,71 @@ pub struct JuliaupConfigFile {
     #[cfg(feature = "selfupdate")]
     pub self_file: File,
     #[cfg(feature = "selfupdate")]
-    pub self_data: JuliaupSelfConfig
+    pub self_data: JuliaupSelfConfig,
 }
 
 pub struct JuliaupReadonlyConfigFile {
     pub data: JuliaupConfig,
     #[cfg(feature = "selfupdate")]
-    pub self_data: JuliaupSelfConfig
+    pub self_data: JuliaupSelfConfig,
 }
 
 pub fn load_config_db(paths: &GlobalPaths) -> Result<JuliaupReadonlyConfigFile> {
     std::fs::create_dir_all(&paths.juliauphome)
         .with_context(|| "Could not create juliaup home folder.")?;
 
-    let lock_file = match OpenOptions::new().read(true).write(true).create(true).open(&paths.lockfile) {
+    let lock_file = match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(&paths.lockfile)
+    {
         Ok(file) => file,
-        Err(e) => return Err(anyhow!("Could not create lockfile: {}.", e))
+        Err(e) => return Err(anyhow!("Could not create lockfile: {}.", e)),
     };
 
     let file_lock = match SharedFlock::try_lock(&lock_file) {
         Ok(lock) => lock,
         Err(_e) => {
-            eprintln!("Juliaup configuration is locked by another process, waiting for it to unlock.");
+            eprintln!(
+                "Juliaup configuration is locked by another process, waiting for it to unlock."
+            );
 
             SharedFlock::wait_lock(&lock_file).unwrap()
         }
     };
 
-    let v = match std::fs::OpenOptions::new().read(true).open(&paths.juliaupconfig) {
+    let v = match std::fs::OpenOptions::new()
+        .read(true)
+        .open(&paths.juliaupconfig)
+    {
         Ok(file) => {
             let reader = BufReader::new(&file);
 
-            serde_json::from_reader(reader)
-                .with_context(|| format!("Failed to parse configuration file '{:?}' for reading.", paths.juliaupconfig))?
-        },
-        Err(error) =>  match error.kind() {
-            ErrorKind::NotFound => {
-                JuliaupConfig {
-                    default: None,
-                    installed_versions: HashMap::new(),
-                    installed_channels: HashMap::new(),
-                    settings: JuliaupConfigSettings {
-                        create_channel_symlinks: false,
-                        versionsdb_update_interval: default_versionsdb_update_interval(),
-                    },
-                    last_version_db_update: None,
-                }
+            serde_json::from_reader(reader).with_context(|| {
+                format!(
+                    "Failed to parse configuration file '{:?}' for reading.",
+                    paths.juliaupconfig
+                )
+            })?
+        }
+        Err(error) => match error.kind() {
+            ErrorKind::NotFound => JuliaupConfig {
+                default: None,
+                installed_versions: HashMap::new(),
+                installed_channels: HashMap::new(),
+                settings: JuliaupConfigSettings {
+                    create_channel_symlinks: false,
+                    versionsdb_update_interval: default_versionsdb_update_interval(),
+                },
+                last_version_db_update: None,
             },
             other_error => {
-                bail!("Problem opening the file {:?}: {:?}", paths.juliaupconfig, other_error)
+                bail!(
+                    "Problem opening the file {:?}: {:?}",
+                    paths.juliaupconfig,
+                    other_error
+                )
             }
         },
     };
@@ -151,18 +184,30 @@ pub fn load_config_db(paths: &GlobalPaths) -> Result<JuliaupReadonlyConfigFile> 
     let selfconfig: JuliaupSelfConfig;
     #[cfg(feature = "selfupdate")]
     {
-        selfconfig = match std::fs::OpenOptions::new().read(true).open(&paths.juliaupselfconfig) {
+        selfconfig = match std::fs::OpenOptions::new()
+            .read(true)
+            .open(&paths.juliaupselfconfig)
+        {
             Ok(file) => {
                 let reader = BufReader::new(&file);
-    
-                serde_json::from_reader(reader)
-                    .with_context(|| format!("Failed to parse self configuration file '{:?}' for reading.", paths.juliaupselfconfig))?
-            },
-            Err(error) => bail!("Could not open self configuration file {:?}: {:?}", paths.juliaupselfconfig, error)
+
+                serde_json::from_reader(reader).with_context(|| {
+                    format!(
+                        "Failed to parse self configuration file '{:?}' for reading.",
+                        paths.juliaupselfconfig
+                    )
+                })?
+            }
+            Err(error) => bail!(
+                "Could not open self configuration file {:?}: {:?}",
+                paths.juliaupselfconfig,
+                error
+            ),
         };
     }
 
-    file_lock.unlock()
+    file_lock
+        .unlock()
         .with_context(|| "Failed to unlock configuration file.")?;
 
     Ok(JuliaupReadonlyConfigFile {
@@ -176,24 +221,36 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
     std::fs::create_dir_all(&paths.juliauphome)
         .with_context(|| "Could not create juliaup home folder.")?;
 
-    let lock_file = match OpenOptions::new().read(true).write(true).create(true).open(&paths.lockfile) {
+    let lock_file = match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(&paths.lockfile)
+    {
         Ok(file) => file,
-        Err(e) => return Err(anyhow!("Could not create lockfile: {}.", e))
+        Err(e) => return Err(anyhow!("Could not create lockfile: {}.", e)),
     };
 
     let file_lock = match ExclusiveFlock::try_lock(lock_file) {
         Ok(lock) => lock,
         Err(e) => {
-            eprintln!("Juliaup configuration is locked by another process, waiting for it to unlock.");
+            eprintln!(
+                "Juliaup configuration is locked by another process, waiting for it to unlock."
+            );
 
             ExclusiveFlock::wait_lock(e.into()).unwrap()
         }
     };
 
-    let mut file = std::fs::OpenOptions::new().read(true).write(true).create(true).open(&paths.juliaupconfig)
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(&paths.juliaupconfig)
         .with_context(|| "Failed to open juliaup config file.")?;
 
-    let stream_len = file.seek(SeekFrom::End(0))
+    let stream_len = file
+        .seek(SeekFrom::End(0))
         .with_context(|| "Failed to determine the length of the configuration file.")?;
 
     let data = match stream_len {
@@ -202,7 +259,7 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
                 default: None,
                 installed_versions: HashMap::new(),
                 installed_channels: HashMap::new(),
-                settings: JuliaupConfigSettings{
+                settings: JuliaupConfigSettings {
                     create_channel_symlinks: false,
                     versionsdb_update_interval: default_versionsdb_update_interval(),
                 },
@@ -214,12 +271,12 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
 
             file.sync_all()
                 .with_context(|| "Failed to write configuration data to disc.")?;
-        
+
             file.rewind()
                 .with_context(|| "Failed to rewind config file after initial write of data.")?;
 
             new_config
-        },
+        }
         _ => {
             file.rewind()
                 .with_context(|| "Failed to rewind existing config file.")?;
@@ -237,13 +294,20 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
     let self_data: JuliaupSelfConfig;
     #[cfg(feature = "selfupdate")]
     {
-        self_file = std::fs::OpenOptions::new().read(true).write(true).open(&paths.juliaupselfconfig)
+        self_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&paths.juliaupselfconfig)
             .with_context(|| "Failed to open juliaup config file.")?;
 
         let reader = BufReader::new(&self_file);
-    
-        self_data = serde_json::from_reader(reader)
-            .with_context(|| format!("Failed to parse self configuration file '{:?}' for reading.", paths.juliaupselfconfig))?
+
+        self_data = serde_json::from_reader(reader).with_context(|| {
+            format!(
+                "Failed to parse self configuration file '{:?}' for reading.",
+                paths.juliaupselfconfig
+            )
+        })?
     }
 
     let result = JuliaupConfigFile {
@@ -253,37 +317,51 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
         #[cfg(feature = "selfupdate")]
         self_file: self_file,
         #[cfg(feature = "selfupdate")]
-        self_data: self_data
+        self_data: self_data,
     };
 
     Ok(result)
 }
 
 pub fn save_config_db(juliaup_config_file: &mut JuliaupConfigFile) -> Result<()> {
-    juliaup_config_file.file.rewind()
+    juliaup_config_file
+        .file
+        .rewind()
         .with_context(|| "Failed to rewind config file for write.")?;
 
-    juliaup_config_file.file.set_len(0)
+    juliaup_config_file
+        .file
+        .set_len(0)
         .with_context(|| "Failed to set len to 0 for config file before writing new content.")?;
 
     serde_json::to_writer_pretty(&juliaup_config_file.file, &juliaup_config_file.data)
         .with_context(|| "Failed to write configuration file.")?;
 
-    juliaup_config_file.file.sync_all()
+    juliaup_config_file
+        .file
+        .sync_all()
         .with_context(|| "Failed to write config data to disc.")?;
 
     #[cfg(feature = "selfupdate")]
     {
-        juliaup_config_file.self_file.rewind()
+        juliaup_config_file
+            .self_file
+            .rewind()
             .with_context(|| "Failed to rewind self config file for write.")?;
 
-        juliaup_config_file.self_file.set_len(0)
-            .with_context(|| "Failed to set len to 0 for self config file before writing new content.")?;
+        juliaup_config_file.self_file.set_len(0).with_context(|| {
+            "Failed to set len to 0 for self config file before writing new content."
+        })?;
 
-        serde_json::to_writer_pretty(&juliaup_config_file.self_file, &juliaup_config_file.self_data)
-            .with_context(|| format!("Failed to write self configuration file."))?;
+        serde_json::to_writer_pretty(
+            &juliaup_config_file.self_file,
+            &juliaup_config_file.self_data,
+        )
+        .with_context(|| format!("Failed to write self configuration file."))?;
 
-        juliaup_config_file.self_file.sync_all()
+        juliaup_config_file
+            .self_file
+            .sync_all()
             .with_context(|| "Failed to write config data to disc.")?;
     }
 

--- a/src/global_paths.rs
+++ b/src/global_paths.rs
@@ -1,8 +1,8 @@
-use std::path::PathBuf;
-use anyhow::{Result,bail,anyhow};
+use crate::get_juliaup_target;
 #[cfg(feature = "selfupdate")]
 use anyhow::Context;
-use crate::get_juliaup_target;
+use anyhow::{anyhow, bail, Result};
+use std::path::PathBuf;
 pub struct GlobalPaths {
     pub juliauphome: PathBuf,
     pub juliaupconfig: PathBuf,
@@ -17,7 +17,11 @@ pub struct GlobalPaths {
 }
 
 fn get_juliaup_home_path() -> Result<PathBuf> {
-    let entry_sep = if std::env::consts::OS == "windows" {';'} else {':'};
+    let entry_sep = if std::env::consts::OS == "windows" {
+        ';'
+    } else {
+        ':'
+    };
 
     match std::env::var("JULIA_DEPOT_PATH") {
         Ok(val) => {
@@ -58,9 +62,7 @@ fn get_juliaup_home_path() -> Result<PathBuf> {
 /// Return ~/.julia/juliaup, if such a directory can be found
 fn get_default_juliaup_home_path() -> Result<PathBuf> {
     let path = dirs::home_dir()
-        .ok_or_else(|| anyhow!(
-            "Could not determine the path of the user home directory."
-        ))?
+        .ok_or_else(|| anyhow!("Could not determine the path of the user home directory."))?
         .join(".julia")
         .join("juliaup");
 
@@ -81,14 +83,15 @@ pub fn get_paths() -> Result<GlobalPaths> {
         .with_context(|| "Could not determine the path of the running exe.")?;
 
     #[cfg(feature = "selfupdate")]
-    let juliaupselfbin = my_own_path.parent()
+    let juliaupselfbin = my_own_path
+        .parent()
         .ok_or_else(|| anyhow!("Could not determine parent."))?
         .to_path_buf();
 
     let juliaupconfig = juliauphome.join("juliaup.json");
 
     let versiondb = juliauphome.join(format!("versiondb-{}.json", get_juliaup_target()));
-    
+
     let lockfile = juliauphome.join(".juliaup-lock");
 
     #[cfg(feature = "selfupdate")]
@@ -100,8 +103,7 @@ pub fn get_paths() -> Result<GlobalPaths> {
         .to_path_buf();
 
     #[cfg(feature = "selfupdate")]
-    let juliaupselfconfig = juliaupselfhome
-        .join("juliaupself.json");
+    let juliaupselfconfig = juliaupselfhome.join("juliaupself.json");
 
     Ok(GlobalPaths {
         juliauphome,

--- a/src/jsonstructs_versionsdb.rs
+++ b/src/jsonstructs_versionsdb.rs
@@ -1,24 +1,24 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize)]
 pub struct JuliaupVersionDBVersion {
     #[serde(rename = "UrlPath")]
-    pub url_path: String
+    pub url_path: String,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct JuliaupVersionDBChannel {
     #[serde(rename = "Version")]
-    pub version: String
+    pub version: String,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct JuliaupVersionDB {
     #[serde(rename = "AvailableVersions")]
-    pub available_versions: HashMap<String,JuliaupVersionDBVersion>,
+    pub available_versions: HashMap<String, JuliaupVersionDBVersion>,
     #[serde(rename = "AvailableChannels")]
-    pub available_channels: HashMap<String,JuliaupVersionDBChannel>,
+    pub available_channels: HashMap<String, JuliaupVersionDBChannel>,
     #[serde(rename = "Version")]
-    pub version: String
+    pub version: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,31 +1,31 @@
 use anyhow::Context;
 
-pub mod utils;
-pub mod global_paths;
-pub mod jsonstructs_versionsdb;
-pub mod config_file;
-pub mod versions_file;
-pub mod operations;
 pub mod command_add;
+pub mod command_api;
+pub mod command_config_backgroundselfupdate;
+pub mod command_config_modifypath;
+pub mod command_config_startupselfupdate;
+pub mod command_config_symlinks;
+pub mod command_config_versionsdbupdate;
 pub mod command_default;
 pub mod command_gc;
+pub mod command_info;
+pub mod command_initial_setup_from_launcher;
 pub mod command_link;
 pub mod command_list;
-pub mod command_status;
 pub mod command_remove;
-pub mod command_update;
-pub mod command_info;
-pub mod command_config_symlinks;
-pub mod command_config_backgroundselfupdate;
-pub mod command_config_startupselfupdate;
-pub mod command_config_versionsdbupdate;
-pub mod command_config_modifypath;
-pub mod command_initial_setup_from_launcher;
-pub mod command_update_version_db;
-pub mod command_api;
-pub mod command_selfupdate;
 pub mod command_selfchannel;
 pub mod command_selfuninstall;
+pub mod command_selfupdate;
+pub mod command_status;
+pub mod command_update;
+pub mod command_update_version_db;
+pub mod config_file;
+pub mod global_paths;
+pub mod jsonstructs_versionsdb;
+pub mod operations;
+pub mod utils;
+pub mod versions_file;
 
 include!(concat!(env!("OUT_DIR"), "/bundled_version.rs"));
 include!(concat!(env!("OUT_DIR"), "/various_constants.rs"));
@@ -38,7 +38,7 @@ pub fn get_bundled_julia_version() -> &'static str {
 pub fn get_bundled_dbversion() -> anyhow::Result<semver::Version> {
     let dbversion = semver::Version::parse(BUNDLED_DB_VERSION)
         .with_context(|| "Failed to parse our own db version.")?;
-    
+
     Ok(dbversion)
 }
 
@@ -49,8 +49,8 @@ pub fn get_juliaup_target() -> &'static str {
 pub fn get_own_version() -> anyhow::Result<semver::Version> {
     use semver::Version;
 
-    let version = Version::parse(PKG_VERSION)
-        .with_context(|| "Failed to parse our own version.")?;
+    let version =
+        Version::parse(PKG_VERSION).with_context(|| "Failed to parse our own version.")?;
 
     Ok(version)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,23 +1,35 @@
 use anyhow::{anyhow, bail, Context, Result};
-use semver::{Version, BuildMetadata};
+use semver::{BuildMetadata, Version};
 use std::path::PathBuf;
 use url::Url;
 
 pub fn get_juliaserver_base_url() -> Result<Url> {
-    let base_url = if let Ok(val) = std::env::var("JULIAUP_SERVER") { 
-        if val.ends_with('/') {val} else {format!("{}/", val)}
-     } else {
-        "https://julialang-s3.julialang.org".to_string() 
+    let base_url = if let Ok(val) = std::env::var("JULIAUP_SERVER") {
+        if val.ends_with('/') {
+            val
+        } else {
+            format!("{}/", val)
+        }
+    } else {
+        "https://julialang-s3.julialang.org".to_string()
     };
 
-    let parsed_url = Url::parse(&base_url)
-        .with_context(|| format!("Failed to parse the value of JULIAUP_SERVER '{}' as a uri.", base_url))?;
+    let parsed_url = Url::parse(&base_url).with_context(|| {
+        format!(
+            "Failed to parse the value of JULIAUP_SERVER '{}' as a uri.",
+            base_url
+        )
+    })?;
 
     Ok(parsed_url)
 }
 
 pub fn get_bin_dir() -> Result<PathBuf> {
-    let entry_sep = if std::env::consts::OS == "windows" {';'} else {':'};
+    let entry_sep = if std::env::consts::OS == "windows" {
+        ';'
+    } else {
+        ':'
+    };
 
     let path = match std::env::var("JULIAUP_BIN_DIR") {
         Ok(val) => {
@@ -50,7 +62,7 @@ pub fn get_bin_dir() -> Result<PathBuf> {
             }
 
             path
-        },
+        }
     };
 
     Ok(path)
@@ -85,7 +97,7 @@ pub fn parse_versionstring(value: &String) -> Result<(String, Version)> {
         minor: version.minor,
         patch: version.patch,
         pre: version.pre,
-        build: BuildMetadata::EMPTY
+        build: BuildMetadata::EMPTY,
     };
 
     let platform = build_parts[1];
@@ -103,12 +115,12 @@ mod tests {
         assert!(parse_versionstring(&s.to_owned()).is_err());
 
         let s = "1.1.1+0.x86.apple.darwin14";
-        let (p,v) = parse_versionstring(&s.to_owned()).unwrap();
+        let (p, v) = parse_versionstring(&s.to_owned()).unwrap();
         assert_eq!(p, "x86");
         assert_eq!(v, Version::new(1, 1, 1));
 
         let s = "1.1.1+0.x64.apple.darwin14";
-        let (p,v) = parse_versionstring(&s.to_owned()).unwrap();
+        let (p, v) = parse_versionstring(&s.to_owned()).unwrap();
         assert_eq!(p, "x64");
         assert_eq!(v, Version::new(1, 1, 1));
     }

--- a/src/versions_file.rs
+++ b/src/versions_file.rs
@@ -3,9 +3,11 @@ use std::{fs::File, io::BufReader};
 // use std::fs::File;
 // use std::io::BufReader;
 // use crate::utils::get_juliaup_home_path;
-use anyhow::{Context,Result};
+use crate::{
+    get_bundled_dbversion, global_paths::GlobalPaths, jsonstructs_versionsdb::JuliaupVersionDB,
+};
+use anyhow::{Context, Result};
 use semver::Version;
-use crate::{jsonstructs_versionsdb::JuliaupVersionDB, global_paths::GlobalPaths, get_bundled_dbversion};
 
 fn load_vendored_db() -> Result<JuliaupVersionDB> {
     let vendored_db = include_str!(concat!(env!("OUT_DIR"), "/versionsdb.json"));
@@ -16,20 +18,22 @@ fn load_vendored_db() -> Result<JuliaupVersionDB> {
     Ok(db)
 }
 
-pub fn load_versions_db(paths: &GlobalPaths) -> Result<JuliaupVersionDB> {  
+pub fn load_versions_db(paths: &GlobalPaths) -> Result<JuliaupVersionDB> {
     let file = File::open(&paths.versiondb);
-    
+
     let local_version_db = match file {
         Ok(file) => {
             let reader = BufReader::new(&file);
-    
-            if let Ok(versiondb) = serde_json::from_reader::<BufReader<&std::fs::File>, JuliaupVersionDB>(reader) {
+
+            if let Ok(versiondb) =
+                serde_json::from_reader::<BufReader<&std::fs::File>, JuliaupVersionDB>(reader)
+            {
                 Some(versiondb)
             } else {
                 None
             }
-        },
-        Err(_) => None
+        }
+        Err(_) => None,
     };
 
     let db = match local_version_db {
@@ -38,18 +42,13 @@ pub fn load_versions_db(paths: &GlobalPaths) -> Result<JuliaupVersionDB> {
                 if version >= get_bundled_dbversion().unwrap() {
                     local_version_db
                 } else {
-                    load_vendored_db()
-                        .with_context(|| "Failed to load vendored version db.")?
-                }    
+                    load_vendored_db().with_context(|| "Failed to load vendored version db.")?
+                }
             } else {
-                load_vendored_db()
-                    .with_context(|| "Failed to load vendored version db.")?
+                load_vendored_db().with_context(|| "Failed to load vendored version db.")?
             }
-        },
-        None => {
-            load_vendored_db()
-                .with_context(|| "Failed to load vendored version db.")?
         }
+        None => load_vendored_db().with_context(|| "Failed to load vendored version db.")?,
     };
 
     Ok(db)

--- a/tests/command_initial_setup_from_launcher_test.rs
+++ b/tests/command_initial_setup_from_launcher_test.rs
@@ -1,13 +1,15 @@
 use assert_cmd::Command;
-use std::path::Path;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
+use std::path::Path;
 
 #[test]
 fn command_initial_setup() {
     let depot_dir = assert_fs::TempDir::new().unwrap();
 
-    depot_dir.child(Path::new("juliaup")).assert(predicate::path::missing());
+    depot_dir
+        .child(Path::new("juliaup"))
+        .assert(predicate::path::missing());
 
     Command::cargo_bin("juliaup")
         .unwrap()
@@ -17,5 +19,7 @@ fn command_initial_setup() {
         .success()
         .stdout("");
 
-    depot_dir.child(Path::new("juliaup").join("juliaup.json")).assert(predicate::path::exists());
+    depot_dir
+        .child(Path::new("juliaup").join("juliaup.json"))
+        .assert(predicate::path::exists());
 }

--- a/tests/command_list_test.rs
+++ b/tests/command_list_test.rs
@@ -3,10 +3,13 @@ use predicates::prelude::*;
 
 #[test]
 fn command_list() {
-    let depot_dir = tempfile::Builder::new().prefix("juliauptest").tempdir().unwrap();
+    let depot_dir = tempfile::Builder::new()
+        .prefix("juliauptest")
+        .tempdir()
+        .unwrap();
 
     Command::cargo_bin("juliaup")
-        .unwrap()        
+        .unwrap()
         .arg("list")
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .assert()
@@ -14,7 +17,7 @@ fn command_list() {
         .stdout(predicate::str::starts_with(" Channel").and(predicate::str::contains("release")));
 
     Command::cargo_bin("juliaup")
-        .unwrap()        
+        .unwrap()
         .arg("ls")
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .assert()

--- a/tests/command_remove.rs
+++ b/tests/command_remove.rs
@@ -3,10 +3,13 @@ use predicates::boolean::PredicateBooleanExt;
 
 #[test]
 fn command_remove() {
-    let depot_dir = tempfile::Builder::new().prefix("juliauptest").tempdir().unwrap();
+    let depot_dir = tempfile::Builder::new()
+        .prefix("juliauptest")
+        .tempdir()
+        .unwrap();
 
     Command::cargo_bin("juliaup")
-        .unwrap()        
+        .unwrap()
         .arg("status")
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .assert()
@@ -23,7 +26,7 @@ fn command_remove() {
         .stdout("");
 
     Command::cargo_bin("juliaup")
-        .unwrap()        
+        .unwrap()
         .arg("status")
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .assert()
@@ -40,7 +43,7 @@ fn command_remove() {
         .stdout("");
 
     Command::cargo_bin("juliaup")
-        .unwrap()        
+        .unwrap()
         .arg("status")
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .assert()
@@ -57,7 +60,7 @@ fn command_remove() {
         .stdout("");
 
     Command::cargo_bin("juliaup")
-        .unwrap()        
+        .unwrap()
         .arg("status")
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .assert()

--- a/tests/command_status_test.rs
+++ b/tests/command_status_test.rs
@@ -2,10 +2,13 @@ use assert_cmd::Command;
 
 #[test]
 fn command_status() {
-    let depot_dir = tempfile::Builder::new().prefix("juliauptest").tempdir().unwrap();
+    let depot_dir = tempfile::Builder::new()
+        .prefix("juliauptest")
+        .tempdir()
+        .unwrap();
 
     Command::cargo_bin("juliaup")
-        .unwrap()        
+        .unwrap()
         .arg("status")
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .assert()

--- a/tests/command_update.rs
+++ b/tests/command_update.rs
@@ -2,10 +2,13 @@ use assert_cmd::Command;
 
 #[test]
 fn command_update() {
-    let depot_dir = tempfile::Builder::new().prefix("juliauptest").tempdir().unwrap();
+    let depot_dir = tempfile::Builder::new()
+        .prefix("juliauptest")
+        .tempdir()
+        .unwrap();
 
     Command::cargo_bin("juliaup")
-        .unwrap()        
+        .unwrap()
         .arg("update")
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .assert()


### PR DESCRIPTION
I was working on https://github.com/JuliaLang/juliaup/issues/257#issuecomment-1403391982 but all the trailing whitespace and unconventional formatting made the diff kind of annoying.
I think it is a good idea to do a big format once and for all. To not lose blame information we can do a `.git-blame-ignore-revs` file after (https://michaelheap.com/git-ignore-rev/)