### PR TITLE
Add .rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+tab_spaces = 4


### PR DESCRIPTION
I'm interested in adding a `.rustfmt.toml` so that autoformat on save doesn't make any unnecessary changes (my global rustfmt.toml has 2 spaces instead of 4)