### PR TITLE
generate completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97aeaa95557bd02f23fbb662f981670c3d20c5a26e69f7354b28f57092437fcd"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +977,7 @@ dependencies = [
  "built",
  "chrono",
  "clap",
+ "clap_complete",
  "cli-table",
  "cluFlock",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ codegen-units = 1
 
 [dependencies]
 clap = { version = "4.3.19", features = ["derive"] }
+clap_complete = "4.3.19"
 dirs = "5.0.1"
 dunce = "1.0.4"
 serde = { version = "1.0.175", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Here are some of the things you can do with `juliaup`:
 - `juliaup override set --path foo/bar lts` sets a directory override for the path `foo/bar` to the `lts` channel.
 - `juliaup override unset --path foo/bar` removes a directory override for the path `foo/bar`.
 - `juliaup override unset --nonexistent` removes all directory overrides for paths that no longer exist.
+- `juliaup completions bash > ~/.local/share/bash-completion/completions/juliaup` generates Bash completions for `juliaup` and saves them to a file. To use them, simply source this file in your `~/.bashrc`. Other supported shells are `zsh`, `fish`, `elvish` and `powershell`.
 - `juliaup` shows you what other commands are available.
 
 The available system provided channels are:

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use juliaup::cli::{ConfigSubCmd, Juliaup, OverrideSubCmd, SelfSubCmd};
 use juliaup::command_api::run_command_api;
+use juliaup::command_completions::run_command_completions;
 #[cfg(not(windows))]
 use juliaup::command_config_symlinks::run_command_config_symlinks;
 use juliaup::command_config_versionsdbupdate::run_command_config_versionsdbupdate;
@@ -111,5 +112,6 @@ fn main() -> Result<()> {
             #[cfg(not(feature = "selfupdate"))]
             SelfSubCmd::Uninstall {} => run_command_selfuninstall_unavailable(),
         },
+        Juliaup::Completions { shell } => run_command_completions(&shell),
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,8 @@ pub enum Juliaup {
     Info {},
     #[clap(subcommand, name = "self")]
     SelfSubCmd(SelfSubCmd),
+    /// Generate tab-completion scripts for your shell
+    Completions { shell: String },
     // This is used for the cron jobs that we create. By using this UUID for the command
     // We can identify the cron jobs that were created by juliaup for uninstall purposes
     #[cfg(feature = "selfupdate")]

--- a/src/command_completions.rs
+++ b/src/command_completions.rs
@@ -1,0 +1,22 @@
+use crate::cli;
+use anyhow::bail;
+use anyhow::Result;
+use clap::CommandFactory;
+use clap_complete::Shell;
+use cli::Juliaup;
+use std::io;
+use std::str::FromStr;
+
+pub fn run_command_completions(shell: &str) -> Result<()> {
+    if let Ok(shell) = Shell::from_str(shell) {
+        clap_complete::generate(
+            shell,
+            &mut Juliaup::command(),
+            "juliaup",
+            &mut io::stdout().lock(),
+        );
+    } else {
+        bail!("'{}' is not a supported shell.", shell)
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use anyhow::Context;
 pub mod cli;
 pub mod command_add;
 pub mod command_api;
+pub mod command_completions;
 pub mod command_config_backgroundselfupdate;
 pub mod command_config_modifypath;
 pub mod command_config_startupselfupdate;


### PR DESCRIPTION
EDIT:
This is done now. It solves https://github.com/JuliaLang/juliaup/issues/151. It works the same way as it does in rustup. https://rust-lang.github.io/rustup/installation/index.html

OLD MESSAGE:
> This is some starting effort that can eventually solve https://github.com/JuliaLang/juliaup/issues/151.
> I don't know how the build files are being packaged for the different distributions and operating systems. I'm asking for feedback in this regard.
> 
> What happens now:
> Every time the package is build the completions for the different shells are generated and put into the build directory `target/release/build/juliaup-<somehexstring>/out/`.
> 
> What is left to do:
> Add the completions to the packages so that they are available after installing juliaup.