### PR TITLE
Make check channel up-to-date in julialauncher optional

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -179,7 +179,7 @@ fn get_julia_path_from_channel(
                 .installed_versions.get(version)
                 .ok_or_else(|| anyhow!("The juliaup configuration is in an inconsistent state, the channel {} is pointing to Julia version {}, which is not installed.", channel, version))?.path;
 
-            if config_data.settings.should_check_channel_update {
+            if config_data.settings.should_check_channel_uptodate {
                 check_channel_uptodate(channel, version, versions_db).with_context(|| {
                     format!(
                         "The Julia launcher failed while checking whether the channe {} is up-to-date.",

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -179,12 +179,14 @@ fn get_julia_path_from_channel(
                 .installed_versions.get(version)
                 .ok_or_else(|| anyhow!("The juliaup configuration is in an inconsistent state, the channel {} is pointing to Julia version {}, which is not installed.", channel, version))?.path;
 
-            check_channel_uptodate(channel, version, versions_db).with_context(|| {
-                format!(
-                    "The Julia launcher failed while checking whether the channe {} is up-to-date.",
-                    channel
-                )
-            })?;
+            if config_data.settings.should_check_channel_update {
+                check_channel_uptodate(channel, version, versions_db).with_context(|| {
+                    format!(
+                        "The Julia launcher failed while checking whether the channe {} is up-to-date.",
+                        channel
+                    )
+                })?;
+            }
             let absolute_path = juliaupconfig_path
                 .parent()
                 .unwrap() // unwrap OK because there should always be a parent

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -4,6 +4,7 @@ use juliaup::command_api::run_command_api;
 #[cfg(not(windows))]
 use juliaup::command_config_symlinks::run_command_config_symlinks;
 use juliaup::command_config_versionsdbupdate::run_command_config_versionsdbupdate;
+use juliaup::command_config_checkchannelupdate::run_command_config_checkchannelupdate;
 use juliaup::command_default::run_command_default;
 use juliaup::command_gc::run_command_gc;
 use juliaup::command_info::run_command_info;
@@ -147,6 +148,12 @@ enum ConfigSubCmd {
         /// New value
         value: Option<i64>,
     },
+    #[clap(name = "checkchannelupdate")]
+    /// Check for updates to the default channel on startup
+    ShouldCheckChannelUpdate {
+        /// New Value
+        value: Option<bool>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -199,6 +206,9 @@ fn main() -> Result<()> {
             }
             ConfigSubCmd::VersionsDbUpdateInterval { value } => {
                 run_command_config_versionsdbupdate(value, false, &paths)
+            }
+            ConfigSubCmd::ShouldCheckChannelUpdate { value } => {
+                run_command_config_checkchannelupdate(value, false, &paths)
             }
         },
         Juliaup::Api { command } => run_command_api(&command, &paths),

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -4,7 +4,7 @@ use juliaup::command_api::run_command_api;
 #[cfg(not(windows))]
 use juliaup::command_config_symlinks::run_command_config_symlinks;
 use juliaup::command_config_versionsdbupdate::run_command_config_versionsdbupdate;
-use juliaup::command_config_checkchannelupdate::run_command_config_checkchannelupdate;
+use juliaup::command_config_checkchanneluptodate::run_command_config_checkchanneluptodate;
 use juliaup::command_default::run_command_default;
 use juliaup::command_gc::run_command_gc;
 use juliaup::command_info::run_command_info;
@@ -208,7 +208,7 @@ fn main() -> Result<()> {
                 run_command_config_versionsdbupdate(value, false, &paths)
             }
             ConfigSubCmd::ShouldCheckChannelUpdate { value } => {
-                run_command_config_checkchannelupdate(value, false, &paths)
+                run_command_config_checkchanneluptodate(value, false, &paths)
             }
         },
         Juliaup::Api { command } => run_command_api(&command, &paths),

--- a/src/command_config_checkchannelupdate.rs
+++ b/src/command_config_checkchannelupdate.rs
@@ -1,0 +1,48 @@
+use anyhow::Result;
+
+pub fn run_command_config_checkchannelupdate(
+    value: Option<bool>,
+    quiet: bool,
+    paths: &crate::global_paths::GlobalPaths,
+) -> Result<()> {
+    use crate::config_file::{load_config_db, load_mut_config_db, save_config_db};
+    use anyhow::Context;
+
+    match value {
+        Some(value) => {
+            let mut config_file = load_mut_config_db(paths)
+                .with_context(|| "`config` command failed to load configuration data.")?;
+
+            let mut value_changed = false;
+
+            if value != config_file.data.settings.should_check_channel_update {
+                config_file.data.settings.should_check_channel_update = value;
+                value_changed = true;
+            }
+
+            save_config_db(&mut config_file)
+                .with_context(|| "Failed to save configuration file from `config` command.")?;
+
+            if !quiet {
+                if value_changed {
+                    eprintln!("Property 'checkchannelupdate' set to '{}'", value);
+                } else {
+                    eprintln!("Property 'checkchannelupdate' is already set to '{}'", value);
+                }
+            }
+        }
+        None => {
+            let config_file = load_config_db(paths)
+                .with_context(|| "`config` command failed to load configuration data.")?;
+
+            if !quiet {
+                eprintln!(
+                    "Property 'checkchannelupdate' set to '{}'",
+                    config_file.data.settings.should_check_channel_update
+                );
+            }
+        }
+    };
+
+    Ok(())
+}

--- a/src/command_config_checkchanneluptodate.rs
+++ b/src/command_config_checkchanneluptodate.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-pub fn run_command_config_checkchannelupdate(
+pub fn run_command_config_checkchanneluptodate(
     value: Option<bool>,
     quiet: bool,
     paths: &crate::global_paths::GlobalPaths,
@@ -15,8 +15,8 @@ pub fn run_command_config_checkchannelupdate(
 
             let mut value_changed = false;
 
-            if value != config_file.data.settings.should_check_channel_update {
-                config_file.data.settings.should_check_channel_update = value;
+            if value != config_file.data.settings.should_check_channel_uptodate {
+                config_file.data.settings.should_check_channel_uptodate = value;
                 value_changed = true;
             }
 
@@ -38,7 +38,7 @@ pub fn run_command_config_checkchannelupdate(
             if !quiet {
                 eprintln!(
                     "Property 'checkchannelupdate' set to '{}'",
-                    config_file.data.settings.should_check_channel_update
+                    config_file.data.settings.should_check_channel_uptodate
                 );
             }
         }

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -20,6 +20,10 @@ fn is_default_versionsdb_update_interval(i: &i64) -> bool {
     *i == default_versionsdb_update_interval()
 }
 
+fn default_should_check_channel_update() -> bool {
+    true
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct JuliaupConfigVersion {
     #[serde(rename = "Path")]
@@ -57,7 +61,7 @@ pub struct JuliaupConfigSettings {
     pub versionsdb_update_interval: i64,
     #[serde(
         rename = "ShouldCheckChannelUpdate",
-        default,
+        default = "default_should_check_channel_update",
         skip_serializing_if = "is_default",
     )]
     pub should_check_channel_update: bool,

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -20,7 +20,7 @@ fn is_default_versionsdb_update_interval(i: &i64) -> bool {
     *i == default_versionsdb_update_interval()
 }
 
-fn default_should_check_channel_update() -> bool {
+fn default_should_check_channel_uptodate() -> bool {
     true
 }
 
@@ -60,11 +60,11 @@ pub struct JuliaupConfigSettings {
     )]
     pub versionsdb_update_interval: i64,
     #[serde(
-        rename = "ShouldCheckChannelUpdate",
-        default = "default_should_check_channel_update",
+        rename = "ShouldCheckChannelUptodate",
+        default = "default_should_check_channel_uptodate",
         skip_serializing_if = "is_default",
     )]
-    pub should_check_channel_update: bool,
+    pub should_check_channel_uptodate: bool,
 }
 
 impl Default for JuliaupConfigSettings {
@@ -72,7 +72,7 @@ impl Default for JuliaupConfigSettings {
         JuliaupConfigSettings {
             create_channel_symlinks: false,
             versionsdb_update_interval: default_versionsdb_update_interval(),
-            should_check_channel_update: true,
+            should_check_channel_uptodate: true,
         }
     }
 }
@@ -189,7 +189,7 @@ pub fn load_config_db(paths: &GlobalPaths) -> Result<JuliaupReadonlyConfigFile> 
                 settings: JuliaupConfigSettings {
                     create_channel_symlinks: false,
                     versionsdb_update_interval: default_versionsdb_update_interval(),
-                    should_check_channel_update: true,
+                    should_check_channel_uptodate: true,
                 },
                 last_version_db_update: None,
             },
@@ -286,7 +286,7 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
                 settings: JuliaupConfigSettings {
                     create_channel_symlinks: false,
                     versionsdb_update_interval: default_versionsdb_update_interval(),
-                    should_check_channel_update: true,
+                    should_check_channel_uptodate: true,
                 },
                 last_version_db_update: None,
             };

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -55,6 +55,12 @@ pub struct JuliaupConfigSettings {
         skip_serializing_if = "is_default_versionsdb_update_interval"
     )]
     pub versionsdb_update_interval: i64,
+    #[serde(
+        rename = "ShouldCheckChannelUpdate",
+        default,
+        skip_serializing_if = "is_default",
+    )]
+    pub should_check_channel_update: bool,
 }
 
 impl Default for JuliaupConfigSettings {
@@ -62,6 +68,7 @@ impl Default for JuliaupConfigSettings {
         JuliaupConfigSettings {
             create_channel_symlinks: false,
             versionsdb_update_interval: default_versionsdb_update_interval(),
+            should_check_channel_update: true,
         }
     }
 }
@@ -178,6 +185,7 @@ pub fn load_config_db(paths: &GlobalPaths) -> Result<JuliaupReadonlyConfigFile> 
                 settings: JuliaupConfigSettings {
                     create_channel_symlinks: false,
                     versionsdb_update_interval: default_versionsdb_update_interval(),
+                    should_check_channel_update: true,
                 },
                 last_version_db_update: None,
             },
@@ -274,6 +282,7 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
                 settings: JuliaupConfigSettings {
                     create_channel_symlinks: false,
                     versionsdb_update_interval: default_versionsdb_update_interval(),
+                    should_check_channel_update: true,
                 },
                 last_version_db_update: None,
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod command_config_modifypath;
 pub mod command_config_startupselfupdate;
 pub mod command_config_symlinks;
 pub mod command_config_versionsdbupdate;
-pub mod command_config_checkchannelupdate;
+pub mod command_config_checkchanneluptodate;
 pub mod command_default;
 pub mod command_gc;
 pub mod command_info;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod command_config_modifypath;
 pub mod command_config_startupselfupdate;
 pub mod command_config_symlinks;
 pub mod command_config_versionsdbupdate;
+pub mod command_config_checkchannelupdate;
 pub mod command_default;
 pub mod command_gc;
 pub mod command_info;


### PR DESCRIPTION
As mentioned in #705, the fact that `juliaup` always prints when an update for the channel in use is available, can sometimes break scripts, etc. which rely on parsing outputs from Julia scripts since this message is also printed to stdout.

This PR adds an option to the config which allows the user to specify whether or not to print the aforementioned warning/info.

I don't really program in Rust, and this was the first time in _ages_, so I probably didn't implement everything correctly :grimacing: There might also be an easier way to all of this, but I figured I'd just give it a go.