### PR TITLE
Fix DB update when julia launcher is symlinked

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -17,7 +17,9 @@ pub struct UserError {
 
 fn get_juliaup_path() -> Result<PathBuf> {
     let my_own_path = std::env::current_exe()
-        .with_context(|| "std::env::current_exe() did not find its own path.")?;
+        .with_context(|| "std::env::current_exe() did not find its own path.")?
+        .canonicalize()
+        .with_context(|| "Failed to canonicalize the path to the Julia launcher.")?;
 
     let juliaup_path = my_own_path
         .parent()


### PR DESCRIPTION
I use a symlink `~/bin/j` which points to the `julia` launcher. Without this change, `julia` was unable to find `juliaup` and therefore fails intermittently, and I have to run `juliaup update` to fix this (which has been problematic if I don't have internet access).

The failure mode is also odd; Julia is booted before the version update, then the launcher process exits suddenly. The REPL banner shows up, but any typing causes Julia to spit out broken pipe errors in the background of my shell.

I'd argue that some of these steps should be soft errors, eg perhaps show a warning if the DB update fails, but always launch Julia if possible. But I've not attempted that larger change.