### PR TITLE
Add support for directory overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1030,7 @@ dependencies = [
  "ctrlc",
  "dialoguer",
  "dirs",
+ "dunce",
  "env_logger",
  "env_proxy",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ codegen-units = 1
 [dependencies]
 clap = { version = "4.0.15", features = ["derive"] }
 dirs = "5.0.1"
+dunce = "1"
 serde = {version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Here are some of the things you can do with `juliaup`:
 - `juliaup link dev ~/juliasrc/julia` configures the `dev` channel to use a binary that you provide that is located at `~/juliasrc/julia`. You can then use `dev` as if it was a system provided channel, i.e. make it the default or use it with the `+` version selector. You can use other names than `dev` and link as many versions into `juliaup` as you want.
 - `juliaup self update` installs the latest version, which is necessary if new releases reach the beta channel, etc.
 - `juliaup self uninstall` uninstalls Juliaup. Note that on some platforms this command is not available, in those situations one should use platform specific methods to uninstall Juliaup.
+- `juliaup override status` shows all configured directory overrides.
+- `juliaup override set lts` sets a directory override for the current working directory to the `lts` channel.
+- `juliaup override unset` removes a directory override for the current working directory.
+- `juliaup override set --path foo/bar lts` sets a directory override for the path `foo/bar` to the `lts` channel.
+- `juliaup override unset --path foo/bar` removes a directory override for the path `foo/bar`.
+- `juliaup override unset --nonexistent` removes all directory overrides for paths that no longer exist.
 - `juliaup` shows you what other commands are available.
 
 The available system provided channels are:
@@ -112,6 +118,7 @@ The Julia launcher `julia` automatically determines which specific version of Ju
 
 1. A command line Julia version specifier, such as `julia +release`.
 2. The `JULIAUP_CHANNEL` environment variable.
+3. A directory override, set with the `juliaup override set` command.
 3. The default Juliaup channel.
 
 The channel is used in the order listed above, using the first available option.

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -322,6 +322,12 @@ fn main() -> Result<()> {
         .write_style("JULIAUP_LOG_STYLE");
     env_logger::init_from_env(env);
 
+    let x = std::env::current_dir()?;
+
+    let x = x.canonicalize()?;
+
+    println!("{:?}", x);
+
     let client_status = run_app()?;
 
     std::process::exit(client_status);

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -82,11 +82,14 @@ enum Juliaup {
 enum OverrideSubCmd {
     List {},
     Set { 
-        channel: String,  
+        channel: String,
+        #[clap(long, short)]
         path: Option<String>
     },
     Unset {
+        #[clap(long, short)]
         nonexistent: bool,
+        #[clap(long, short)]
         path: Option<String>,
     }
 }
@@ -202,9 +205,9 @@ fn main() -> Result<()> {
         Juliaup::InitialSetupFromLauncher {} => run_command_initial_setup_from_launcher(&paths),
         Juliaup::UpdateVersionDb {} => run_command_update_version_db(&paths),
         Juliaup::OverrideSubCmd(subcmd) => match subcmd {
-            OverrideSubCmd::List {  } => run_command_override_list(),
-            OverrideSubCmd::Set { channel, path } => run_command_override_set(channel, path),
-            OverrideSubCmd::Unset { nonexistent, path } => run_command_override_unset(nonexistent, path),
+            OverrideSubCmd::List {  } => run_command_override_list(&paths),
+            OverrideSubCmd::Set { channel, path } => run_command_override_set(&paths, channel, path),
+            OverrideSubCmd::Unset { nonexistent, path } => run_command_override_unset(&paths, nonexistent, path),
         }
         Juliaup::Info {} => run_command_info(&paths),
         #[cfg(feature = "selfupdate")]

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -11,7 +11,7 @@ use juliaup::command_info::run_command_info;
 use juliaup::command_initial_setup_from_launcher::run_command_initial_setup_from_launcher;
 use juliaup::command_link::run_command_link;
 use juliaup::command_list::run_command_list;
-use juliaup::command_override::{run_command_override_list, run_command_override_unset};
+use juliaup::command_override::{run_command_override_status, run_command_override_unset};
 use juliaup::command_remove::run_command_remove;
 use juliaup::command_selfupdate::run_command_selfupdate;
 use juliaup::command_status::run_command_status;
@@ -80,7 +80,7 @@ enum Juliaup {
 #[derive(Parser)]
 /// Manage directory overrides
 enum OverrideSubCmd {
-    List {},
+    Status {},
     Set { 
         channel: String,
         #[clap(long, short)]
@@ -205,7 +205,7 @@ fn main() -> Result<()> {
         Juliaup::InitialSetupFromLauncher {} => run_command_initial_setup_from_launcher(&paths),
         Juliaup::UpdateVersionDb {} => run_command_update_version_db(&paths),
         Juliaup::OverrideSubCmd(subcmd) => match subcmd {
-            OverrideSubCmd::List {  } => run_command_override_list(&paths),
+            OverrideSubCmd::Status {  } => run_command_override_status(&paths),
             OverrideSubCmd::Set { channel, path } => run_command_override_set(&paths, channel, path),
             OverrideSubCmd::Unset { nonexistent, path } => run_command_override_unset(&paths, nonexistent, path),
         }

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use juliaup::command_add::run_command_add;
+use juliaup::{command_add::run_command_add, command_override::run_command_override_set};
 use juliaup::command_api::run_command_api;
 #[cfg(not(windows))]
 use juliaup::command_config_symlinks::run_command_config_symlinks;
@@ -11,6 +11,7 @@ use juliaup::command_info::run_command_info;
 use juliaup::command_initial_setup_from_launcher::run_command_initial_setup_from_launcher;
 use juliaup::command_link::run_command_link;
 use juliaup::command_list::run_command_list;
+use juliaup::command_override::{run_command_override_list, run_command_override_unset};
 use juliaup::command_remove::run_command_remove;
 use juliaup::command_selfupdate::run_command_selfupdate;
 use juliaup::command_status::run_command_status;
@@ -43,6 +44,8 @@ enum Juliaup {
     /// List all available channels
     #[clap(alias = "ls")]
     List {},
+    #[clap(subcommand, name = "override")]
+    OverrideSubCmd(OverrideSubCmd),
     #[clap(alias = "up")]
     /// Update all or a specific channel to the latest Julia version
     Update { channel: Option<String> },
@@ -72,6 +75,20 @@ enum Juliaup {
     #[cfg(feature = "selfupdate")]
     #[clap(name = "4c79c12db1d34bbbab1f6c6f838f423f", hide = true)]
     SecretSelfUpdate {},
+}
+
+#[derive(Parser)]
+/// Manage directory overrides
+enum OverrideSubCmd {
+    List {},
+    Set { 
+        channel: String,  
+        path: Option<String>
+    },
+    Unset {
+        nonexistent: bool,
+        path: Option<String>,
+    }
 }
 
 #[derive(Parser)]
@@ -184,6 +201,11 @@ fn main() -> Result<()> {
         Juliaup::Api { command } => run_command_api(&command, &paths),
         Juliaup::InitialSetupFromLauncher {} => run_command_initial_setup_from_launcher(&paths),
         Juliaup::UpdateVersionDb {} => run_command_update_version_db(&paths),
+        Juliaup::OverrideSubCmd(subcmd) => match subcmd {
+            OverrideSubCmd::List {  } => run_command_override_list(),
+            OverrideSubCmd::Set { channel, path } => run_command_override_set(channel, path),
+            OverrideSubCmd::Unset { nonexistent, path } => run_command_override_unset(nonexistent, path),
+        }
         Juliaup::Info {} => run_command_info(&paths),
         #[cfg(feature = "selfupdate")]
         Juliaup::SecretSelfUpdate {} => run_command_selfupdate(&paths),

--- a/src/command_override.rs
+++ b/src/command_override.rs
@@ -14,9 +14,9 @@ struct OverrideRow {
     channel: String    
 }
 
-pub fn run_command_override_list(paths: &GlobalPaths) -> Result<()> {
+pub fn run_command_override_status(paths: &GlobalPaths) -> Result<()> {
     let config_file = load_config_db(paths)
-        .with_context(|| "`override list` command failed to load configuration file.")?;
+        .with_context(|| "`override status` command failed to load configuration file.")?;
 
     let rows_in_table: Vec<_> = config_file
         .data

--- a/src/command_override.rs
+++ b/src/command_override.rs
@@ -25,7 +25,7 @@ pub fn run_command_override_list(paths: &GlobalPaths) -> Result<()> {
         .sorted_by_key(|i| i.path.to_string())
         .map(|i| -> OverrideRow {
             OverrideRow {
-                path: i.path.to_string(),
+                path: dunce::simplified(&PathBuf::from(&i.path)).to_string_lossy().to_string(),
                 channel: i.channel.to_string(),
             }
         })

--- a/src/command_override.rs
+++ b/src/command_override.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+
+pub fn run_command_override_list() -> Result<()> {
+    Ok(())
+}
+
+pub fn run_command_override_set(channel: String, path: Option<String>) -> Result<()> {
+    Ok(())
+}
+
+pub fn run_command_override_unset(nonexistent: bool, path: Option<String>) -> Result<()> {
+    Ok(())
+}

--- a/src/command_override.rs
+++ b/src/command_override.rs
@@ -1,13 +1,99 @@
-use anyhow::Result;
+use std::{path::{PathBuf, Path}, env::{current_dir}};
 
-pub fn run_command_override_list() -> Result<()> {
+use anyhow::{Result, Context, bail};
+use cli_table::{Table, print_stdout, WithTitle, format::{Separator, HorizontalLine, Border}, ColorChoice};
+use itertools::Itertools;
+
+use crate::{config_file::{load_config_db, load_mut_config_db, JuliaupOverride, save_config_db}, global_paths::GlobalPaths};
+
+#[derive(Table)]
+struct OverrideRow {
+    #[table(title = "Path")]
+    path: String,
+    #[table(title = "Channel")]
+    channel: String    
+}
+
+pub fn run_command_override_list(paths: &GlobalPaths) -> Result<()> {
+    let config_file = load_config_db(paths)
+        .with_context(|| "`override list` command failed to load configuration file.")?;
+
+    let rows_in_table: Vec<_> = config_file
+        .data
+        .overrides
+        .iter()
+        .sorted_by_key(|i| i.path.to_string())
+        .map(|i| -> OverrideRow {
+            OverrideRow {
+                path: i.path.to_string(),
+                channel: i.channel.to_string(),
+            }
+        })
+        .collect();
+
+    print_stdout(
+        rows_in_table
+            .with_title()
+            .color_choice(ColorChoice::Never)
+            .border(Border::builder().build())
+            .separator(
+                Separator::builder()
+                    .title(Some(HorizontalLine::new('1', '2', '3', '-')))
+                    .build(),
+            ),
+    )?;
+    
     Ok(())
 }
 
-pub fn run_command_override_set(channel: String, path: Option<String>) -> Result<()> {
+pub fn run_command_override_set(paths: &GlobalPaths, channel: String, path: Option<String>) -> Result<()> {
+    let mut config_file = load_mut_config_db(paths)
+        .with_context(|| "`override set` command failed to load configuration data.")?;
+
+    if !config_file.data.installed_channels.contains_key(&channel) {
+        bail!("'{}' channel does not exist.", &channel);
+    }
+
+    let path = match path {
+        Some(path) => PathBuf::from(path),
+        None => {
+            current_dir()?
+        }
+    }.canonicalize()?;
+
+    if config_file.data.overrides.iter().any(|i| i.path == path.to_string_lossy().to_string()) {
+        bail!("'{}' path already has an override configured.", &channel);
+    }
+    
+    config_file.data.overrides.push(JuliaupOverride { path: path.to_string_lossy().to_string(), channel: channel.clone() });
+
+    save_config_db(&mut config_file)
+        .with_context(|| "Failed to save configuration file from `override add` command.")?;
+
     Ok(())
 }
 
-pub fn run_command_override_unset(nonexistent: bool, path: Option<String>) -> Result<()> {
+pub fn run_command_override_unset(paths: &GlobalPaths, nonexistent: bool, path: Option<String>) -> Result<()> {
+    let mut config_file = load_mut_config_db(paths)
+        .with_context(|| "`override unset` command failed to load configuration data.")?;
+
+    let path = match path {
+        Some(path) => PathBuf::from(path),
+        None => {
+            current_dir()?
+        }
+    }.canonicalize()?;
+
+    if nonexistent {
+        config_file.data.overrides.retain(|x| Path::new(&x.path).is_dir());
+    }
+    else {
+        // First remove any duplicates
+        config_file.data.overrides.retain(|x| Path::new(&x.path) != path);
+    }
+
+    save_config_db(&mut config_file)
+        .with_context(|| "Failed to save configuration file from `override add` command.")?;
+
     Ok(())
 }

--- a/src/command_remove.rs
+++ b/src/command_remove.rs
@@ -27,6 +27,13 @@ pub fn run_command_remove(channel: &str, paths: &GlobalPaths) -> Result<()> {
         }
     }
 
+    if config_file.data.overrides.iter().any(|i| i.channel == channel) {
+        bail!(
+            "'{}' cannot be removed because it is currently used in a directory override.",
+            channel
+        );
+    }
+
     config_file.data.installed_channels.remove(channel);
 
     #[cfg(not(windows))]

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -67,6 +67,14 @@ impl Default for JuliaupConfigSettings {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+pub struct JuliaupOverride {
+    #[serde(rename = "Path")]
+    pub path: String,
+    #[serde(rename = "Channel")]
+    pub channel: String
+}
+
+#[derive(Serialize, Deserialize, Clone)]
 pub struct JuliaupConfig {
     #[serde(rename = "Default")]
     pub default: Option<String>,
@@ -76,6 +84,8 @@ pub struct JuliaupConfig {
     pub installed_channels: HashMap<String, JuliaupConfigChannel>,
     #[serde(rename = "Settings", default)]
     pub settings: JuliaupConfigSettings,
+    #[serde(rename = "Overrides", default)]
+    pub overrides: Vec<JuliaupOverride>,
     #[serde(
         rename = "LastVersionDbUpdate",
         skip_serializing_if = "Option::is_none"
@@ -164,6 +174,7 @@ pub fn load_config_db(paths: &GlobalPaths) -> Result<JuliaupReadonlyConfigFile> 
                 default: None,
                 installed_versions: HashMap::new(),
                 installed_channels: HashMap::new(),
+                overrides: Vec::new(),
                 settings: JuliaupConfigSettings {
                     create_channel_symlinks: false,
                     versionsdb_update_interval: default_versionsdb_update_interval(),
@@ -259,6 +270,7 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
                 default: None,
                 installed_versions: HashMap::new(),
                 installed_channels: HashMap::new(),
+                overrides: Vec::new(),
                 settings: JuliaupConfigSettings {
                     create_channel_symlinks: false,
                     versionsdb_update_interval: default_versionsdb_update_interval(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod command_info;
 pub mod command_initial_setup_from_launcher;
 pub mod command_link;
 pub mod command_list;
+pub mod command_override;
 pub mod command_remove;
 pub mod command_selfchannel;
 pub mod command_selfuninstall;

--- a/tests/command_override_test.rs
+++ b/tests/command_override_test.rs
@@ -2,7 +2,7 @@ use assert_cmd::Command;
 use predicates::prelude::PredicateBooleanExt;
 
 #[test]
-fn command_override_list_test() {
+fn command_override_status_test() {
     let depot_dir = assert_fs::TempDir::new().unwrap();
 
     Command::cargo_bin("juliaup")
@@ -26,7 +26,7 @@ fn command_override_list_test() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("override")
-        .arg("list")
+        .arg("status")
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .assert()
         .success()
@@ -350,7 +350,7 @@ fn command_override_delete_empty_test() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("override")
-        .arg("list")
+        .arg("status")
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .assert()
         .success()
@@ -372,7 +372,7 @@ fn command_override_delete_empty_test() {
     Command::cargo_bin("juliaup")
         .unwrap()
         .arg("override")
-        .arg("list")
+        .arg("status")
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .assert()
         .success()

--- a/tests/command_override_test.rs
+++ b/tests/command_override_test.rs
@@ -1,0 +1,380 @@
+use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
+
+#[test]
+fn command_override_list_test() {
+    let depot_dir = assert_fs::TempDir::new().unwrap();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("1.6.7")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("1.8.5")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("list")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout(" Path  Channel \n---------------\n");
+}
+
+#[test]
+fn command_override_cur_dir_test() {
+    let depot_dir = assert_fs::TempDir::new().unwrap();
+
+    let or_dir = assert_fs::TempDir::new().unwrap();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("1.6.7")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("1.8.5")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("default")
+        .arg("1.6.7")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("julialauncher")
+        .unwrap()
+        .arg("-e")
+        .arg("print(VERSION)")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .current_dir(&or_dir)
+        .assert()
+        .success()
+        .stdout("1.6.7");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("set")
+        .arg("1.8.5")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .current_dir(&or_dir)
+        .assert()
+        .success();
+
+    Command::cargo_bin("julialauncher")
+        .unwrap()
+        .arg("-e")
+        .arg("print(VERSION)")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .current_dir(&or_dir)
+        .assert()
+        .success()
+        .stdout("1.8.5");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("unset")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .current_dir(&or_dir)
+        .assert()
+        .success();
+
+    Command::cargo_bin("julialauncher")
+        .unwrap()
+        .arg("-e")
+        .arg("print(VERSION)")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .current_dir(&or_dir)
+        .assert()
+        .success()
+        .stdout("1.6.7");
+}
+
+#[test]
+fn command_override_arg_test() {
+    let depot_dir = assert_fs::TempDir::new().unwrap();
+
+    let or_dir = assert_fs::TempDir::new().unwrap();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("1.6.7")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("1.8.5")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("default")
+        .arg("1.6.7")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("julialauncher")
+        .unwrap()
+        .arg("-e")
+        .arg("print(VERSION)")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .current_dir(&or_dir)
+        .assert()
+        .success()
+        .stdout("1.6.7");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("set")
+        .arg("--path")
+        .arg(or_dir.as_os_str())
+        .arg("1.8.5")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("julialauncher")
+        .unwrap()
+        .arg("-e")
+        .arg("print(VERSION)")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .current_dir(&or_dir)
+        .assert()
+        .success()
+        .stdout("1.8.5");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("unset")
+        .arg("--path")
+        .arg(or_dir.as_os_str())
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("julialauncher")
+        .unwrap()
+        .arg("-e")
+        .arg("print(VERSION)")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .current_dir(&or_dir)
+        .assert()
+        .success()
+        .stdout("1.6.7");
+}
+
+#[test]
+fn command_override_overlap_test() {
+    let depot_dir = assert_fs::TempDir::new().unwrap();
+
+    let or_dir_parent = assert_fs::TempDir::new().unwrap();
+    let or_dir_child= or_dir_parent.join("child");
+    std::fs::create_dir_all(&or_dir_child).unwrap();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("1.6.7")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("1.7.3")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("1.8.5")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("default")
+        .arg("1.6.7")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("set")
+        .arg("--path")
+        .arg(or_dir_parent.as_os_str())
+        .arg("1.7.3")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("set")
+        .arg("--path")
+        .arg(&or_dir_child.as_os_str())
+        .arg("1.8.5")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("julialauncher")
+        .unwrap()
+        .arg("-e")
+        .arg("print(VERSION)")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .current_dir(&or_dir_parent)
+        .assert()
+        .success()
+        .stdout("1.7.3");
+
+    Command::cargo_bin("julialauncher")
+        .unwrap()
+        .arg("-e")
+        .arg("print(VERSION)")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .current_dir(&or_dir_child)
+        .assert()
+        .success()
+        .stdout("1.8.5");
+}
+
+#[test]
+fn command_override_delete_empty_test() {
+    let depot_dir = assert_fs::TempDir::new().unwrap();
+
+    let or_dir1 = assert_fs::TempDir::new().unwrap();
+    let or_dir2 = assert_fs::TempDir::new().unwrap();
+    let or_dir3 = assert_fs::TempDir::new().unwrap();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("1.6.7")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+    
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("set")
+        .arg("--path")
+        .arg(or_dir1.as_os_str())
+        .arg("1.6.7")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("set")
+        .arg("--path")
+        .arg(or_dir2.as_os_str())
+        .arg("1.6.7")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("set")
+        .arg("--path")
+        .arg(or_dir3.as_os_str())
+        .arg("1.6.7")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("unset")
+        .arg("--nonexistent")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("list")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::ord::eq(" Path  Channel \n---------------\n").not());
+
+    std::fs::remove_dir(or_dir1).unwrap();
+    std::fs::remove_dir(or_dir2).unwrap();
+    std::fs::remove_dir(or_dir3).unwrap();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("unset")
+        .arg("--nonexistent")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("override")
+        .arg("list")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout(" Path  Channel \n---------------\n");
+}


### PR DESCRIPTION
This adds an `override` command to `juliaup`:

- `juliaup override set lts`: Sets an override for the current directory to the `lts` channel.
- `juliaup override unset`: Removes an override for the current directory.
- `juliaup override status`: Shows all overrides.

There are some more options, see the command line help for those.