### PR TITLE
disentangle JULIA_DEPOT_PATH from Juliaup and use JULIAUP_HOME instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The installer also bundles a full Julia version manager called `juliaup`. One ca
 
 ## Status
 
-This installer is considered production ready. 
+This installer is considered production ready.
 
 ## Installation
 
@@ -105,6 +105,11 @@ All of these channels can be combined with the `~x86`, `~x64` or `~aarch64` suff
 To launch the default Julia version simply run `julia` in your terminal.
 
 To launch a specific Julia version, say in channel `release`, run `julia +release`.
+
+## Path used by Juliaup
+
+Juliaup will by default use `~/.juliaup` to store Julia versions and log files. This can be changed by setting
+the `JULIAUP_HOME` environment variable.
 
 ## Juliaup server
 

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -147,6 +147,7 @@ fn get_julia_path_from_channel(
     config_data: &JuliaupConfig,
     channel: &str,
     juliaupconfig_path: &Path,
+    juliainstalls_path: &Path,
     julia_version_from_cmd_line: bool,
 ) -> Result<(PathBuf, Vec<String>)> {
     let channel_info = if julia_version_from_cmd_line {
@@ -177,9 +178,7 @@ fn get_julia_path_from_channel(
                     channel
                 )
             })?;
-            let absolute_path = juliaupconfig_path
-                .parent()
-                .unwrap() // unwrap OK because there should always be a parent
+            let absolute_path = juliainstalls_path
                 .join(path)
                 .join("bin")
                 .join(format!("julia{}", std::env::consts::EXE_SUFFIX))
@@ -235,6 +234,7 @@ fn run_app() -> Result<i32> {
         &config_file.data,
         &julia_channel_to_use,
         &paths.juliaupconfig,
+        &paths.juliainstalls,
         julia_version_from_cmd_line,
     )
     .with_context(|| {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -339,7 +339,7 @@ pub fn install_version(
         .join("BundledJulia");
 
     let child_target_foldername = format!("julia-{}", fullversion);
-    let target_path = paths.juliauphome.join(&child_target_foldername);
+    let target_path = paths.juliainstalls.join(&child_target_foldername);
     std::fs::create_dir_all(target_path.parent().unwrap())?;
 
     if fullversion == full_version_string_of_bundled_version && path_of_bundled_version.exists() {
@@ -407,7 +407,7 @@ pub fn garbage_collect_versions(
                 args: _,
             } => true,
         }) {
-            let path_to_delete = paths.juliauphome.join(&detail.path);
+            let path_to_delete = paths.juliainstalls.join(&detail.path);
             let display = path_to_delete.display();
 
             if std::fs::remove_dir_all(&path_to_delete).is_err() {
@@ -466,7 +466,7 @@ pub fn create_symlink(
         JuliaupConfigChannel::SystemChannel { version } => {
             let child_target_fullname = format!("julia-{}", version);
 
-            let target_path = paths.juliauphome.join(&child_target_fullname);
+            let target_path = paths.juliainstalls.join(&child_target_fullname);
 
             eprintln!(
                 "{} {} for Julia {}.",

--- a/tests/command_add.rs
+++ b/tests/command_add.rs
@@ -8,7 +8,7 @@ fn command_add() {
         .unwrap()
         .arg("add")
         .arg("1.6.4")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout("");
@@ -16,9 +16,10 @@ fn command_add() {
     Command::cargo_bin("julialauncher")
         .unwrap()
         .arg("+1.6.4")
+        .arg("--startup-file=no")
         .arg("-e")
         .arg("print(VERSION)")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout("1.6.4");

--- a/tests/command_default.rs
+++ b/tests/command_default.rs
@@ -8,7 +8,7 @@ fn command_default() {
         .unwrap()
         .arg("add")
         .arg("1.6.0")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout("");
@@ -17,16 +17,17 @@ fn command_default() {
         .unwrap()
         .arg("default")
         .arg("1.6.0")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout("");
 
     Command::cargo_bin("julialauncher")
         .unwrap()
+        .arg("--startup-file=no")
         .arg("-e")
         .arg("print(VERSION)")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout("1.6.0");

--- a/tests/command_initial_setup_from_launcher_test.rs
+++ b/tests/command_initial_setup_from_launcher_test.rs
@@ -8,18 +8,18 @@ fn command_initial_setup() {
     let depot_dir = assert_fs::TempDir::new().unwrap();
 
     depot_dir
-        .child(Path::new("juliaup"))
+        .child(Path::new("juliaup.json"))
         .assert(predicate::path::missing());
 
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("46029ef5-0b73-4a71-bff3-d0d05de42aac")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout("");
 
     depot_dir
-        .child(Path::new("juliaup").join("juliaup.json"))
+        .child(Path::new("juliaup.json"))
         .assert(predicate::path::exists());
 }

--- a/tests/command_list_test.rs
+++ b/tests/command_list_test.rs
@@ -11,7 +11,7 @@ fn command_list() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("list")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout(predicate::str::starts_with(" Channel").and(predicate::str::contains("release")));
@@ -19,7 +19,7 @@ fn command_list() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("ls")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout(predicate::str::starts_with(" Channel").and(predicate::str::contains("release")));

--- a/tests/command_remove.rs
+++ b/tests/command_remove.rs
@@ -11,7 +11,7 @@ fn command_remove() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("status")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("1.6.4").not());
@@ -20,7 +20,7 @@ fn command_remove() {
         .unwrap()
         .arg("add")
         .arg("1.6.4")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout("");
@@ -28,7 +28,7 @@ fn command_remove() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("status")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("1.6.4"));
@@ -37,7 +37,7 @@ fn command_remove() {
         .unwrap()
         .arg("add")
         .arg("release")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout("");
@@ -45,7 +45,7 @@ fn command_remove() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("status")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("1.6.4").and(predicates::str::contains("release")));
@@ -54,7 +54,7 @@ fn command_remove() {
         .unwrap()
         .arg("remove")
         .arg("release")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout("");
@@ -62,7 +62,7 @@ fn command_remove() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("status")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("1.6.4").and(predicates::str::contains("release").not()));

--- a/tests/command_status_test.rs
+++ b/tests/command_status_test.rs
@@ -10,7 +10,7 @@ fn command_status() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("status")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout(" Default  Channel  Version  Update \n-----------------------------------\n");
@@ -18,7 +18,7 @@ fn command_status() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("st")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout(" Default  Channel  Version  Update \n-----------------------------------\n");

--- a/tests/command_update.rs
+++ b/tests/command_update.rs
@@ -10,7 +10,7 @@ fn command_update() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("update")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout("");
@@ -18,7 +18,7 @@ fn command_update() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("up")
-        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_HOME", depot_dir.path())
         .assert()
         .success()
         .stdout("");


### PR DESCRIPTION
The current "piggybacking" of `JULIA_DEPOT_PATH` in juliaup makes no sense to me. The depot path is a Julia setting but it does not (and should not) configure the Julia installation itself. Doing so makes it annoying when you want to change this Julia setting (e.g use a single temporary depot path) with your currently installed Julia version. Losing access to the Julia installation is not something desirable when changing the depot path.

This PR removes any usage of the depot path in juliaup. Instead, it stores all config files and julia installations in `~/.juliaup` by default, changeable with the env variable `JULIAUP_HOME` (in the same way as rustup). The subdir in the juliaup home directory for the installs is `juliainstallations`.



Fixes: https://github.com/JuliaLang/juliaup/issues/257