### PR TITLE
Sort versions in status output in natural order.

### DIFF
--- a/src/command_status.rs
+++ b/src/command_status.rs
@@ -10,6 +10,7 @@ use cli_table::{
     format::{Border, Justify},
     print_stdout, Table, WithTitle,
 };
+use human_sort::compare;
 use itertools::Itertools;
 
 #[derive(Table)]
@@ -35,7 +36,7 @@ pub fn run_command_status(paths: &GlobalPaths) -> Result<()> {
         .data
         .installed_channels
         .iter()
-        .sorted_by_key(|i| i.0.to_string())
+        .sorted_by(|a, b| compare(&a.0.to_string(), &b.0.to_string()))
         .map(|i| -> ChannelRow {
             ChannelRow {
                 default: match config_file.data.default {


### PR DESCRIPTION
Use natural sort comparison to list versions in the expected order.

Before:
```
$ juliaup status
 Default  Channel  Version                       Update                                           
--------------------------------------------------------------------------------------------------
          0.6      0.6.4+0.x64.linux.gnu                                                          
          1.10     1.10.0-beta1+0.x64.linux.gnu  Update to 1.10.0-beta2+0.x64.linux.gnu available 
          1.6      1.6.7+0.x64.linux.gnu                                                          
          1.6.7    1.6.7+0.x64.linux.gnu                                                          
          1.7      1.7.3+0.x64.linux.gnu                                                          
          1.8      1.8.5+0.x64.linux.gnu                                                          
          1.9      1.9.2+0.x64.linux.gnu         Update to 1.9.3+0.x64.linux.gnu available        
       *  release  1.9.2+0.x64.linux.gnu         Update to 1.9.3+0.x64.linux.gnu available        
```
After:
```
$ juliaup status
 Default  Channel  Version                       Update                                           
--------------------------------------------------------------------------------------------------
          0.6      0.6.4+0.x64.linux.gnu                                                          
          1.6      1.6.7+0.x64.linux.gnu                                                          
          1.6.7    1.6.7+0.x64.linux.gnu                                                          
          1.7      1.7.3+0.x64.linux.gnu                                                          
          1.8      1.8.5+0.x64.linux.gnu                                                          
          1.9      1.9.2+0.x64.linux.gnu         Update to 1.9.3+0.x64.linux.gnu available        
          1.10     1.10.0-beta1+0.x64.linux.gnu  Update to 1.10.0-beta2+0.x64.linux.gnu available 
       *  release  1.9.2+0.x64.linux.gnu         Update to 1.9.3+0.x64.linux.gnu available       
```