### PR TITLE
Do not error when adding an already installed channel.

### DIFF
--- a/src/command_add.rs
+++ b/src/command_add.rs
@@ -4,7 +4,7 @@ use crate::global_paths::GlobalPaths;
 use crate::operations::create_symlink;
 use crate::operations::{install_version, update_version_db};
 use crate::versions_file::load_versions_db;
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 
 pub fn run_command_add(channel: &str, paths: &GlobalPaths) -> Result<()> {
     update_version_db(paths).with_context(|| "Failed to update versions db.")?;
@@ -26,7 +26,8 @@ pub fn run_command_add(channel: &str, paths: &GlobalPaths) -> Result<()> {
         .with_context(|| "`add` command failed to load configuration data.")?;
 
     if config_file.data.installed_channels.contains_key(channel) {
-        bail!("'{}' is already installed.", &channel);
+        eprintln!("'{}' is already installed.", &channel);
+        return Ok(());
     }
 
     install_version(required_version, &mut config_file.data, &version_db, paths)?;


### PR DESCRIPTION
Make it benign to add a channel that was already installed.

Before PR:
```
julia> run(`juliaup add 1.6.7`)
Error: '1.6.7' is already installed.
ERROR: failed process: Process(`juliaup add 1.6.7`, ProcessExited(1)) [1]
```

After PR:
```
julia> run(`juliaup add 1.6.7`)
'1.6.7' is already installed.
Process(`target/debug/juliaup add 1.6.7`, ProcessExited(0))
```

Fixes #573.

Disclaimer: I have never written a single line of Rust, so anything in this small PR could potentially be wrong.
