### PR TITLE
Truncate exit code to u8, even if the real code doesn't fit in u8.

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -366,7 +366,9 @@ fn main() -> Result<std::process::ExitCode> {
         }
     }
 
-    let client_status: u8 = client_status?.try_into().unwrap();
+    // We truncate to the lower 8 bits, even though a Windows exit code is i32.
+    // this matches Julia's own behaviour on Unix
+    let client_status: u8 = client_status? as u8;
 
     Ok(std::process::ExitCode::from(client_status))
 }


### PR DESCRIPTION
This prevents JuliaLauncher from panicking if a user exits with an error code which doesn't fit in u8.
This is already the behaviour of Julia on Linux, where `ccall(:jl_exit)` can be called with Int32(-1), yet returns error code 255.

Closes #737 