### PR TITLE
fix musl versiondb links and generator

### DIFF
--- a/scripts/versiondb/updateversiondb.jl
+++ b/scripts/versiondb/updateversiondb.jl
@@ -29,6 +29,12 @@ function triplet2channel(triplet)
         "x86"
     elseif triplet=="aarch64-linux-gnu"
         "aarch64"
+    elseif triplet=="x86_64-linux-musl"
+        "x64"
+    elseif triplet=="i686-linux-musl"
+        "x86"
+    elseif triplet=="aarch64-linux-musl"
+        "aarch64"
     else
         error("Unknown platform.")
     end
@@ -59,11 +65,11 @@ function get_available_versions(data, platform)
     elseif platform=="aarch64-unknown-linux-gnu"
         ["aarch64-linux-gnu"]
     elseif platform=="x86_64-unknown-linux-musl"
-        ["x86_64-linux-gnu", "i686-linux-gnu"]
+        ["x86_64-linux-musl", "i686-linux-musl"]
     elseif platform=="i686-unknown-linux-musl"
-        ["i686-linux-gnu"]
+        ["i686-linux-musl"]
     elseif platform=="aarch64-unknown-linux-musl"
-        ["aarch64-linux-gnu"]
+        ["aarch64-linux-musl"]
     else
         error("Unknown platform.")
     end

--- a/versiondb/versiondb-aarch64-unknown-linux-musl.json
+++ b/versiondb/versiondb-aarch64-unknown-linux-musl.json
@@ -1,918 +1,918 @@
 {
     "AvailableVersions": {
-        "0.6.1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/0.6/julia-0.6.1-linux-aarch64.tar.gz"
+        "0.6.1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/0.6/julia-0.6.1-musl-aarch64.tar.gz"
         },
-        "0.6.2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/0.6/julia-0.6.2-linux-aarch64.tar.gz"
+        "0.6.2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/0.6/julia-0.6.2-musl-aarch64.tar.gz"
         },
-        "0.6.3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/0.6/julia-0.6.3-linux-aarch64.tar.gz"
+        "0.6.3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/0.6/julia-0.6.3-musl-aarch64.tar.gz"
         },
-        "1.0.3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.0/julia-1.0.3-linux-aarch64.tar.gz"
+        "1.0.3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.0/julia-1.0.3-musl-aarch64.tar.gz"
         },
-        "1.0.4+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.0/julia-1.0.4-linux-aarch64.tar.gz"
+        "1.0.4+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.0/julia-1.0.4-musl-aarch64.tar.gz"
         },
-        "1.0.5+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.0/julia-1.0.5-linux-aarch64.tar.gz"
+        "1.0.5+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.0/julia-1.0.5-musl-aarch64.tar.gz"
         },
-        "1.1.0+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.1/julia-1.1.0-linux-aarch64.tar.gz"
+        "1.1.0+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.1/julia-1.1.0-musl-aarch64.tar.gz"
         },
-        "1.1.1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.1/julia-1.1.1-linux-aarch64.tar.gz"
+        "1.1.1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.1/julia-1.1.1-musl-aarch64.tar.gz"
         },
-        "1.2.0-rc1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.2/julia-1.2.0-rc1-linux-aarch64.tar.gz"
+        "1.2.0-rc1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.2/julia-1.2.0-rc1-musl-aarch64.tar.gz"
         },
-        "1.2.0-rc2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.2/julia-1.2.0-rc2-linux-aarch64.tar.gz"
+        "1.2.0-rc2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.2/julia-1.2.0-rc2-musl-aarch64.tar.gz"
         },
-        "1.2.0-rc3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.2/julia-1.2.0-rc3-linux-aarch64.tar.gz"
+        "1.2.0-rc3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.2/julia-1.2.0-rc3-musl-aarch64.tar.gz"
         },
-        "1.2.0+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.2/julia-1.2.0-linux-aarch64.tar.gz"
+        "1.2.0+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.2/julia-1.2.0-musl-aarch64.tar.gz"
         },
-        "1.3.0-alpha+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.3/julia-1.3.0-alpha-linux-aarch64.tar.gz"
+        "1.3.0-alpha+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.3/julia-1.3.0-alpha-musl-aarch64.tar.gz"
         },
-        "1.3.0-rc1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.3/julia-1.3.0-rc1-linux-aarch64.tar.gz"
+        "1.3.0-rc1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.3/julia-1.3.0-rc1-musl-aarch64.tar.gz"
         },
-        "1.3.0-rc2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.3/julia-1.3.0-rc2-linux-aarch64.tar.gz"
+        "1.3.0-rc2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.3/julia-1.3.0-rc2-musl-aarch64.tar.gz"
         },
-        "1.3.0-rc3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.3/julia-1.3.0-rc3-linux-aarch64.tar.gz"
+        "1.3.0-rc3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.3/julia-1.3.0-rc3-musl-aarch64.tar.gz"
         },
-        "1.3.0-rc4+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.3/julia-1.3.0-rc4-linux-aarch64.tar.gz"
+        "1.3.0-rc4+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.3/julia-1.3.0-rc4-musl-aarch64.tar.gz"
         },
-        "1.3.0-rc5+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.3/julia-1.3.0-rc5-linux-aarch64.tar.gz"
+        "1.3.0-rc5+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.3/julia-1.3.0-rc5-musl-aarch64.tar.gz"
         },
-        "1.3.0+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.3/julia-1.3.0-linux-aarch64.tar.gz"
+        "1.3.0+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.3/julia-1.3.0-musl-aarch64.tar.gz"
         },
-        "1.3.1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.3/julia-1.3.1-linux-aarch64.tar.gz"
+        "1.3.1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.3/julia-1.3.1-musl-aarch64.tar.gz"
         },
-        "1.4.0-rc1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.4/julia-1.4.0-rc1-linux-aarch64.tar.gz"
+        "1.4.0-rc1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.4/julia-1.4.0-rc1-musl-aarch64.tar.gz"
         },
-        "1.4.0-rc2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.4/julia-1.4.0-rc2-linux-aarch64.tar.gz"
+        "1.4.0-rc2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.4/julia-1.4.0-rc2-musl-aarch64.tar.gz"
         },
-        "1.4.0+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.4/julia-1.4.0-linux-aarch64.tar.gz"
+        "1.4.0+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.4/julia-1.4.0-musl-aarch64.tar.gz"
         },
-        "1.4.1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.4/julia-1.4.1-linux-aarch64.tar.gz"
+        "1.4.1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.4/julia-1.4.1-musl-aarch64.tar.gz"
         },
-        "1.4.2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.4/julia-1.4.2-linux-aarch64.tar.gz"
+        "1.4.2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.4/julia-1.4.2-musl-aarch64.tar.gz"
         },
-        "1.5.0-beta1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.5/julia-1.5.0-beta1-linux-aarch64.tar.gz"
+        "1.5.0-beta1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.5/julia-1.5.0-beta1-musl-aarch64.tar.gz"
         },
-        "1.5.0-rc1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.5/julia-1.5.0-rc1-linux-aarch64.tar.gz"
+        "1.5.0-rc1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.5/julia-1.5.0-rc1-musl-aarch64.tar.gz"
         },
-        "1.5.0-rc2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.5/julia-1.5.0-rc2-linux-aarch64.tar.gz"
+        "1.5.0-rc2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.5/julia-1.5.0-rc2-musl-aarch64.tar.gz"
         },
-        "1.5.0+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.5/julia-1.5.0-linux-aarch64.tar.gz"
+        "1.5.0+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.5/julia-1.5.0-musl-aarch64.tar.gz"
         },
-        "1.5.1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.5/julia-1.5.1-linux-aarch64.tar.gz"
+        "1.5.1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.5/julia-1.5.1-musl-aarch64.tar.gz"
         },
-        "1.5.2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.5/julia-1.5.2-linux-aarch64.tar.gz"
+        "1.5.2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.5/julia-1.5.2-musl-aarch64.tar.gz"
         },
-        "1.5.3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.5/julia-1.5.3-linux-aarch64.tar.gz"
+        "1.5.3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.5/julia-1.5.3-musl-aarch64.tar.gz"
         },
-        "1.5.4+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.5/julia-1.5.4-linux-aarch64.tar.gz"
+        "1.5.4+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.5/julia-1.5.4-musl-aarch64.tar.gz"
         },
-        "1.6.0-beta1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.0-beta1-linux-aarch64.tar.gz"
+        "1.6.0-beta1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.0-beta1-musl-aarch64.tar.gz"
         },
-        "1.6.0-rc1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.0-rc1-linux-aarch64.tar.gz"
+        "1.6.0-rc1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.0-rc1-musl-aarch64.tar.gz"
         },
-        "1.6.0-rc2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.0-rc2-linux-aarch64.tar.gz"
+        "1.6.0-rc2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.0-rc2-musl-aarch64.tar.gz"
         },
-        "1.6.0-rc3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.0-rc3-linux-aarch64.tar.gz"
+        "1.6.0-rc3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.0-rc3-musl-aarch64.tar.gz"
         },
-        "1.6.0+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.0-linux-aarch64.tar.gz"
+        "1.6.0+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.0-musl-aarch64.tar.gz"
         },
-        "1.6.1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.1-linux-aarch64.tar.gz"
+        "1.6.1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.1-musl-aarch64.tar.gz"
         },
-        "1.6.2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.2-linux-aarch64.tar.gz"
+        "1.6.2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.2-musl-aarch64.tar.gz"
         },
-        "1.6.3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.3-linux-aarch64.tar.gz"
+        "1.6.3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.3-musl-aarch64.tar.gz"
         },
-        "1.6.4+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.4-linux-aarch64.tar.gz"
+        "1.6.4+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.4-musl-aarch64.tar.gz"
         },
-        "1.6.5+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.5-linux-aarch64.tar.gz"
+        "1.6.5+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.5-musl-aarch64.tar.gz"
         },
-        "1.6.6+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.6-linux-aarch64.tar.gz"
+        "1.6.6+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.6-musl-aarch64.tar.gz"
         },
-        "1.6.7+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.6/julia-1.6.7-linux-aarch64.tar.gz"
+        "1.6.7+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.6/julia-1.6.7-musl-aarch64.tar.gz"
         },
-        "1.7.0-beta1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.7/julia-1.7.0-beta1-linux-aarch64.tar.gz"
+        "1.7.0-beta1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.7/julia-1.7.0-beta1-musl-aarch64.tar.gz"
         },
-        "1.7.0-beta2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.7/julia-1.7.0-beta2-linux-aarch64.tar.gz"
+        "1.7.0-beta2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.7/julia-1.7.0-beta2-musl-aarch64.tar.gz"
         },
-        "1.7.0-beta3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.7/julia-1.7.0-beta3-linux-aarch64.tar.gz"
+        "1.7.0-beta3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.7/julia-1.7.0-beta3-musl-aarch64.tar.gz"
         },
-        "1.7.0-beta4+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.7/julia-1.7.0-beta4-linux-aarch64.tar.gz"
+        "1.7.0-beta4+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.7/julia-1.7.0-beta4-musl-aarch64.tar.gz"
         },
-        "1.7.0-rc1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.7/julia-1.7.0-rc1-linux-aarch64.tar.gz"
+        "1.7.0-rc1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.7/julia-1.7.0-rc1-musl-aarch64.tar.gz"
         },
-        "1.7.0-rc2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.7/julia-1.7.0-rc2-linux-aarch64.tar.gz"
+        "1.7.0-rc2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.7/julia-1.7.0-rc2-musl-aarch64.tar.gz"
         },
-        "1.7.0-rc3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.7/julia-1.7.0-rc3-linux-aarch64.tar.gz"
+        "1.7.0-rc3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.7/julia-1.7.0-rc3-musl-aarch64.tar.gz"
         },
-        "1.7.0+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.7/julia-1.7.0-linux-aarch64.tar.gz"
+        "1.7.0+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.7/julia-1.7.0-musl-aarch64.tar.gz"
         },
-        "1.7.1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.7/julia-1.7.1-linux-aarch64.tar.gz"
+        "1.7.1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.7/julia-1.7.1-musl-aarch64.tar.gz"
         },
-        "1.7.2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.7/julia-1.7.2-linux-aarch64.tar.gz"
+        "1.7.2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.7/julia-1.7.2-musl-aarch64.tar.gz"
         },
-        "1.7.3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.7/julia-1.7.3-linux-aarch64.tar.gz"
+        "1.7.3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.7/julia-1.7.3-musl-aarch64.tar.gz"
         },
-        "1.8.0-beta1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.0-beta1-linux-aarch64.tar.gz"
+        "1.8.0-beta1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.0-beta1-musl-aarch64.tar.gz"
         },
-        "1.8.0-beta2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.0-beta2-linux-aarch64.tar.gz"
+        "1.8.0-beta2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.0-beta2-musl-aarch64.tar.gz"
         },
-        "1.8.0-beta3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.0-beta3-linux-aarch64.tar.gz"
+        "1.8.0-beta3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.0-beta3-musl-aarch64.tar.gz"
         },
-        "1.8.0-rc1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.0-rc1-linux-aarch64.tar.gz"
+        "1.8.0-rc1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.0-rc1-musl-aarch64.tar.gz"
         },
-        "1.8.0-rc2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.0-rc2-linux-aarch64.tar.gz"
+        "1.8.0-rc2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.0-rc2-musl-aarch64.tar.gz"
         },
-        "1.8.0-rc3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.0-rc3-linux-aarch64.tar.gz"
+        "1.8.0-rc3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.0-rc3-musl-aarch64.tar.gz"
         },
-        "1.8.0-rc4+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.0-rc4-linux-aarch64.tar.gz"
+        "1.8.0-rc4+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.0-rc4-musl-aarch64.tar.gz"
         },
-        "1.8.0+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.0-linux-aarch64.tar.gz"
+        "1.8.0+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.0-musl-aarch64.tar.gz"
         },
-        "1.8.1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.1-linux-aarch64.tar.gz"
+        "1.8.1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.1-musl-aarch64.tar.gz"
         },
-        "1.8.2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.2-linux-aarch64.tar.gz"
+        "1.8.2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.2-musl-aarch64.tar.gz"
         },
-        "1.8.3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.3-linux-aarch64.tar.gz"
+        "1.8.3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.3-musl-aarch64.tar.gz"
         },
-        "1.8.4+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.4-linux-aarch64.tar.gz"
+        "1.8.4+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.4-musl-aarch64.tar.gz"
         },
-        "1.8.5+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.8/julia-1.8.5-linux-aarch64.tar.gz"
+        "1.8.5+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.8/julia-1.8.5-musl-aarch64.tar.gz"
         },
-        "1.9.0-alpha1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.0-alpha1-linux-aarch64.tar.gz"
+        "1.9.0-alpha1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.0-alpha1-musl-aarch64.tar.gz"
         },
-        "1.9.0-beta1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.0-beta1-linux-aarch64.tar.gz"
+        "1.9.0-beta1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.0-beta1-musl-aarch64.tar.gz"
         },
-        "1.9.0-beta2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.0-beta2-linux-aarch64.tar.gz"
+        "1.9.0-beta2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.0-beta2-musl-aarch64.tar.gz"
         },
-        "1.9.0-beta3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.0-beta3-linux-aarch64.tar.gz"
+        "1.9.0-beta3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.0-beta3-musl-aarch64.tar.gz"
         },
-        "1.9.0-beta4+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.0-beta4-linux-aarch64.tar.gz"
+        "1.9.0-beta4+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.0-beta4-musl-aarch64.tar.gz"
         },
-        "1.9.0-rc1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.0-rc1-linux-aarch64.tar.gz"
+        "1.9.0-rc1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.0-rc1-musl-aarch64.tar.gz"
         },
-        "1.9.0-rc2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.0-rc2-linux-aarch64.tar.gz"
+        "1.9.0-rc2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.0-rc2-musl-aarch64.tar.gz"
         },
-        "1.9.0-rc3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.0-rc3-linux-aarch64.tar.gz"
+        "1.9.0-rc3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.0-rc3-musl-aarch64.tar.gz"
         },
-        "1.9.0+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.0-linux-aarch64.tar.gz"
+        "1.9.0+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.0-musl-aarch64.tar.gz"
         },
-        "1.9.1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.1-linux-aarch64.tar.gz"
+        "1.9.1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.1-musl-aarch64.tar.gz"
         },
-        "1.9.2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.2-linux-aarch64.tar.gz"
+        "1.9.2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.2-musl-aarch64.tar.gz"
         },
-        "1.9.3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.3-linux-aarch64.tar.gz"
+        "1.9.3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.3-musl-aarch64.tar.gz"
         },
-        "1.9.4+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.9/julia-1.9.4-linux-aarch64.tar.gz"
+        "1.9.4+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.9/julia-1.9.4-musl-aarch64.tar.gz"
         },
-        "1.10.0-alpha1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.10/julia-1.10.0-alpha1-linux-aarch64.tar.gz"
+        "1.10.0-alpha1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.10/julia-1.10.0-alpha1-musl-aarch64.tar.gz"
         },
-        "1.10.0-beta1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.10/julia-1.10.0-beta1-linux-aarch64.tar.gz"
+        "1.10.0-beta1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.10/julia-1.10.0-beta1-musl-aarch64.tar.gz"
         },
-        "1.10.0-beta2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.10/julia-1.10.0-beta2-linux-aarch64.tar.gz"
+        "1.10.0-beta2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.10/julia-1.10.0-beta2-musl-aarch64.tar.gz"
         },
-        "1.10.0-beta3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.10/julia-1.10.0-beta3-linux-aarch64.tar.gz"
+        "1.10.0-beta3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.10/julia-1.10.0-beta3-musl-aarch64.tar.gz"
         },
-        "1.10.0-rc1+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.10/julia-1.10.0-rc1-linux-aarch64.tar.gz"
+        "1.10.0-rc1+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.10/julia-1.10.0-rc1-musl-aarch64.tar.gz"
         },
-        "1.10.0-rc2+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.10/julia-1.10.0-rc2-linux-aarch64.tar.gz"
+        "1.10.0-rc2+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.10/julia-1.10.0-rc2-musl-aarch64.tar.gz"
         },
-        "1.10.0-rc3+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.10/julia-1.10.0-rc3-linux-aarch64.tar.gz"
+        "1.10.0-rc3+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.10/julia-1.10.0-rc3-musl-aarch64.tar.gz"
         },
-        "1.10.0+0.aarch64.linux.gnu": {
-            "UrlPath": "bin/linux/aarch64/1.10/julia-1.10.0-linux-aarch64.tar.gz"
+        "1.10.0+0.aarch64.linux.musl": {
+            "UrlPath": "bin/musl/aarch64/1.10/julia-1.10.0-musl-aarch64.tar.gz"
         }
     },
     "AvailableChannels": {
         "0.6.1": {
-            "Version": "0.6.1+0.aarch64.linux.gnu"
+            "Version": "0.6.1+0.aarch64.linux.musl"
         },
         "0.6.1~aarch64": {
-            "Version": "0.6.1+0.aarch64.linux.gnu"
+            "Version": "0.6.1+0.aarch64.linux.musl"
         },
         "0.6.2": {
-            "Version": "0.6.2+0.aarch64.linux.gnu"
+            "Version": "0.6.2+0.aarch64.linux.musl"
         },
         "0.6.2~aarch64": {
-            "Version": "0.6.2+0.aarch64.linux.gnu"
+            "Version": "0.6.2+0.aarch64.linux.musl"
         },
         "0.6.3": {
-            "Version": "0.6.3+0.aarch64.linux.gnu"
+            "Version": "0.6.3+0.aarch64.linux.musl"
         },
         "0.6.3~aarch64": {
-            "Version": "0.6.3+0.aarch64.linux.gnu"
+            "Version": "0.6.3+0.aarch64.linux.musl"
         },
         "1": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "1.0": {
-            "Version": "1.0.5+0.aarch64.linux.gnu"
+            "Version": "1.0.5+0.aarch64.linux.musl"
         },
         "1.0.3": {
-            "Version": "1.0.3+0.aarch64.linux.gnu"
+            "Version": "1.0.3+0.aarch64.linux.musl"
         },
         "1.0.3~aarch64": {
-            "Version": "1.0.3+0.aarch64.linux.gnu"
+            "Version": "1.0.3+0.aarch64.linux.musl"
         },
         "1.0.4": {
-            "Version": "1.0.4+0.aarch64.linux.gnu"
+            "Version": "1.0.4+0.aarch64.linux.musl"
         },
         "1.0.4~aarch64": {
-            "Version": "1.0.4+0.aarch64.linux.gnu"
+            "Version": "1.0.4+0.aarch64.linux.musl"
         },
         "1.0.5": {
-            "Version": "1.0.5+0.aarch64.linux.gnu"
+            "Version": "1.0.5+0.aarch64.linux.musl"
         },
         "1.0.5~aarch64": {
-            "Version": "1.0.5+0.aarch64.linux.gnu"
+            "Version": "1.0.5+0.aarch64.linux.musl"
         },
         "1.0~aarch64": {
-            "Version": "1.0.5+0.aarch64.linux.gnu"
+            "Version": "1.0.5+0.aarch64.linux.musl"
         },
         "1.1": {
-            "Version": "1.1.1+0.aarch64.linux.gnu"
+            "Version": "1.1.1+0.aarch64.linux.musl"
         },
         "1.1.0": {
-            "Version": "1.1.0+0.aarch64.linux.gnu"
+            "Version": "1.1.0+0.aarch64.linux.musl"
         },
         "1.1.0~aarch64": {
-            "Version": "1.1.0+0.aarch64.linux.gnu"
+            "Version": "1.1.0+0.aarch64.linux.musl"
         },
         "1.1.1": {
-            "Version": "1.1.1+0.aarch64.linux.gnu"
+            "Version": "1.1.1+0.aarch64.linux.musl"
         },
         "1.1.1~aarch64": {
-            "Version": "1.1.1+0.aarch64.linux.gnu"
+            "Version": "1.1.1+0.aarch64.linux.musl"
         },
         "1.10": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "1.10.0": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "1.10.0-alpha1": {
-            "Version": "1.10.0-alpha1+0.aarch64.linux.gnu"
+            "Version": "1.10.0-alpha1+0.aarch64.linux.musl"
         },
         "1.10.0-alpha1~aarch64": {
-            "Version": "1.10.0-alpha1+0.aarch64.linux.gnu"
+            "Version": "1.10.0-alpha1+0.aarch64.linux.musl"
         },
         "1.10.0-beta1": {
-            "Version": "1.10.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.10.0-beta1+0.aarch64.linux.musl"
         },
         "1.10.0-beta1~aarch64": {
-            "Version": "1.10.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.10.0-beta1+0.aarch64.linux.musl"
         },
         "1.10.0-beta2": {
-            "Version": "1.10.0-beta2+0.aarch64.linux.gnu"
+            "Version": "1.10.0-beta2+0.aarch64.linux.musl"
         },
         "1.10.0-beta2~aarch64": {
-            "Version": "1.10.0-beta2+0.aarch64.linux.gnu"
+            "Version": "1.10.0-beta2+0.aarch64.linux.musl"
         },
         "1.10.0-beta3": {
-            "Version": "1.10.0-beta3+0.aarch64.linux.gnu"
+            "Version": "1.10.0-beta3+0.aarch64.linux.musl"
         },
         "1.10.0-beta3~aarch64": {
-            "Version": "1.10.0-beta3+0.aarch64.linux.gnu"
+            "Version": "1.10.0-beta3+0.aarch64.linux.musl"
         },
         "1.10.0-rc1": {
-            "Version": "1.10.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.10.0-rc1+0.aarch64.linux.musl"
         },
         "1.10.0-rc1~aarch64": {
-            "Version": "1.10.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.10.0-rc1+0.aarch64.linux.musl"
         },
         "1.10.0-rc2": {
-            "Version": "1.10.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.10.0-rc2+0.aarch64.linux.musl"
         },
         "1.10.0-rc2~aarch64": {
-            "Version": "1.10.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.10.0-rc2+0.aarch64.linux.musl"
         },
         "1.10.0-rc3": {
-            "Version": "1.10.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.10.0-rc3+0.aarch64.linux.musl"
         },
         "1.10.0-rc3~aarch64": {
-            "Version": "1.10.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.10.0-rc3+0.aarch64.linux.musl"
         },
         "1.10.0~aarch64": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "1.10~aarch64": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "1.1~aarch64": {
-            "Version": "1.1.1+0.aarch64.linux.gnu"
+            "Version": "1.1.1+0.aarch64.linux.musl"
         },
         "1.2": {
-            "Version": "1.2.0+0.aarch64.linux.gnu"
+            "Version": "1.2.0+0.aarch64.linux.musl"
         },
         "1.2.0": {
-            "Version": "1.2.0+0.aarch64.linux.gnu"
+            "Version": "1.2.0+0.aarch64.linux.musl"
         },
         "1.2.0-rc1": {
-            "Version": "1.2.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.2.0-rc1+0.aarch64.linux.musl"
         },
         "1.2.0-rc1~aarch64": {
-            "Version": "1.2.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.2.0-rc1+0.aarch64.linux.musl"
         },
         "1.2.0-rc2": {
-            "Version": "1.2.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.2.0-rc2+0.aarch64.linux.musl"
         },
         "1.2.0-rc2~aarch64": {
-            "Version": "1.2.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.2.0-rc2+0.aarch64.linux.musl"
         },
         "1.2.0-rc3": {
-            "Version": "1.2.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.2.0-rc3+0.aarch64.linux.musl"
         },
         "1.2.0-rc3~aarch64": {
-            "Version": "1.2.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.2.0-rc3+0.aarch64.linux.musl"
         },
         "1.2.0~aarch64": {
-            "Version": "1.2.0+0.aarch64.linux.gnu"
+            "Version": "1.2.0+0.aarch64.linux.musl"
         },
         "1.2~aarch64": {
-            "Version": "1.2.0+0.aarch64.linux.gnu"
+            "Version": "1.2.0+0.aarch64.linux.musl"
         },
         "1.3": {
-            "Version": "1.3.1+0.aarch64.linux.gnu"
+            "Version": "1.3.1+0.aarch64.linux.musl"
         },
         "1.3.0": {
-            "Version": "1.3.0+0.aarch64.linux.gnu"
+            "Version": "1.3.0+0.aarch64.linux.musl"
         },
         "1.3.0-alpha": {
-            "Version": "1.3.0-alpha+0.aarch64.linux.gnu"
+            "Version": "1.3.0-alpha+0.aarch64.linux.musl"
         },
         "1.3.0-alpha~aarch64": {
-            "Version": "1.3.0-alpha+0.aarch64.linux.gnu"
+            "Version": "1.3.0-alpha+0.aarch64.linux.musl"
         },
         "1.3.0-rc1": {
-            "Version": "1.3.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.3.0-rc1+0.aarch64.linux.musl"
         },
         "1.3.0-rc1~aarch64": {
-            "Version": "1.3.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.3.0-rc1+0.aarch64.linux.musl"
         },
         "1.3.0-rc2": {
-            "Version": "1.3.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.3.0-rc2+0.aarch64.linux.musl"
         },
         "1.3.0-rc2~aarch64": {
-            "Version": "1.3.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.3.0-rc2+0.aarch64.linux.musl"
         },
         "1.3.0-rc3": {
-            "Version": "1.3.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.3.0-rc3+0.aarch64.linux.musl"
         },
         "1.3.0-rc3~aarch64": {
-            "Version": "1.3.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.3.0-rc3+0.aarch64.linux.musl"
         },
         "1.3.0-rc4": {
-            "Version": "1.3.0-rc4+0.aarch64.linux.gnu"
+            "Version": "1.3.0-rc4+0.aarch64.linux.musl"
         },
         "1.3.0-rc4~aarch64": {
-            "Version": "1.3.0-rc4+0.aarch64.linux.gnu"
+            "Version": "1.3.0-rc4+0.aarch64.linux.musl"
         },
         "1.3.0-rc5": {
-            "Version": "1.3.0-rc5+0.aarch64.linux.gnu"
+            "Version": "1.3.0-rc5+0.aarch64.linux.musl"
         },
         "1.3.0-rc5~aarch64": {
-            "Version": "1.3.0-rc5+0.aarch64.linux.gnu"
+            "Version": "1.3.0-rc5+0.aarch64.linux.musl"
         },
         "1.3.0~aarch64": {
-            "Version": "1.3.0+0.aarch64.linux.gnu"
+            "Version": "1.3.0+0.aarch64.linux.musl"
         },
         "1.3.1": {
-            "Version": "1.3.1+0.aarch64.linux.gnu"
+            "Version": "1.3.1+0.aarch64.linux.musl"
         },
         "1.3.1~aarch64": {
-            "Version": "1.3.1+0.aarch64.linux.gnu"
+            "Version": "1.3.1+0.aarch64.linux.musl"
         },
         "1.3~aarch64": {
-            "Version": "1.3.1+0.aarch64.linux.gnu"
+            "Version": "1.3.1+0.aarch64.linux.musl"
         },
         "1.4": {
-            "Version": "1.4.2+0.aarch64.linux.gnu"
+            "Version": "1.4.2+0.aarch64.linux.musl"
         },
         "1.4.0": {
-            "Version": "1.4.0+0.aarch64.linux.gnu"
+            "Version": "1.4.0+0.aarch64.linux.musl"
         },
         "1.4.0-rc1": {
-            "Version": "1.4.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.4.0-rc1+0.aarch64.linux.musl"
         },
         "1.4.0-rc1~aarch64": {
-            "Version": "1.4.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.4.0-rc1+0.aarch64.linux.musl"
         },
         "1.4.0-rc2": {
-            "Version": "1.4.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.4.0-rc2+0.aarch64.linux.musl"
         },
         "1.4.0-rc2~aarch64": {
-            "Version": "1.4.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.4.0-rc2+0.aarch64.linux.musl"
         },
         "1.4.0~aarch64": {
-            "Version": "1.4.0+0.aarch64.linux.gnu"
+            "Version": "1.4.0+0.aarch64.linux.musl"
         },
         "1.4.1": {
-            "Version": "1.4.1+0.aarch64.linux.gnu"
+            "Version": "1.4.1+0.aarch64.linux.musl"
         },
         "1.4.1~aarch64": {
-            "Version": "1.4.1+0.aarch64.linux.gnu"
+            "Version": "1.4.1+0.aarch64.linux.musl"
         },
         "1.4.2": {
-            "Version": "1.4.2+0.aarch64.linux.gnu"
+            "Version": "1.4.2+0.aarch64.linux.musl"
         },
         "1.4.2~aarch64": {
-            "Version": "1.4.2+0.aarch64.linux.gnu"
+            "Version": "1.4.2+0.aarch64.linux.musl"
         },
         "1.4~aarch64": {
-            "Version": "1.4.2+0.aarch64.linux.gnu"
+            "Version": "1.4.2+0.aarch64.linux.musl"
         },
         "1.5": {
-            "Version": "1.5.4+0.aarch64.linux.gnu"
+            "Version": "1.5.4+0.aarch64.linux.musl"
         },
         "1.5.0": {
-            "Version": "1.5.0+0.aarch64.linux.gnu"
+            "Version": "1.5.0+0.aarch64.linux.musl"
         },
         "1.5.0-beta1": {
-            "Version": "1.5.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.5.0-beta1+0.aarch64.linux.musl"
         },
         "1.5.0-beta1~aarch64": {
-            "Version": "1.5.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.5.0-beta1+0.aarch64.linux.musl"
         },
         "1.5.0-rc1": {
-            "Version": "1.5.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.5.0-rc1+0.aarch64.linux.musl"
         },
         "1.5.0-rc1~aarch64": {
-            "Version": "1.5.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.5.0-rc1+0.aarch64.linux.musl"
         },
         "1.5.0-rc2": {
-            "Version": "1.5.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.5.0-rc2+0.aarch64.linux.musl"
         },
         "1.5.0-rc2~aarch64": {
-            "Version": "1.5.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.5.0-rc2+0.aarch64.linux.musl"
         },
         "1.5.0~aarch64": {
-            "Version": "1.5.0+0.aarch64.linux.gnu"
+            "Version": "1.5.0+0.aarch64.linux.musl"
         },
         "1.5.1": {
-            "Version": "1.5.1+0.aarch64.linux.gnu"
+            "Version": "1.5.1+0.aarch64.linux.musl"
         },
         "1.5.1~aarch64": {
-            "Version": "1.5.1+0.aarch64.linux.gnu"
+            "Version": "1.5.1+0.aarch64.linux.musl"
         },
         "1.5.2": {
-            "Version": "1.5.2+0.aarch64.linux.gnu"
+            "Version": "1.5.2+0.aarch64.linux.musl"
         },
         "1.5.2~aarch64": {
-            "Version": "1.5.2+0.aarch64.linux.gnu"
+            "Version": "1.5.2+0.aarch64.linux.musl"
         },
         "1.5.3": {
-            "Version": "1.5.3+0.aarch64.linux.gnu"
+            "Version": "1.5.3+0.aarch64.linux.musl"
         },
         "1.5.3~aarch64": {
-            "Version": "1.5.3+0.aarch64.linux.gnu"
+            "Version": "1.5.3+0.aarch64.linux.musl"
         },
         "1.5.4": {
-            "Version": "1.5.4+0.aarch64.linux.gnu"
+            "Version": "1.5.4+0.aarch64.linux.musl"
         },
         "1.5.4~aarch64": {
-            "Version": "1.5.4+0.aarch64.linux.gnu"
+            "Version": "1.5.4+0.aarch64.linux.musl"
         },
         "1.5~aarch64": {
-            "Version": "1.5.4+0.aarch64.linux.gnu"
+            "Version": "1.5.4+0.aarch64.linux.musl"
         },
         "1.6": {
-            "Version": "1.6.7+0.aarch64.linux.gnu"
+            "Version": "1.6.7+0.aarch64.linux.musl"
         },
         "1.6.0": {
-            "Version": "1.6.0+0.aarch64.linux.gnu"
+            "Version": "1.6.0+0.aarch64.linux.musl"
         },
         "1.6.0-beta1": {
-            "Version": "1.6.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.6.0-beta1+0.aarch64.linux.musl"
         },
         "1.6.0-beta1~aarch64": {
-            "Version": "1.6.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.6.0-beta1+0.aarch64.linux.musl"
         },
         "1.6.0-rc1": {
-            "Version": "1.6.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.6.0-rc1+0.aarch64.linux.musl"
         },
         "1.6.0-rc1~aarch64": {
-            "Version": "1.6.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.6.0-rc1+0.aarch64.linux.musl"
         },
         "1.6.0-rc2": {
-            "Version": "1.6.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.6.0-rc2+0.aarch64.linux.musl"
         },
         "1.6.0-rc2~aarch64": {
-            "Version": "1.6.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.6.0-rc2+0.aarch64.linux.musl"
         },
         "1.6.0-rc3": {
-            "Version": "1.6.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.6.0-rc3+0.aarch64.linux.musl"
         },
         "1.6.0-rc3~aarch64": {
-            "Version": "1.6.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.6.0-rc3+0.aarch64.linux.musl"
         },
         "1.6.0~aarch64": {
-            "Version": "1.6.0+0.aarch64.linux.gnu"
+            "Version": "1.6.0+0.aarch64.linux.musl"
         },
         "1.6.1": {
-            "Version": "1.6.1+0.aarch64.linux.gnu"
+            "Version": "1.6.1+0.aarch64.linux.musl"
         },
         "1.6.1~aarch64": {
-            "Version": "1.6.1+0.aarch64.linux.gnu"
+            "Version": "1.6.1+0.aarch64.linux.musl"
         },
         "1.6.2": {
-            "Version": "1.6.2+0.aarch64.linux.gnu"
+            "Version": "1.6.2+0.aarch64.linux.musl"
         },
         "1.6.2~aarch64": {
-            "Version": "1.6.2+0.aarch64.linux.gnu"
+            "Version": "1.6.2+0.aarch64.linux.musl"
         },
         "1.6.3": {
-            "Version": "1.6.3+0.aarch64.linux.gnu"
+            "Version": "1.6.3+0.aarch64.linux.musl"
         },
         "1.6.3~aarch64": {
-            "Version": "1.6.3+0.aarch64.linux.gnu"
+            "Version": "1.6.3+0.aarch64.linux.musl"
         },
         "1.6.4": {
-            "Version": "1.6.4+0.aarch64.linux.gnu"
+            "Version": "1.6.4+0.aarch64.linux.musl"
         },
         "1.6.4~aarch64": {
-            "Version": "1.6.4+0.aarch64.linux.gnu"
+            "Version": "1.6.4+0.aarch64.linux.musl"
         },
         "1.6.5": {
-            "Version": "1.6.5+0.aarch64.linux.gnu"
+            "Version": "1.6.5+0.aarch64.linux.musl"
         },
         "1.6.5~aarch64": {
-            "Version": "1.6.5+0.aarch64.linux.gnu"
+            "Version": "1.6.5+0.aarch64.linux.musl"
         },
         "1.6.6": {
-            "Version": "1.6.6+0.aarch64.linux.gnu"
+            "Version": "1.6.6+0.aarch64.linux.musl"
         },
         "1.6.6~aarch64": {
-            "Version": "1.6.6+0.aarch64.linux.gnu"
+            "Version": "1.6.6+0.aarch64.linux.musl"
         },
         "1.6.7": {
-            "Version": "1.6.7+0.aarch64.linux.gnu"
+            "Version": "1.6.7+0.aarch64.linux.musl"
         },
         "1.6.7~aarch64": {
-            "Version": "1.6.7+0.aarch64.linux.gnu"
+            "Version": "1.6.7+0.aarch64.linux.musl"
         },
         "1.6~aarch64": {
-            "Version": "1.6.7+0.aarch64.linux.gnu"
+            "Version": "1.6.7+0.aarch64.linux.musl"
         },
         "1.7": {
-            "Version": "1.7.3+0.aarch64.linux.gnu"
+            "Version": "1.7.3+0.aarch64.linux.musl"
         },
         "1.7.0": {
-            "Version": "1.7.0+0.aarch64.linux.gnu"
+            "Version": "1.7.0+0.aarch64.linux.musl"
         },
         "1.7.0-beta1": {
-            "Version": "1.7.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.7.0-beta1+0.aarch64.linux.musl"
         },
         "1.7.0-beta1~aarch64": {
-            "Version": "1.7.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.7.0-beta1+0.aarch64.linux.musl"
         },
         "1.7.0-beta2": {
-            "Version": "1.7.0-beta2+0.aarch64.linux.gnu"
+            "Version": "1.7.0-beta2+0.aarch64.linux.musl"
         },
         "1.7.0-beta2~aarch64": {
-            "Version": "1.7.0-beta2+0.aarch64.linux.gnu"
+            "Version": "1.7.0-beta2+0.aarch64.linux.musl"
         },
         "1.7.0-beta3": {
-            "Version": "1.7.0-beta3+0.aarch64.linux.gnu"
+            "Version": "1.7.0-beta3+0.aarch64.linux.musl"
         },
         "1.7.0-beta3~aarch64": {
-            "Version": "1.7.0-beta3+0.aarch64.linux.gnu"
+            "Version": "1.7.0-beta3+0.aarch64.linux.musl"
         },
         "1.7.0-beta4": {
-            "Version": "1.7.0-beta4+0.aarch64.linux.gnu"
+            "Version": "1.7.0-beta4+0.aarch64.linux.musl"
         },
         "1.7.0-beta4~aarch64": {
-            "Version": "1.7.0-beta4+0.aarch64.linux.gnu"
+            "Version": "1.7.0-beta4+0.aarch64.linux.musl"
         },
         "1.7.0-rc1": {
-            "Version": "1.7.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.7.0-rc1+0.aarch64.linux.musl"
         },
         "1.7.0-rc1~aarch64": {
-            "Version": "1.7.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.7.0-rc1+0.aarch64.linux.musl"
         },
         "1.7.0-rc2": {
-            "Version": "1.7.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.7.0-rc2+0.aarch64.linux.musl"
         },
         "1.7.0-rc2~aarch64": {
-            "Version": "1.7.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.7.0-rc2+0.aarch64.linux.musl"
         },
         "1.7.0-rc3": {
-            "Version": "1.7.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.7.0-rc3+0.aarch64.linux.musl"
         },
         "1.7.0-rc3~aarch64": {
-            "Version": "1.7.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.7.0-rc3+0.aarch64.linux.musl"
         },
         "1.7.0~aarch64": {
-            "Version": "1.7.0+0.aarch64.linux.gnu"
+            "Version": "1.7.0+0.aarch64.linux.musl"
         },
         "1.7.1": {
-            "Version": "1.7.1+0.aarch64.linux.gnu"
+            "Version": "1.7.1+0.aarch64.linux.musl"
         },
         "1.7.1~aarch64": {
-            "Version": "1.7.1+0.aarch64.linux.gnu"
+            "Version": "1.7.1+0.aarch64.linux.musl"
         },
         "1.7.2": {
-            "Version": "1.7.2+0.aarch64.linux.gnu"
+            "Version": "1.7.2+0.aarch64.linux.musl"
         },
         "1.7.2~aarch64": {
-            "Version": "1.7.2+0.aarch64.linux.gnu"
+            "Version": "1.7.2+0.aarch64.linux.musl"
         },
         "1.7.3": {
-            "Version": "1.7.3+0.aarch64.linux.gnu"
+            "Version": "1.7.3+0.aarch64.linux.musl"
         },
         "1.7.3~aarch64": {
-            "Version": "1.7.3+0.aarch64.linux.gnu"
+            "Version": "1.7.3+0.aarch64.linux.musl"
         },
         "1.7~aarch64": {
-            "Version": "1.7.3+0.aarch64.linux.gnu"
+            "Version": "1.7.3+0.aarch64.linux.musl"
         },
         "1.8": {
-            "Version": "1.8.5+0.aarch64.linux.gnu"
+            "Version": "1.8.5+0.aarch64.linux.musl"
         },
         "1.8.0": {
-            "Version": "1.8.0+0.aarch64.linux.gnu"
+            "Version": "1.8.0+0.aarch64.linux.musl"
         },
         "1.8.0-beta1": {
-            "Version": "1.8.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.8.0-beta1+0.aarch64.linux.musl"
         },
         "1.8.0-beta1~aarch64": {
-            "Version": "1.8.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.8.0-beta1+0.aarch64.linux.musl"
         },
         "1.8.0-beta2": {
-            "Version": "1.8.0-beta2+0.aarch64.linux.gnu"
+            "Version": "1.8.0-beta2+0.aarch64.linux.musl"
         },
         "1.8.0-beta2~aarch64": {
-            "Version": "1.8.0-beta2+0.aarch64.linux.gnu"
+            "Version": "1.8.0-beta2+0.aarch64.linux.musl"
         },
         "1.8.0-beta3": {
-            "Version": "1.8.0-beta3+0.aarch64.linux.gnu"
+            "Version": "1.8.0-beta3+0.aarch64.linux.musl"
         },
         "1.8.0-beta3~aarch64": {
-            "Version": "1.8.0-beta3+0.aarch64.linux.gnu"
+            "Version": "1.8.0-beta3+0.aarch64.linux.musl"
         },
         "1.8.0-rc1": {
-            "Version": "1.8.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.8.0-rc1+0.aarch64.linux.musl"
         },
         "1.8.0-rc1~aarch64": {
-            "Version": "1.8.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.8.0-rc1+0.aarch64.linux.musl"
         },
         "1.8.0-rc2": {
-            "Version": "1.8.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.8.0-rc2+0.aarch64.linux.musl"
         },
         "1.8.0-rc2~aarch64": {
-            "Version": "1.8.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.8.0-rc2+0.aarch64.linux.musl"
         },
         "1.8.0-rc3": {
-            "Version": "1.8.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.8.0-rc3+0.aarch64.linux.musl"
         },
         "1.8.0-rc3~aarch64": {
-            "Version": "1.8.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.8.0-rc3+0.aarch64.linux.musl"
         },
         "1.8.0-rc4": {
-            "Version": "1.8.0-rc4+0.aarch64.linux.gnu"
+            "Version": "1.8.0-rc4+0.aarch64.linux.musl"
         },
         "1.8.0-rc4~aarch64": {
-            "Version": "1.8.0-rc4+0.aarch64.linux.gnu"
+            "Version": "1.8.0-rc4+0.aarch64.linux.musl"
         },
         "1.8.0~aarch64": {
-            "Version": "1.8.0+0.aarch64.linux.gnu"
+            "Version": "1.8.0+0.aarch64.linux.musl"
         },
         "1.8.1": {
-            "Version": "1.8.1+0.aarch64.linux.gnu"
+            "Version": "1.8.1+0.aarch64.linux.musl"
         },
         "1.8.1~aarch64": {
-            "Version": "1.8.1+0.aarch64.linux.gnu"
+            "Version": "1.8.1+0.aarch64.linux.musl"
         },
         "1.8.2": {
-            "Version": "1.8.2+0.aarch64.linux.gnu"
+            "Version": "1.8.2+0.aarch64.linux.musl"
         },
         "1.8.2~aarch64": {
-            "Version": "1.8.2+0.aarch64.linux.gnu"
+            "Version": "1.8.2+0.aarch64.linux.musl"
         },
         "1.8.3": {
-            "Version": "1.8.3+0.aarch64.linux.gnu"
+            "Version": "1.8.3+0.aarch64.linux.musl"
         },
         "1.8.3~aarch64": {
-            "Version": "1.8.3+0.aarch64.linux.gnu"
+            "Version": "1.8.3+0.aarch64.linux.musl"
         },
         "1.8.4": {
-            "Version": "1.8.4+0.aarch64.linux.gnu"
+            "Version": "1.8.4+0.aarch64.linux.musl"
         },
         "1.8.4~aarch64": {
-            "Version": "1.8.4+0.aarch64.linux.gnu"
+            "Version": "1.8.4+0.aarch64.linux.musl"
         },
         "1.8.5": {
-            "Version": "1.8.5+0.aarch64.linux.gnu"
+            "Version": "1.8.5+0.aarch64.linux.musl"
         },
         "1.8.5~aarch64": {
-            "Version": "1.8.5+0.aarch64.linux.gnu"
+            "Version": "1.8.5+0.aarch64.linux.musl"
         },
         "1.8~aarch64": {
-            "Version": "1.8.5+0.aarch64.linux.gnu"
+            "Version": "1.8.5+0.aarch64.linux.musl"
         },
         "1.9": {
-            "Version": "1.9.4+0.aarch64.linux.gnu"
+            "Version": "1.9.4+0.aarch64.linux.musl"
         },
         "1.9.0": {
-            "Version": "1.9.0+0.aarch64.linux.gnu"
+            "Version": "1.9.0+0.aarch64.linux.musl"
         },
         "1.9.0-alpha1": {
-            "Version": "1.9.0-alpha1+0.aarch64.linux.gnu"
+            "Version": "1.9.0-alpha1+0.aarch64.linux.musl"
         },
         "1.9.0-alpha1~aarch64": {
-            "Version": "1.9.0-alpha1+0.aarch64.linux.gnu"
+            "Version": "1.9.0-alpha1+0.aarch64.linux.musl"
         },
         "1.9.0-beta1": {
-            "Version": "1.9.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.9.0-beta1+0.aarch64.linux.musl"
         },
         "1.9.0-beta1~aarch64": {
-            "Version": "1.9.0-beta1+0.aarch64.linux.gnu"
+            "Version": "1.9.0-beta1+0.aarch64.linux.musl"
         },
         "1.9.0-beta2": {
-            "Version": "1.9.0-beta2+0.aarch64.linux.gnu"
+            "Version": "1.9.0-beta2+0.aarch64.linux.musl"
         },
         "1.9.0-beta2~aarch64": {
-            "Version": "1.9.0-beta2+0.aarch64.linux.gnu"
+            "Version": "1.9.0-beta2+0.aarch64.linux.musl"
         },
         "1.9.0-beta3": {
-            "Version": "1.9.0-beta3+0.aarch64.linux.gnu"
+            "Version": "1.9.0-beta3+0.aarch64.linux.musl"
         },
         "1.9.0-beta3~aarch64": {
-            "Version": "1.9.0-beta3+0.aarch64.linux.gnu"
+            "Version": "1.9.0-beta3+0.aarch64.linux.musl"
         },
         "1.9.0-beta4": {
-            "Version": "1.9.0-beta4+0.aarch64.linux.gnu"
+            "Version": "1.9.0-beta4+0.aarch64.linux.musl"
         },
         "1.9.0-beta4~aarch64": {
-            "Version": "1.9.0-beta4+0.aarch64.linux.gnu"
+            "Version": "1.9.0-beta4+0.aarch64.linux.musl"
         },
         "1.9.0-rc1": {
-            "Version": "1.9.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.9.0-rc1+0.aarch64.linux.musl"
         },
         "1.9.0-rc1~aarch64": {
-            "Version": "1.9.0-rc1+0.aarch64.linux.gnu"
+            "Version": "1.9.0-rc1+0.aarch64.linux.musl"
         },
         "1.9.0-rc2": {
-            "Version": "1.9.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.9.0-rc2+0.aarch64.linux.musl"
         },
         "1.9.0-rc2~aarch64": {
-            "Version": "1.9.0-rc2+0.aarch64.linux.gnu"
+            "Version": "1.9.0-rc2+0.aarch64.linux.musl"
         },
         "1.9.0-rc3": {
-            "Version": "1.9.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.9.0-rc3+0.aarch64.linux.musl"
         },
         "1.9.0-rc3~aarch64": {
-            "Version": "1.9.0-rc3+0.aarch64.linux.gnu"
+            "Version": "1.9.0-rc3+0.aarch64.linux.musl"
         },
         "1.9.0~aarch64": {
-            "Version": "1.9.0+0.aarch64.linux.gnu"
+            "Version": "1.9.0+0.aarch64.linux.musl"
         },
         "1.9.1": {
-            "Version": "1.9.1+0.aarch64.linux.gnu"
+            "Version": "1.9.1+0.aarch64.linux.musl"
         },
         "1.9.1~aarch64": {
-            "Version": "1.9.1+0.aarch64.linux.gnu"
+            "Version": "1.9.1+0.aarch64.linux.musl"
         },
         "1.9.2": {
-            "Version": "1.9.2+0.aarch64.linux.gnu"
+            "Version": "1.9.2+0.aarch64.linux.musl"
         },
         "1.9.2~aarch64": {
-            "Version": "1.9.2+0.aarch64.linux.gnu"
+            "Version": "1.9.2+0.aarch64.linux.musl"
         },
         "1.9.3": {
-            "Version": "1.9.3+0.aarch64.linux.gnu"
+            "Version": "1.9.3+0.aarch64.linux.musl"
         },
         "1.9.3~aarch64": {
-            "Version": "1.9.3+0.aarch64.linux.gnu"
+            "Version": "1.9.3+0.aarch64.linux.musl"
         },
         "1.9.4": {
-            "Version": "1.9.4+0.aarch64.linux.gnu"
+            "Version": "1.9.4+0.aarch64.linux.musl"
         },
         "1.9.4~aarch64": {
-            "Version": "1.9.4+0.aarch64.linux.gnu"
+            "Version": "1.9.4+0.aarch64.linux.musl"
         },
         "1.9~aarch64": {
-            "Version": "1.9.4+0.aarch64.linux.gnu"
+            "Version": "1.9.4+0.aarch64.linux.musl"
         },
         "1~aarch64": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "alpha": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "alpha~aarch64": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "beta": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "beta~aarch64": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "lts": {
-            "Version": "1.6.7+0.aarch64.linux.gnu"
+            "Version": "1.6.7+0.aarch64.linux.musl"
         },
         "lts~aarch64": {
-            "Version": "1.6.7+0.aarch64.linux.gnu"
+            "Version": "1.6.7+0.aarch64.linux.musl"
         },
         "rc": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "rc~aarch64": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "release": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         },
         "release~aarch64": {
-            "Version": "1.10.0+0.aarch64.linux.gnu"
+            "Version": "1.10.0+0.aarch64.linux.musl"
         }
     },
     "Version": "1.0.36"

--- a/versiondb/versiondb-i686-unknown-linux-musl.json
+++ b/versiondb/versiondb-i686-unknown-linux-musl.json
@@ -1,1422 +1,1422 @@
 {
     "AvailableVersions": {
-        "0.3.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.1-linux-i686.tar.gz"
+        "0.3.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.1-musl-i686.tar.gz"
         },
-        "0.3.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.2-linux-i686.tar.gz"
+        "0.3.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.2-musl-i686.tar.gz"
         },
-        "0.3.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.3-linux-i686.tar.gz"
+        "0.3.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.3-musl-i686.tar.gz"
         },
-        "0.3.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.4-linux-i686.tar.gz"
+        "0.3.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.4-musl-i686.tar.gz"
         },
-        "0.3.5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.5-linux-i686.tar.gz"
+        "0.3.5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.5-musl-i686.tar.gz"
         },
-        "0.3.6+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.6-linux-i686.tar.gz"
+        "0.3.6+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.6-musl-i686.tar.gz"
         },
-        "0.3.7+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.7-linux-i686.tar.gz"
+        "0.3.7+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.7-musl-i686.tar.gz"
         },
-        "0.3.8+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.8-linux-i686.tar.gz"
+        "0.3.8+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.8-musl-i686.tar.gz"
         },
-        "0.3.9+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.9-linux-i686.tar.gz"
+        "0.3.9+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.9-musl-i686.tar.gz"
         },
-        "0.3.10+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.10-linux-i686.tar.gz"
+        "0.3.10+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.10-musl-i686.tar.gz"
         },
-        "0.3.11+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.11-linux-i686.tar.gz"
+        "0.3.11+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.11-musl-i686.tar.gz"
         },
-        "0.3.12+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.12-linux-i686.tar.gz"
+        "0.3.12+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.12-musl-i686.tar.gz"
         },
-        "0.4.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.0-rc1-linux-i686.tar.gz"
+        "0.4.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.0-rc1-musl-i686.tar.gz"
         },
-        "0.4.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.0-rc2-linux-i686.tar.gz"
+        "0.4.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.0-rc2-musl-i686.tar.gz"
         },
-        "0.4.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.0-rc3-linux-i686.tar.gz"
+        "0.4.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.0-rc3-musl-i686.tar.gz"
         },
-        "0.4.0-rc4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.0-rc4-linux-i686.tar.gz"
+        "0.4.0-rc4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.0-rc4-musl-i686.tar.gz"
         },
-        "0.4.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.0-linux-i686.tar.gz"
+        "0.4.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.0-musl-i686.tar.gz"
         },
-        "0.4.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.1-linux-i686.tar.gz"
+        "0.4.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.1-musl-i686.tar.gz"
         },
-        "0.4.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.2-linux-i686.tar.gz"
+        "0.4.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.2-musl-i686.tar.gz"
         },
-        "0.4.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.3-linux-i686.tar.gz"
+        "0.4.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.3-musl-i686.tar.gz"
         },
-        "0.4.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.4-linux-i686.tar.gz"
+        "0.4.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.4-musl-i686.tar.gz"
         },
-        "0.4.5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.5-linux-i686.tar.gz"
+        "0.4.5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.5-musl-i686.tar.gz"
         },
-        "0.4.6+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.6-linux-i686.tar.gz"
+        "0.4.6+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.6-musl-i686.tar.gz"
         },
-        "0.4.7+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.7-linux-i686.tar.gz"
+        "0.4.7+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.7-musl-i686.tar.gz"
         },
-        "0.5.0-rc0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-rc0-linux-i686.tar.gz"
+        "0.5.0-rc0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-rc0-musl-i686.tar.gz"
         },
-        "0.5.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-rc1-linux-i686.tar.gz"
+        "0.5.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-rc1-musl-i686.tar.gz"
         },
-        "0.5.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-rc2-linux-i686.tar.gz"
+        "0.5.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-rc2-musl-i686.tar.gz"
         },
-        "0.5.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-rc3-linux-i686.tar.gz"
+        "0.5.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-rc3-musl-i686.tar.gz"
         },
-        "0.5.0-rc4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-rc4-linux-i686.tar.gz"
+        "0.5.0-rc4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-rc4-musl-i686.tar.gz"
         },
-        "0.5.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-linux-i686.tar.gz"
+        "0.5.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-musl-i686.tar.gz"
         },
-        "0.5.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.1-linux-i686.tar.gz"
+        "0.5.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.1-musl-i686.tar.gz"
         },
-        "0.5.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.2-linux-i686.tar.gz"
+        "0.5.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.2-musl-i686.tar.gz"
         },
-        "0.6.0-pre.alpha+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-pre.alpha-linux-i686.tar.gz"
+        "0.6.0-pre.alpha+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-pre.alpha-musl-i686.tar.gz"
         },
-        "0.6.0-pre.beta+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-pre.beta-linux-i686.tar.gz"
+        "0.6.0-pre.beta+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-pre.beta-musl-i686.tar.gz"
         },
-        "0.6.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-rc1-linux-i686.tar.gz"
+        "0.6.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-rc1-musl-i686.tar.gz"
         },
-        "0.6.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-rc2-linux-i686.tar.gz"
+        "0.6.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-rc2-musl-i686.tar.gz"
         },
-        "0.6.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-rc3-linux-i686.tar.gz"
+        "0.6.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-rc3-musl-i686.tar.gz"
         },
-        "0.6.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-linux-i686.tar.gz"
+        "0.6.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-musl-i686.tar.gz"
         },
-        "0.6.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.1-linux-i686.tar.gz"
+        "0.6.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.1-musl-i686.tar.gz"
         },
-        "0.6.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.2-linux-i686.tar.gz"
+        "0.6.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.2-musl-i686.tar.gz"
         },
-        "0.6.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.3-linux-i686.tar.gz"
+        "0.6.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.3-musl-i686.tar.gz"
         },
-        "0.6.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.4-linux-i686.tar.gz"
+        "0.6.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.4-musl-i686.tar.gz"
         },
-        "0.7.0-alpha+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-alpha-linux-i686.tar.gz"
+        "0.7.0-alpha+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-alpha-musl-i686.tar.gz"
         },
-        "0.7.0-beta+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-beta-linux-i686.tar.gz"
+        "0.7.0-beta+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-beta-musl-i686.tar.gz"
         },
-        "0.7.0-beta2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-beta2-linux-i686.tar.gz"
+        "0.7.0-beta2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-beta2-musl-i686.tar.gz"
         },
-        "0.7.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-rc1-linux-i686.tar.gz"
+        "0.7.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-rc1-musl-i686.tar.gz"
         },
-        "0.7.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-rc2-linux-i686.tar.gz"
+        "0.7.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-rc2-musl-i686.tar.gz"
         },
-        "0.7.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-rc3-linux-i686.tar.gz"
+        "0.7.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-rc3-musl-i686.tar.gz"
         },
-        "0.7.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-linux-i686.tar.gz"
+        "0.7.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-musl-i686.tar.gz"
         },
-        "1.0.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.0-rc1-linux-i686.tar.gz"
+        "1.0.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.0-rc1-musl-i686.tar.gz"
         },
-        "1.0.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.0-linux-i686.tar.gz"
+        "1.0.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.0-musl-i686.tar.gz"
         },
-        "1.0.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.1-linux-i686.tar.gz"
+        "1.0.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.1-musl-i686.tar.gz"
         },
-        "1.0.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.2-linux-i686.tar.gz"
+        "1.0.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.2-musl-i686.tar.gz"
         },
-        "1.0.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.3-linux-i686.tar.gz"
+        "1.0.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.3-musl-i686.tar.gz"
         },
-        "1.0.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.4-linux-i686.tar.gz"
+        "1.0.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.4-musl-i686.tar.gz"
         },
-        "1.0.5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.5-linux-i686.tar.gz"
+        "1.0.5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.5-musl-i686.tar.gz"
         },
-        "1.1.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.1/julia-1.1.0-rc1-linux-i686.tar.gz"
+        "1.1.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.1/julia-1.1.0-rc1-musl-i686.tar.gz"
         },
-        "1.1.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.1/julia-1.1.0-rc2-linux-i686.tar.gz"
+        "1.1.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.1/julia-1.1.0-rc2-musl-i686.tar.gz"
         },
-        "1.1.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.1/julia-1.1.0-linux-i686.tar.gz"
+        "1.1.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.1/julia-1.1.0-musl-i686.tar.gz"
         },
-        "1.1.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.1/julia-1.1.1-linux-i686.tar.gz"
+        "1.1.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.1/julia-1.1.1-musl-i686.tar.gz"
         },
-        "1.2.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.2/julia-1.2.0-rc1-linux-i686.tar.gz"
+        "1.2.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.2/julia-1.2.0-rc1-musl-i686.tar.gz"
         },
-        "1.2.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.2/julia-1.2.0-rc2-linux-i686.tar.gz"
+        "1.2.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.2/julia-1.2.0-rc2-musl-i686.tar.gz"
         },
-        "1.2.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.2/julia-1.2.0-rc3-linux-i686.tar.gz"
+        "1.2.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.2/julia-1.2.0-rc3-musl-i686.tar.gz"
         },
-        "1.2.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.2/julia-1.2.0-linux-i686.tar.gz"
+        "1.2.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.2/julia-1.2.0-musl-i686.tar.gz"
         },
-        "1.3.0-alpha+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-alpha-linux-i686.tar.gz"
+        "1.3.0-alpha+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-alpha-musl-i686.tar.gz"
         },
-        "1.3.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-rc1-linux-i686.tar.gz"
+        "1.3.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-rc1-musl-i686.tar.gz"
         },
-        "1.3.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-rc2-linux-i686.tar.gz"
+        "1.3.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-rc2-musl-i686.tar.gz"
         },
-        "1.3.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-rc3-linux-i686.tar.gz"
+        "1.3.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-rc3-musl-i686.tar.gz"
         },
-        "1.3.0-rc4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-rc4-linux-i686.tar.gz"
+        "1.3.0-rc4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-rc4-musl-i686.tar.gz"
         },
-        "1.3.0-rc5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-rc5-linux-i686.tar.gz"
+        "1.3.0-rc5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-rc5-musl-i686.tar.gz"
         },
-        "1.3.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-linux-i686.tar.gz"
+        "1.3.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-musl-i686.tar.gz"
         },
-        "1.3.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.1-linux-i686.tar.gz"
+        "1.3.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.1-musl-i686.tar.gz"
         },
-        "1.4.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.4/julia-1.4.0-rc1-linux-i686.tar.gz"
+        "1.4.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.4/julia-1.4.0-rc1-musl-i686.tar.gz"
         },
-        "1.4.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.4/julia-1.4.0-rc2-linux-i686.tar.gz"
+        "1.4.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.4/julia-1.4.0-rc2-musl-i686.tar.gz"
         },
-        "1.4.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.4/julia-1.4.0-linux-i686.tar.gz"
+        "1.4.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.4/julia-1.4.0-musl-i686.tar.gz"
         },
-        "1.4.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.4/julia-1.4.1-linux-i686.tar.gz"
+        "1.4.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.4/julia-1.4.1-musl-i686.tar.gz"
         },
-        "1.4.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.4/julia-1.4.2-linux-i686.tar.gz"
+        "1.4.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.4/julia-1.4.2-musl-i686.tar.gz"
         },
-        "1.5.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.0-beta1-linux-i686.tar.gz"
+        "1.5.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.0-beta1-musl-i686.tar.gz"
         },
-        "1.5.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.0-rc1-linux-i686.tar.gz"
+        "1.5.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.0-rc1-musl-i686.tar.gz"
         },
-        "1.5.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.0-rc2-linux-i686.tar.gz"
+        "1.5.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.0-rc2-musl-i686.tar.gz"
         },
-        "1.5.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.0-linux-i686.tar.gz"
+        "1.5.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.0-musl-i686.tar.gz"
         },
-        "1.5.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.1-linux-i686.tar.gz"
+        "1.5.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.1-musl-i686.tar.gz"
         },
-        "1.5.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.2-linux-i686.tar.gz"
+        "1.5.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.2-musl-i686.tar.gz"
         },
-        "1.5.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.3-linux-i686.tar.gz"
+        "1.5.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.3-musl-i686.tar.gz"
         },
-        "1.5.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.4-linux-i686.tar.gz"
+        "1.5.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.4-musl-i686.tar.gz"
         },
-        "1.6.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.0-beta1-linux-i686.tar.gz"
+        "1.6.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.0-beta1-musl-i686.tar.gz"
         },
-        "1.6.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.0-rc1-linux-i686.tar.gz"
+        "1.6.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.0-rc1-musl-i686.tar.gz"
         },
-        "1.6.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.0-rc2-linux-i686.tar.gz"
+        "1.6.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.0-rc2-musl-i686.tar.gz"
         },
-        "1.6.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.0-rc3-linux-i686.tar.gz"
+        "1.6.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.0-rc3-musl-i686.tar.gz"
         },
-        "1.6.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.0-linux-i686.tar.gz"
+        "1.6.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.0-musl-i686.tar.gz"
         },
-        "1.6.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.1-linux-i686.tar.gz"
+        "1.6.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.1-musl-i686.tar.gz"
         },
-        "1.6.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.2-linux-i686.tar.gz"
+        "1.6.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.2-musl-i686.tar.gz"
         },
-        "1.6.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.3-linux-i686.tar.gz"
+        "1.6.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.3-musl-i686.tar.gz"
         },
-        "1.6.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.4-linux-i686.tar.gz"
+        "1.6.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.4-musl-i686.tar.gz"
         },
-        "1.6.5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.5-linux-i686.tar.gz"
+        "1.6.5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.5-musl-i686.tar.gz"
         },
-        "1.6.6+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.6-linux-i686.tar.gz"
+        "1.6.6+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.6-musl-i686.tar.gz"
         },
-        "1.6.7+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.7-linux-i686.tar.gz"
+        "1.6.7+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.7-musl-i686.tar.gz"
         },
-        "1.7.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-beta1-linux-i686.tar.gz"
+        "1.7.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-beta1-musl-i686.tar.gz"
         },
-        "1.7.0-beta2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-beta2-linux-i686.tar.gz"
+        "1.7.0-beta2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-beta2-musl-i686.tar.gz"
         },
-        "1.7.0-beta3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-beta3-linux-i686.tar.gz"
+        "1.7.0-beta3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-beta3-musl-i686.tar.gz"
         },
-        "1.7.0-beta4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-beta4-linux-i686.tar.gz"
+        "1.7.0-beta4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-beta4-musl-i686.tar.gz"
         },
-        "1.7.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-rc1-linux-i686.tar.gz"
+        "1.7.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-rc1-musl-i686.tar.gz"
         },
-        "1.7.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-rc2-linux-i686.tar.gz"
+        "1.7.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-rc2-musl-i686.tar.gz"
         },
-        "1.7.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-rc3-linux-i686.tar.gz"
+        "1.7.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-rc3-musl-i686.tar.gz"
         },
-        "1.7.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-linux-i686.tar.gz"
+        "1.7.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-musl-i686.tar.gz"
         },
-        "1.7.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.1-linux-i686.tar.gz"
+        "1.7.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.1-musl-i686.tar.gz"
         },
-        "1.7.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.2-linux-i686.tar.gz"
+        "1.7.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.2-musl-i686.tar.gz"
         },
-        "1.7.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.3-linux-i686.tar.gz"
+        "1.7.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.3-musl-i686.tar.gz"
         },
-        "1.8.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-beta1-linux-i686.tar.gz"
+        "1.8.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-beta1-musl-i686.tar.gz"
         },
-        "1.8.0-beta2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-beta2-linux-i686.tar.gz"
+        "1.8.0-beta2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-beta2-musl-i686.tar.gz"
         },
-        "1.8.0-beta3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-beta3-linux-i686.tar.gz"
+        "1.8.0-beta3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-beta3-musl-i686.tar.gz"
         },
-        "1.8.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-rc1-linux-i686.tar.gz"
+        "1.8.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-rc1-musl-i686.tar.gz"
         },
-        "1.8.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-rc2-linux-i686.tar.gz"
+        "1.8.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-rc2-musl-i686.tar.gz"
         },
-        "1.8.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-rc3-linux-i686.tar.gz"
+        "1.8.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-rc3-musl-i686.tar.gz"
         },
-        "1.8.0-rc4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-rc4-linux-i686.tar.gz"
+        "1.8.0-rc4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-rc4-musl-i686.tar.gz"
         },
-        "1.8.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-linux-i686.tar.gz"
+        "1.8.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-musl-i686.tar.gz"
         },
-        "1.8.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.1-linux-i686.tar.gz"
+        "1.8.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.1-musl-i686.tar.gz"
         },
-        "1.8.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.2-linux-i686.tar.gz"
+        "1.8.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.2-musl-i686.tar.gz"
         },
-        "1.8.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.3-linux-i686.tar.gz"
+        "1.8.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.3-musl-i686.tar.gz"
         },
-        "1.8.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.4-linux-i686.tar.gz"
+        "1.8.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.4-musl-i686.tar.gz"
         },
-        "1.8.5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.5-linux-i686.tar.gz"
+        "1.8.5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.5-musl-i686.tar.gz"
         },
-        "1.9.0-alpha1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-alpha1-linux-i686.tar.gz"
+        "1.9.0-alpha1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-alpha1-musl-i686.tar.gz"
         },
-        "1.9.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-beta1-linux-i686.tar.gz"
+        "1.9.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-beta1-musl-i686.tar.gz"
         },
-        "1.9.0-beta2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-beta2-linux-i686.tar.gz"
+        "1.9.0-beta2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-beta2-musl-i686.tar.gz"
         },
-        "1.9.0-beta3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-beta3-linux-i686.tar.gz"
+        "1.9.0-beta3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-beta3-musl-i686.tar.gz"
         },
-        "1.9.0-beta4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-beta4-linux-i686.tar.gz"
+        "1.9.0-beta4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-beta4-musl-i686.tar.gz"
         },
-        "1.9.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-rc1-linux-i686.tar.gz"
+        "1.9.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-rc1-musl-i686.tar.gz"
         },
-        "1.9.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-rc2-linux-i686.tar.gz"
+        "1.9.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-rc2-musl-i686.tar.gz"
         },
-        "1.9.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-rc3-linux-i686.tar.gz"
+        "1.9.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-rc3-musl-i686.tar.gz"
         },
-        "1.9.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-linux-i686.tar.gz"
+        "1.9.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-musl-i686.tar.gz"
         },
-        "1.9.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.1-linux-i686.tar.gz"
+        "1.9.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.1-musl-i686.tar.gz"
         },
-        "1.9.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.2-linux-i686.tar.gz"
+        "1.9.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.2-musl-i686.tar.gz"
         },
-        "1.9.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.3-linux-i686.tar.gz"
+        "1.9.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.3-musl-i686.tar.gz"
         },
-        "1.9.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.4-linux-i686.tar.gz"
+        "1.9.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.4-musl-i686.tar.gz"
         },
-        "1.10.0-alpha1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-alpha1-linux-i686.tar.gz"
+        "1.10.0-alpha1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-alpha1-musl-i686.tar.gz"
         },
-        "1.10.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-beta1-linux-i686.tar.gz"
+        "1.10.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-beta1-musl-i686.tar.gz"
         },
-        "1.10.0-beta2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-beta2-linux-i686.tar.gz"
+        "1.10.0-beta2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-beta2-musl-i686.tar.gz"
         },
-        "1.10.0-beta3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-beta3-linux-i686.tar.gz"
+        "1.10.0-beta3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-beta3-musl-i686.tar.gz"
         },
-        "1.10.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-rc1-linux-i686.tar.gz"
+        "1.10.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-rc1-musl-i686.tar.gz"
         },
-        "1.10.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-rc2-linux-i686.tar.gz"
+        "1.10.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-rc2-musl-i686.tar.gz"
         },
-        "1.10.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-rc3-linux-i686.tar.gz"
+        "1.10.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-rc3-musl-i686.tar.gz"
         },
-        "1.10.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-linux-i686.tar.gz"
+        "1.10.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-musl-i686.tar.gz"
         }
     },
     "AvailableChannels": {
         "0": {
-            "Version": "0.7.0+0.x86.linux.gnu"
+            "Version": "0.7.0+0.x86.linux.musl"
         },
         "0.3": {
-            "Version": "0.3.12+0.x86.linux.gnu"
+            "Version": "0.3.12+0.x86.linux.musl"
         },
         "0.3.1": {
-            "Version": "0.3.1+0.x86.linux.gnu"
+            "Version": "0.3.1+0.x86.linux.musl"
         },
         "0.3.10": {
-            "Version": "0.3.10+0.x86.linux.gnu"
+            "Version": "0.3.10+0.x86.linux.musl"
         },
         "0.3.10~x86": {
-            "Version": "0.3.10+0.x86.linux.gnu"
+            "Version": "0.3.10+0.x86.linux.musl"
         },
         "0.3.11": {
-            "Version": "0.3.11+0.x86.linux.gnu"
+            "Version": "0.3.11+0.x86.linux.musl"
         },
         "0.3.11~x86": {
-            "Version": "0.3.11+0.x86.linux.gnu"
+            "Version": "0.3.11+0.x86.linux.musl"
         },
         "0.3.12": {
-            "Version": "0.3.12+0.x86.linux.gnu"
+            "Version": "0.3.12+0.x86.linux.musl"
         },
         "0.3.12~x86": {
-            "Version": "0.3.12+0.x86.linux.gnu"
+            "Version": "0.3.12+0.x86.linux.musl"
         },
         "0.3.1~x86": {
-            "Version": "0.3.1+0.x86.linux.gnu"
+            "Version": "0.3.1+0.x86.linux.musl"
         },
         "0.3.2": {
-            "Version": "0.3.2+0.x86.linux.gnu"
+            "Version": "0.3.2+0.x86.linux.musl"
         },
         "0.3.2~x86": {
-            "Version": "0.3.2+0.x86.linux.gnu"
+            "Version": "0.3.2+0.x86.linux.musl"
         },
         "0.3.3": {
-            "Version": "0.3.3+0.x86.linux.gnu"
+            "Version": "0.3.3+0.x86.linux.musl"
         },
         "0.3.3~x86": {
-            "Version": "0.3.3+0.x86.linux.gnu"
+            "Version": "0.3.3+0.x86.linux.musl"
         },
         "0.3.4": {
-            "Version": "0.3.4+0.x86.linux.gnu"
+            "Version": "0.3.4+0.x86.linux.musl"
         },
         "0.3.4~x86": {
-            "Version": "0.3.4+0.x86.linux.gnu"
+            "Version": "0.3.4+0.x86.linux.musl"
         },
         "0.3.5": {
-            "Version": "0.3.5+0.x86.linux.gnu"
+            "Version": "0.3.5+0.x86.linux.musl"
         },
         "0.3.5~x86": {
-            "Version": "0.3.5+0.x86.linux.gnu"
+            "Version": "0.3.5+0.x86.linux.musl"
         },
         "0.3.6": {
-            "Version": "0.3.6+0.x86.linux.gnu"
+            "Version": "0.3.6+0.x86.linux.musl"
         },
         "0.3.6~x86": {
-            "Version": "0.3.6+0.x86.linux.gnu"
+            "Version": "0.3.6+0.x86.linux.musl"
         },
         "0.3.7": {
-            "Version": "0.3.7+0.x86.linux.gnu"
+            "Version": "0.3.7+0.x86.linux.musl"
         },
         "0.3.7~x86": {
-            "Version": "0.3.7+0.x86.linux.gnu"
+            "Version": "0.3.7+0.x86.linux.musl"
         },
         "0.3.8": {
-            "Version": "0.3.8+0.x86.linux.gnu"
+            "Version": "0.3.8+0.x86.linux.musl"
         },
         "0.3.8~x86": {
-            "Version": "0.3.8+0.x86.linux.gnu"
+            "Version": "0.3.8+0.x86.linux.musl"
         },
         "0.3.9": {
-            "Version": "0.3.9+0.x86.linux.gnu"
+            "Version": "0.3.9+0.x86.linux.musl"
         },
         "0.3.9~x86": {
-            "Version": "0.3.9+0.x86.linux.gnu"
+            "Version": "0.3.9+0.x86.linux.musl"
         },
         "0.3~x86": {
-            "Version": "0.3.12+0.x86.linux.gnu"
+            "Version": "0.3.12+0.x86.linux.musl"
         },
         "0.4": {
-            "Version": "0.4.7+0.x86.linux.gnu"
+            "Version": "0.4.7+0.x86.linux.musl"
         },
         "0.4.0": {
-            "Version": "0.4.0+0.x86.linux.gnu"
+            "Version": "0.4.0+0.x86.linux.musl"
         },
         "0.4.0-rc1": {
-            "Version": "0.4.0-rc1+0.x86.linux.gnu"
+            "Version": "0.4.0-rc1+0.x86.linux.musl"
         },
         "0.4.0-rc1~x86": {
-            "Version": "0.4.0-rc1+0.x86.linux.gnu"
+            "Version": "0.4.0-rc1+0.x86.linux.musl"
         },
         "0.4.0-rc2": {
-            "Version": "0.4.0-rc2+0.x86.linux.gnu"
+            "Version": "0.4.0-rc2+0.x86.linux.musl"
         },
         "0.4.0-rc2~x86": {
-            "Version": "0.4.0-rc2+0.x86.linux.gnu"
+            "Version": "0.4.0-rc2+0.x86.linux.musl"
         },
         "0.4.0-rc3": {
-            "Version": "0.4.0-rc3+0.x86.linux.gnu"
+            "Version": "0.4.0-rc3+0.x86.linux.musl"
         },
         "0.4.0-rc3~x86": {
-            "Version": "0.4.0-rc3+0.x86.linux.gnu"
+            "Version": "0.4.0-rc3+0.x86.linux.musl"
         },
         "0.4.0-rc4": {
-            "Version": "0.4.0-rc4+0.x86.linux.gnu"
+            "Version": "0.4.0-rc4+0.x86.linux.musl"
         },
         "0.4.0-rc4~x86": {
-            "Version": "0.4.0-rc4+0.x86.linux.gnu"
+            "Version": "0.4.0-rc4+0.x86.linux.musl"
         },
         "0.4.0~x86": {
-            "Version": "0.4.0+0.x86.linux.gnu"
+            "Version": "0.4.0+0.x86.linux.musl"
         },
         "0.4.1": {
-            "Version": "0.4.1+0.x86.linux.gnu"
+            "Version": "0.4.1+0.x86.linux.musl"
         },
         "0.4.1~x86": {
-            "Version": "0.4.1+0.x86.linux.gnu"
+            "Version": "0.4.1+0.x86.linux.musl"
         },
         "0.4.2": {
-            "Version": "0.4.2+0.x86.linux.gnu"
+            "Version": "0.4.2+0.x86.linux.musl"
         },
         "0.4.2~x86": {
-            "Version": "0.4.2+0.x86.linux.gnu"
+            "Version": "0.4.2+0.x86.linux.musl"
         },
         "0.4.3": {
-            "Version": "0.4.3+0.x86.linux.gnu"
+            "Version": "0.4.3+0.x86.linux.musl"
         },
         "0.4.3~x86": {
-            "Version": "0.4.3+0.x86.linux.gnu"
+            "Version": "0.4.3+0.x86.linux.musl"
         },
         "0.4.4": {
-            "Version": "0.4.4+0.x86.linux.gnu"
+            "Version": "0.4.4+0.x86.linux.musl"
         },
         "0.4.4~x86": {
-            "Version": "0.4.4+0.x86.linux.gnu"
+            "Version": "0.4.4+0.x86.linux.musl"
         },
         "0.4.5": {
-            "Version": "0.4.5+0.x86.linux.gnu"
+            "Version": "0.4.5+0.x86.linux.musl"
         },
         "0.4.5~x86": {
-            "Version": "0.4.5+0.x86.linux.gnu"
+            "Version": "0.4.5+0.x86.linux.musl"
         },
         "0.4.6": {
-            "Version": "0.4.6+0.x86.linux.gnu"
+            "Version": "0.4.6+0.x86.linux.musl"
         },
         "0.4.6~x86": {
-            "Version": "0.4.6+0.x86.linux.gnu"
+            "Version": "0.4.6+0.x86.linux.musl"
         },
         "0.4.7": {
-            "Version": "0.4.7+0.x86.linux.gnu"
+            "Version": "0.4.7+0.x86.linux.musl"
         },
         "0.4.7~x86": {
-            "Version": "0.4.7+0.x86.linux.gnu"
+            "Version": "0.4.7+0.x86.linux.musl"
         },
         "0.4~x86": {
-            "Version": "0.4.7+0.x86.linux.gnu"
+            "Version": "0.4.7+0.x86.linux.musl"
         },
         "0.5": {
-            "Version": "0.5.2+0.x86.linux.gnu"
+            "Version": "0.5.2+0.x86.linux.musl"
         },
         "0.5.0": {
-            "Version": "0.5.0+0.x86.linux.gnu"
+            "Version": "0.5.0+0.x86.linux.musl"
         },
         "0.5.0-rc0": {
-            "Version": "0.5.0-rc0+0.x86.linux.gnu"
+            "Version": "0.5.0-rc0+0.x86.linux.musl"
         },
         "0.5.0-rc0~x86": {
-            "Version": "0.5.0-rc0+0.x86.linux.gnu"
+            "Version": "0.5.0-rc0+0.x86.linux.musl"
         },
         "0.5.0-rc1": {
-            "Version": "0.5.0-rc1+0.x86.linux.gnu"
+            "Version": "0.5.0-rc1+0.x86.linux.musl"
         },
         "0.5.0-rc1~x86": {
-            "Version": "0.5.0-rc1+0.x86.linux.gnu"
+            "Version": "0.5.0-rc1+0.x86.linux.musl"
         },
         "0.5.0-rc2": {
-            "Version": "0.5.0-rc2+0.x86.linux.gnu"
+            "Version": "0.5.0-rc2+0.x86.linux.musl"
         },
         "0.5.0-rc2~x86": {
-            "Version": "0.5.0-rc2+0.x86.linux.gnu"
+            "Version": "0.5.0-rc2+0.x86.linux.musl"
         },
         "0.5.0-rc3": {
-            "Version": "0.5.0-rc3+0.x86.linux.gnu"
+            "Version": "0.5.0-rc3+0.x86.linux.musl"
         },
         "0.5.0-rc3~x86": {
-            "Version": "0.5.0-rc3+0.x86.linux.gnu"
+            "Version": "0.5.0-rc3+0.x86.linux.musl"
         },
         "0.5.0-rc4": {
-            "Version": "0.5.0-rc4+0.x86.linux.gnu"
+            "Version": "0.5.0-rc4+0.x86.linux.musl"
         },
         "0.5.0-rc4~x86": {
-            "Version": "0.5.0-rc4+0.x86.linux.gnu"
+            "Version": "0.5.0-rc4+0.x86.linux.musl"
         },
         "0.5.0~x86": {
-            "Version": "0.5.0+0.x86.linux.gnu"
+            "Version": "0.5.0+0.x86.linux.musl"
         },
         "0.5.1": {
-            "Version": "0.5.1+0.x86.linux.gnu"
+            "Version": "0.5.1+0.x86.linux.musl"
         },
         "0.5.1~x86": {
-            "Version": "0.5.1+0.x86.linux.gnu"
+            "Version": "0.5.1+0.x86.linux.musl"
         },
         "0.5.2": {
-            "Version": "0.5.2+0.x86.linux.gnu"
+            "Version": "0.5.2+0.x86.linux.musl"
         },
         "0.5.2~x86": {
-            "Version": "0.5.2+0.x86.linux.gnu"
+            "Version": "0.5.2+0.x86.linux.musl"
         },
         "0.5~x86": {
-            "Version": "0.5.2+0.x86.linux.gnu"
+            "Version": "0.5.2+0.x86.linux.musl"
         },
         "0.6": {
-            "Version": "0.6.4+0.x86.linux.gnu"
+            "Version": "0.6.4+0.x86.linux.musl"
         },
         "0.6.0": {
-            "Version": "0.6.0+0.x86.linux.gnu"
+            "Version": "0.6.0+0.x86.linux.musl"
         },
         "0.6.0-pre.alpha": {
-            "Version": "0.6.0-pre.alpha+0.x86.linux.gnu"
+            "Version": "0.6.0-pre.alpha+0.x86.linux.musl"
         },
         "0.6.0-pre.alpha~x86": {
-            "Version": "0.6.0-pre.alpha+0.x86.linux.gnu"
+            "Version": "0.6.0-pre.alpha+0.x86.linux.musl"
         },
         "0.6.0-pre.beta": {
-            "Version": "0.6.0-pre.beta+0.x86.linux.gnu"
+            "Version": "0.6.0-pre.beta+0.x86.linux.musl"
         },
         "0.6.0-pre.beta~x86": {
-            "Version": "0.6.0-pre.beta+0.x86.linux.gnu"
+            "Version": "0.6.0-pre.beta+0.x86.linux.musl"
         },
         "0.6.0-rc1": {
-            "Version": "0.6.0-rc1+0.x86.linux.gnu"
+            "Version": "0.6.0-rc1+0.x86.linux.musl"
         },
         "0.6.0-rc1~x86": {
-            "Version": "0.6.0-rc1+0.x86.linux.gnu"
+            "Version": "0.6.0-rc1+0.x86.linux.musl"
         },
         "0.6.0-rc2": {
-            "Version": "0.6.0-rc2+0.x86.linux.gnu"
+            "Version": "0.6.0-rc2+0.x86.linux.musl"
         },
         "0.6.0-rc2~x86": {
-            "Version": "0.6.0-rc2+0.x86.linux.gnu"
+            "Version": "0.6.0-rc2+0.x86.linux.musl"
         },
         "0.6.0-rc3": {
-            "Version": "0.6.0-rc3+0.x86.linux.gnu"
+            "Version": "0.6.0-rc3+0.x86.linux.musl"
         },
         "0.6.0-rc3~x86": {
-            "Version": "0.6.0-rc3+0.x86.linux.gnu"
+            "Version": "0.6.0-rc3+0.x86.linux.musl"
         },
         "0.6.0~x86": {
-            "Version": "0.6.0+0.x86.linux.gnu"
+            "Version": "0.6.0+0.x86.linux.musl"
         },
         "0.6.1": {
-            "Version": "0.6.1+0.x86.linux.gnu"
+            "Version": "0.6.1+0.x86.linux.musl"
         },
         "0.6.1~x86": {
-            "Version": "0.6.1+0.x86.linux.gnu"
+            "Version": "0.6.1+0.x86.linux.musl"
         },
         "0.6.2": {
-            "Version": "0.6.2+0.x86.linux.gnu"
+            "Version": "0.6.2+0.x86.linux.musl"
         },
         "0.6.2~x86": {
-            "Version": "0.6.2+0.x86.linux.gnu"
+            "Version": "0.6.2+0.x86.linux.musl"
         },
         "0.6.3": {
-            "Version": "0.6.3+0.x86.linux.gnu"
+            "Version": "0.6.3+0.x86.linux.musl"
         },
         "0.6.3~x86": {
-            "Version": "0.6.3+0.x86.linux.gnu"
+            "Version": "0.6.3+0.x86.linux.musl"
         },
         "0.6.4": {
-            "Version": "0.6.4+0.x86.linux.gnu"
+            "Version": "0.6.4+0.x86.linux.musl"
         },
         "0.6.4~x86": {
-            "Version": "0.6.4+0.x86.linux.gnu"
+            "Version": "0.6.4+0.x86.linux.musl"
         },
         "0.6~x86": {
-            "Version": "0.6.4+0.x86.linux.gnu"
+            "Version": "0.6.4+0.x86.linux.musl"
         },
         "0.7": {
-            "Version": "0.7.0+0.x86.linux.gnu"
+            "Version": "0.7.0+0.x86.linux.musl"
         },
         "0.7.0": {
-            "Version": "0.7.0+0.x86.linux.gnu"
+            "Version": "0.7.0+0.x86.linux.musl"
         },
         "0.7.0-alpha": {
-            "Version": "0.7.0-alpha+0.x86.linux.gnu"
+            "Version": "0.7.0-alpha+0.x86.linux.musl"
         },
         "0.7.0-alpha~x86": {
-            "Version": "0.7.0-alpha+0.x86.linux.gnu"
+            "Version": "0.7.0-alpha+0.x86.linux.musl"
         },
         "0.7.0-beta": {
-            "Version": "0.7.0-beta+0.x86.linux.gnu"
+            "Version": "0.7.0-beta+0.x86.linux.musl"
         },
         "0.7.0-beta2": {
-            "Version": "0.7.0-beta2+0.x86.linux.gnu"
+            "Version": "0.7.0-beta2+0.x86.linux.musl"
         },
         "0.7.0-beta2~x86": {
-            "Version": "0.7.0-beta2+0.x86.linux.gnu"
+            "Version": "0.7.0-beta2+0.x86.linux.musl"
         },
         "0.7.0-beta~x86": {
-            "Version": "0.7.0-beta+0.x86.linux.gnu"
+            "Version": "0.7.0-beta+0.x86.linux.musl"
         },
         "0.7.0-rc1": {
-            "Version": "0.7.0-rc1+0.x86.linux.gnu"
+            "Version": "0.7.0-rc1+0.x86.linux.musl"
         },
         "0.7.0-rc1~x86": {
-            "Version": "0.7.0-rc1+0.x86.linux.gnu"
+            "Version": "0.7.0-rc1+0.x86.linux.musl"
         },
         "0.7.0-rc2": {
-            "Version": "0.7.0-rc2+0.x86.linux.gnu"
+            "Version": "0.7.0-rc2+0.x86.linux.musl"
         },
         "0.7.0-rc2~x86": {
-            "Version": "0.7.0-rc2+0.x86.linux.gnu"
+            "Version": "0.7.0-rc2+0.x86.linux.musl"
         },
         "0.7.0-rc3": {
-            "Version": "0.7.0-rc3+0.x86.linux.gnu"
+            "Version": "0.7.0-rc3+0.x86.linux.musl"
         },
         "0.7.0-rc3~x86": {
-            "Version": "0.7.0-rc3+0.x86.linux.gnu"
+            "Version": "0.7.0-rc3+0.x86.linux.musl"
         },
         "0.7.0~x86": {
-            "Version": "0.7.0+0.x86.linux.gnu"
+            "Version": "0.7.0+0.x86.linux.musl"
         },
         "0.7~x86": {
-            "Version": "0.7.0+0.x86.linux.gnu"
+            "Version": "0.7.0+0.x86.linux.musl"
         },
         "0~x86": {
-            "Version": "0.7.0+0.x86.linux.gnu"
+            "Version": "0.7.0+0.x86.linux.musl"
         },
         "1": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "1.0": {
-            "Version": "1.0.5+0.x86.linux.gnu"
+            "Version": "1.0.5+0.x86.linux.musl"
         },
         "1.0.0": {
-            "Version": "1.0.0+0.x86.linux.gnu"
+            "Version": "1.0.0+0.x86.linux.musl"
         },
         "1.0.0-rc1": {
-            "Version": "1.0.0-rc1+0.x86.linux.gnu"
+            "Version": "1.0.0-rc1+0.x86.linux.musl"
         },
         "1.0.0-rc1~x86": {
-            "Version": "1.0.0-rc1+0.x86.linux.gnu"
+            "Version": "1.0.0-rc1+0.x86.linux.musl"
         },
         "1.0.0~x86": {
-            "Version": "1.0.0+0.x86.linux.gnu"
+            "Version": "1.0.0+0.x86.linux.musl"
         },
         "1.0.1": {
-            "Version": "1.0.1+0.x86.linux.gnu"
+            "Version": "1.0.1+0.x86.linux.musl"
         },
         "1.0.1~x86": {
-            "Version": "1.0.1+0.x86.linux.gnu"
+            "Version": "1.0.1+0.x86.linux.musl"
         },
         "1.0.2": {
-            "Version": "1.0.2+0.x86.linux.gnu"
+            "Version": "1.0.2+0.x86.linux.musl"
         },
         "1.0.2~x86": {
-            "Version": "1.0.2+0.x86.linux.gnu"
+            "Version": "1.0.2+0.x86.linux.musl"
         },
         "1.0.3": {
-            "Version": "1.0.3+0.x86.linux.gnu"
+            "Version": "1.0.3+0.x86.linux.musl"
         },
         "1.0.3~x86": {
-            "Version": "1.0.3+0.x86.linux.gnu"
+            "Version": "1.0.3+0.x86.linux.musl"
         },
         "1.0.4": {
-            "Version": "1.0.4+0.x86.linux.gnu"
+            "Version": "1.0.4+0.x86.linux.musl"
         },
         "1.0.4~x86": {
-            "Version": "1.0.4+0.x86.linux.gnu"
+            "Version": "1.0.4+0.x86.linux.musl"
         },
         "1.0.5": {
-            "Version": "1.0.5+0.x86.linux.gnu"
+            "Version": "1.0.5+0.x86.linux.musl"
         },
         "1.0.5~x86": {
-            "Version": "1.0.5+0.x86.linux.gnu"
+            "Version": "1.0.5+0.x86.linux.musl"
         },
         "1.0~x86": {
-            "Version": "1.0.5+0.x86.linux.gnu"
+            "Version": "1.0.5+0.x86.linux.musl"
         },
         "1.1": {
-            "Version": "1.1.1+0.x86.linux.gnu"
+            "Version": "1.1.1+0.x86.linux.musl"
         },
         "1.1.0": {
-            "Version": "1.1.0+0.x86.linux.gnu"
+            "Version": "1.1.0+0.x86.linux.musl"
         },
         "1.1.0-rc1": {
-            "Version": "1.1.0-rc1+0.x86.linux.gnu"
+            "Version": "1.1.0-rc1+0.x86.linux.musl"
         },
         "1.1.0-rc1~x86": {
-            "Version": "1.1.0-rc1+0.x86.linux.gnu"
+            "Version": "1.1.0-rc1+0.x86.linux.musl"
         },
         "1.1.0-rc2": {
-            "Version": "1.1.0-rc2+0.x86.linux.gnu"
+            "Version": "1.1.0-rc2+0.x86.linux.musl"
         },
         "1.1.0-rc2~x86": {
-            "Version": "1.1.0-rc2+0.x86.linux.gnu"
+            "Version": "1.1.0-rc2+0.x86.linux.musl"
         },
         "1.1.0~x86": {
-            "Version": "1.1.0+0.x86.linux.gnu"
+            "Version": "1.1.0+0.x86.linux.musl"
         },
         "1.1.1": {
-            "Version": "1.1.1+0.x86.linux.gnu"
+            "Version": "1.1.1+0.x86.linux.musl"
         },
         "1.1.1~x86": {
-            "Version": "1.1.1+0.x86.linux.gnu"
+            "Version": "1.1.1+0.x86.linux.musl"
         },
         "1.10": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "1.10.0": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "1.10.0-alpha1": {
-            "Version": "1.10.0-alpha1+0.x86.linux.gnu"
+            "Version": "1.10.0-alpha1+0.x86.linux.musl"
         },
         "1.10.0-alpha1~x86": {
-            "Version": "1.10.0-alpha1+0.x86.linux.gnu"
+            "Version": "1.10.0-alpha1+0.x86.linux.musl"
         },
         "1.10.0-beta1": {
-            "Version": "1.10.0-beta1+0.x86.linux.gnu"
+            "Version": "1.10.0-beta1+0.x86.linux.musl"
         },
         "1.10.0-beta1~x86": {
-            "Version": "1.10.0-beta1+0.x86.linux.gnu"
+            "Version": "1.10.0-beta1+0.x86.linux.musl"
         },
         "1.10.0-beta2": {
-            "Version": "1.10.0-beta2+0.x86.linux.gnu"
+            "Version": "1.10.0-beta2+0.x86.linux.musl"
         },
         "1.10.0-beta2~x86": {
-            "Version": "1.10.0-beta2+0.x86.linux.gnu"
+            "Version": "1.10.0-beta2+0.x86.linux.musl"
         },
         "1.10.0-beta3": {
-            "Version": "1.10.0-beta3+0.x86.linux.gnu"
+            "Version": "1.10.0-beta3+0.x86.linux.musl"
         },
         "1.10.0-beta3~x86": {
-            "Version": "1.10.0-beta3+0.x86.linux.gnu"
+            "Version": "1.10.0-beta3+0.x86.linux.musl"
         },
         "1.10.0-rc1": {
-            "Version": "1.10.0-rc1+0.x86.linux.gnu"
+            "Version": "1.10.0-rc1+0.x86.linux.musl"
         },
         "1.10.0-rc1~x86": {
-            "Version": "1.10.0-rc1+0.x86.linux.gnu"
+            "Version": "1.10.0-rc1+0.x86.linux.musl"
         },
         "1.10.0-rc2": {
-            "Version": "1.10.0-rc2+0.x86.linux.gnu"
+            "Version": "1.10.0-rc2+0.x86.linux.musl"
         },
         "1.10.0-rc2~x86": {
-            "Version": "1.10.0-rc2+0.x86.linux.gnu"
+            "Version": "1.10.0-rc2+0.x86.linux.musl"
         },
         "1.10.0-rc3": {
-            "Version": "1.10.0-rc3+0.x86.linux.gnu"
+            "Version": "1.10.0-rc3+0.x86.linux.musl"
         },
         "1.10.0-rc3~x86": {
-            "Version": "1.10.0-rc3+0.x86.linux.gnu"
+            "Version": "1.10.0-rc3+0.x86.linux.musl"
         },
         "1.10.0~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "1.10~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "1.1~x86": {
-            "Version": "1.1.1+0.x86.linux.gnu"
+            "Version": "1.1.1+0.x86.linux.musl"
         },
         "1.2": {
-            "Version": "1.2.0+0.x86.linux.gnu"
+            "Version": "1.2.0+0.x86.linux.musl"
         },
         "1.2.0": {
-            "Version": "1.2.0+0.x86.linux.gnu"
+            "Version": "1.2.0+0.x86.linux.musl"
         },
         "1.2.0-rc1": {
-            "Version": "1.2.0-rc1+0.x86.linux.gnu"
+            "Version": "1.2.0-rc1+0.x86.linux.musl"
         },
         "1.2.0-rc1~x86": {
-            "Version": "1.2.0-rc1+0.x86.linux.gnu"
+            "Version": "1.2.0-rc1+0.x86.linux.musl"
         },
         "1.2.0-rc2": {
-            "Version": "1.2.0-rc2+0.x86.linux.gnu"
+            "Version": "1.2.0-rc2+0.x86.linux.musl"
         },
         "1.2.0-rc2~x86": {
-            "Version": "1.2.0-rc2+0.x86.linux.gnu"
+            "Version": "1.2.0-rc2+0.x86.linux.musl"
         },
         "1.2.0-rc3": {
-            "Version": "1.2.0-rc3+0.x86.linux.gnu"
+            "Version": "1.2.0-rc3+0.x86.linux.musl"
         },
         "1.2.0-rc3~x86": {
-            "Version": "1.2.0-rc3+0.x86.linux.gnu"
+            "Version": "1.2.0-rc3+0.x86.linux.musl"
         },
         "1.2.0~x86": {
-            "Version": "1.2.0+0.x86.linux.gnu"
+            "Version": "1.2.0+0.x86.linux.musl"
         },
         "1.2~x86": {
-            "Version": "1.2.0+0.x86.linux.gnu"
+            "Version": "1.2.0+0.x86.linux.musl"
         },
         "1.3": {
-            "Version": "1.3.1+0.x86.linux.gnu"
+            "Version": "1.3.1+0.x86.linux.musl"
         },
         "1.3.0": {
-            "Version": "1.3.0+0.x86.linux.gnu"
+            "Version": "1.3.0+0.x86.linux.musl"
         },
         "1.3.0-alpha": {
-            "Version": "1.3.0-alpha+0.x86.linux.gnu"
+            "Version": "1.3.0-alpha+0.x86.linux.musl"
         },
         "1.3.0-alpha~x86": {
-            "Version": "1.3.0-alpha+0.x86.linux.gnu"
+            "Version": "1.3.0-alpha+0.x86.linux.musl"
         },
         "1.3.0-rc1": {
-            "Version": "1.3.0-rc1+0.x86.linux.gnu"
+            "Version": "1.3.0-rc1+0.x86.linux.musl"
         },
         "1.3.0-rc1~x86": {
-            "Version": "1.3.0-rc1+0.x86.linux.gnu"
+            "Version": "1.3.0-rc1+0.x86.linux.musl"
         },
         "1.3.0-rc2": {
-            "Version": "1.3.0-rc2+0.x86.linux.gnu"
+            "Version": "1.3.0-rc2+0.x86.linux.musl"
         },
         "1.3.0-rc2~x86": {
-            "Version": "1.3.0-rc2+0.x86.linux.gnu"
+            "Version": "1.3.0-rc2+0.x86.linux.musl"
         },
         "1.3.0-rc3": {
-            "Version": "1.3.0-rc3+0.x86.linux.gnu"
+            "Version": "1.3.0-rc3+0.x86.linux.musl"
         },
         "1.3.0-rc3~x86": {
-            "Version": "1.3.0-rc3+0.x86.linux.gnu"
+            "Version": "1.3.0-rc3+0.x86.linux.musl"
         },
         "1.3.0-rc4": {
-            "Version": "1.3.0-rc4+0.x86.linux.gnu"
+            "Version": "1.3.0-rc4+0.x86.linux.musl"
         },
         "1.3.0-rc4~x86": {
-            "Version": "1.3.0-rc4+0.x86.linux.gnu"
+            "Version": "1.3.0-rc4+0.x86.linux.musl"
         },
         "1.3.0-rc5": {
-            "Version": "1.3.0-rc5+0.x86.linux.gnu"
+            "Version": "1.3.0-rc5+0.x86.linux.musl"
         },
         "1.3.0-rc5~x86": {
-            "Version": "1.3.0-rc5+0.x86.linux.gnu"
+            "Version": "1.3.0-rc5+0.x86.linux.musl"
         },
         "1.3.0~x86": {
-            "Version": "1.3.0+0.x86.linux.gnu"
+            "Version": "1.3.0+0.x86.linux.musl"
         },
         "1.3.1": {
-            "Version": "1.3.1+0.x86.linux.gnu"
+            "Version": "1.3.1+0.x86.linux.musl"
         },
         "1.3.1~x86": {
-            "Version": "1.3.1+0.x86.linux.gnu"
+            "Version": "1.3.1+0.x86.linux.musl"
         },
         "1.3~x86": {
-            "Version": "1.3.1+0.x86.linux.gnu"
+            "Version": "1.3.1+0.x86.linux.musl"
         },
         "1.4": {
-            "Version": "1.4.2+0.x86.linux.gnu"
+            "Version": "1.4.2+0.x86.linux.musl"
         },
         "1.4.0": {
-            "Version": "1.4.0+0.x86.linux.gnu"
+            "Version": "1.4.0+0.x86.linux.musl"
         },
         "1.4.0-rc1": {
-            "Version": "1.4.0-rc1+0.x86.linux.gnu"
+            "Version": "1.4.0-rc1+0.x86.linux.musl"
         },
         "1.4.0-rc1~x86": {
-            "Version": "1.4.0-rc1+0.x86.linux.gnu"
+            "Version": "1.4.0-rc1+0.x86.linux.musl"
         },
         "1.4.0-rc2": {
-            "Version": "1.4.0-rc2+0.x86.linux.gnu"
+            "Version": "1.4.0-rc2+0.x86.linux.musl"
         },
         "1.4.0-rc2~x86": {
-            "Version": "1.4.0-rc2+0.x86.linux.gnu"
+            "Version": "1.4.0-rc2+0.x86.linux.musl"
         },
         "1.4.0~x86": {
-            "Version": "1.4.0+0.x86.linux.gnu"
+            "Version": "1.4.0+0.x86.linux.musl"
         },
         "1.4.1": {
-            "Version": "1.4.1+0.x86.linux.gnu"
+            "Version": "1.4.1+0.x86.linux.musl"
         },
         "1.4.1~x86": {
-            "Version": "1.4.1+0.x86.linux.gnu"
+            "Version": "1.4.1+0.x86.linux.musl"
         },
         "1.4.2": {
-            "Version": "1.4.2+0.x86.linux.gnu"
+            "Version": "1.4.2+0.x86.linux.musl"
         },
         "1.4.2~x86": {
-            "Version": "1.4.2+0.x86.linux.gnu"
+            "Version": "1.4.2+0.x86.linux.musl"
         },
         "1.4~x86": {
-            "Version": "1.4.2+0.x86.linux.gnu"
+            "Version": "1.4.2+0.x86.linux.musl"
         },
         "1.5": {
-            "Version": "1.5.4+0.x86.linux.gnu"
+            "Version": "1.5.4+0.x86.linux.musl"
         },
         "1.5.0": {
-            "Version": "1.5.0+0.x86.linux.gnu"
+            "Version": "1.5.0+0.x86.linux.musl"
         },
         "1.5.0-beta1": {
-            "Version": "1.5.0-beta1+0.x86.linux.gnu"
+            "Version": "1.5.0-beta1+0.x86.linux.musl"
         },
         "1.5.0-beta1~x86": {
-            "Version": "1.5.0-beta1+0.x86.linux.gnu"
+            "Version": "1.5.0-beta1+0.x86.linux.musl"
         },
         "1.5.0-rc1": {
-            "Version": "1.5.0-rc1+0.x86.linux.gnu"
+            "Version": "1.5.0-rc1+0.x86.linux.musl"
         },
         "1.5.0-rc1~x86": {
-            "Version": "1.5.0-rc1+0.x86.linux.gnu"
+            "Version": "1.5.0-rc1+0.x86.linux.musl"
         },
         "1.5.0-rc2": {
-            "Version": "1.5.0-rc2+0.x86.linux.gnu"
+            "Version": "1.5.0-rc2+0.x86.linux.musl"
         },
         "1.5.0-rc2~x86": {
-            "Version": "1.5.0-rc2+0.x86.linux.gnu"
+            "Version": "1.5.0-rc2+0.x86.linux.musl"
         },
         "1.5.0~x86": {
-            "Version": "1.5.0+0.x86.linux.gnu"
+            "Version": "1.5.0+0.x86.linux.musl"
         },
         "1.5.1": {
-            "Version": "1.5.1+0.x86.linux.gnu"
+            "Version": "1.5.1+0.x86.linux.musl"
         },
         "1.5.1~x86": {
-            "Version": "1.5.1+0.x86.linux.gnu"
+            "Version": "1.5.1+0.x86.linux.musl"
         },
         "1.5.2": {
-            "Version": "1.5.2+0.x86.linux.gnu"
+            "Version": "1.5.2+0.x86.linux.musl"
         },
         "1.5.2~x86": {
-            "Version": "1.5.2+0.x86.linux.gnu"
+            "Version": "1.5.2+0.x86.linux.musl"
         },
         "1.5.3": {
-            "Version": "1.5.3+0.x86.linux.gnu"
+            "Version": "1.5.3+0.x86.linux.musl"
         },
         "1.5.3~x86": {
-            "Version": "1.5.3+0.x86.linux.gnu"
+            "Version": "1.5.3+0.x86.linux.musl"
         },
         "1.5.4": {
-            "Version": "1.5.4+0.x86.linux.gnu"
+            "Version": "1.5.4+0.x86.linux.musl"
         },
         "1.5.4~x86": {
-            "Version": "1.5.4+0.x86.linux.gnu"
+            "Version": "1.5.4+0.x86.linux.musl"
         },
         "1.5~x86": {
-            "Version": "1.5.4+0.x86.linux.gnu"
+            "Version": "1.5.4+0.x86.linux.musl"
         },
         "1.6": {
-            "Version": "1.6.7+0.x86.linux.gnu"
+            "Version": "1.6.7+0.x86.linux.musl"
         },
         "1.6.0": {
-            "Version": "1.6.0+0.x86.linux.gnu"
+            "Version": "1.6.0+0.x86.linux.musl"
         },
         "1.6.0-beta1": {
-            "Version": "1.6.0-beta1+0.x86.linux.gnu"
+            "Version": "1.6.0-beta1+0.x86.linux.musl"
         },
         "1.6.0-beta1~x86": {
-            "Version": "1.6.0-beta1+0.x86.linux.gnu"
+            "Version": "1.6.0-beta1+0.x86.linux.musl"
         },
         "1.6.0-rc1": {
-            "Version": "1.6.0-rc1+0.x86.linux.gnu"
+            "Version": "1.6.0-rc1+0.x86.linux.musl"
         },
         "1.6.0-rc1~x86": {
-            "Version": "1.6.0-rc1+0.x86.linux.gnu"
+            "Version": "1.6.0-rc1+0.x86.linux.musl"
         },
         "1.6.0-rc2": {
-            "Version": "1.6.0-rc2+0.x86.linux.gnu"
+            "Version": "1.6.0-rc2+0.x86.linux.musl"
         },
         "1.6.0-rc2~x86": {
-            "Version": "1.6.0-rc2+0.x86.linux.gnu"
+            "Version": "1.6.0-rc2+0.x86.linux.musl"
         },
         "1.6.0-rc3": {
-            "Version": "1.6.0-rc3+0.x86.linux.gnu"
+            "Version": "1.6.0-rc3+0.x86.linux.musl"
         },
         "1.6.0-rc3~x86": {
-            "Version": "1.6.0-rc3+0.x86.linux.gnu"
+            "Version": "1.6.0-rc3+0.x86.linux.musl"
         },
         "1.6.0~x86": {
-            "Version": "1.6.0+0.x86.linux.gnu"
+            "Version": "1.6.0+0.x86.linux.musl"
         },
         "1.6.1": {
-            "Version": "1.6.1+0.x86.linux.gnu"
+            "Version": "1.6.1+0.x86.linux.musl"
         },
         "1.6.1~x86": {
-            "Version": "1.6.1+0.x86.linux.gnu"
+            "Version": "1.6.1+0.x86.linux.musl"
         },
         "1.6.2": {
-            "Version": "1.6.2+0.x86.linux.gnu"
+            "Version": "1.6.2+0.x86.linux.musl"
         },
         "1.6.2~x86": {
-            "Version": "1.6.2+0.x86.linux.gnu"
+            "Version": "1.6.2+0.x86.linux.musl"
         },
         "1.6.3": {
-            "Version": "1.6.3+0.x86.linux.gnu"
+            "Version": "1.6.3+0.x86.linux.musl"
         },
         "1.6.3~x86": {
-            "Version": "1.6.3+0.x86.linux.gnu"
+            "Version": "1.6.3+0.x86.linux.musl"
         },
         "1.6.4": {
-            "Version": "1.6.4+0.x86.linux.gnu"
+            "Version": "1.6.4+0.x86.linux.musl"
         },
         "1.6.4~x86": {
-            "Version": "1.6.4+0.x86.linux.gnu"
+            "Version": "1.6.4+0.x86.linux.musl"
         },
         "1.6.5": {
-            "Version": "1.6.5+0.x86.linux.gnu"
+            "Version": "1.6.5+0.x86.linux.musl"
         },
         "1.6.5~x86": {
-            "Version": "1.6.5+0.x86.linux.gnu"
+            "Version": "1.6.5+0.x86.linux.musl"
         },
         "1.6.6": {
-            "Version": "1.6.6+0.x86.linux.gnu"
+            "Version": "1.6.6+0.x86.linux.musl"
         },
         "1.6.6~x86": {
-            "Version": "1.6.6+0.x86.linux.gnu"
+            "Version": "1.6.6+0.x86.linux.musl"
         },
         "1.6.7": {
-            "Version": "1.6.7+0.x86.linux.gnu"
+            "Version": "1.6.7+0.x86.linux.musl"
         },
         "1.6.7~x86": {
-            "Version": "1.6.7+0.x86.linux.gnu"
+            "Version": "1.6.7+0.x86.linux.musl"
         },
         "1.6~x86": {
-            "Version": "1.6.7+0.x86.linux.gnu"
+            "Version": "1.6.7+0.x86.linux.musl"
         },
         "1.7": {
-            "Version": "1.7.3+0.x86.linux.gnu"
+            "Version": "1.7.3+0.x86.linux.musl"
         },
         "1.7.0": {
-            "Version": "1.7.0+0.x86.linux.gnu"
+            "Version": "1.7.0+0.x86.linux.musl"
         },
         "1.7.0-beta1": {
-            "Version": "1.7.0-beta1+0.x86.linux.gnu"
+            "Version": "1.7.0-beta1+0.x86.linux.musl"
         },
         "1.7.0-beta1~x86": {
-            "Version": "1.7.0-beta1+0.x86.linux.gnu"
+            "Version": "1.7.0-beta1+0.x86.linux.musl"
         },
         "1.7.0-beta2": {
-            "Version": "1.7.0-beta2+0.x86.linux.gnu"
+            "Version": "1.7.0-beta2+0.x86.linux.musl"
         },
         "1.7.0-beta2~x86": {
-            "Version": "1.7.0-beta2+0.x86.linux.gnu"
+            "Version": "1.7.0-beta2+0.x86.linux.musl"
         },
         "1.7.0-beta3": {
-            "Version": "1.7.0-beta3+0.x86.linux.gnu"
+            "Version": "1.7.0-beta3+0.x86.linux.musl"
         },
         "1.7.0-beta3~x86": {
-            "Version": "1.7.0-beta3+0.x86.linux.gnu"
+            "Version": "1.7.0-beta3+0.x86.linux.musl"
         },
         "1.7.0-beta4": {
-            "Version": "1.7.0-beta4+0.x86.linux.gnu"
+            "Version": "1.7.0-beta4+0.x86.linux.musl"
         },
         "1.7.0-beta4~x86": {
-            "Version": "1.7.0-beta4+0.x86.linux.gnu"
+            "Version": "1.7.0-beta4+0.x86.linux.musl"
         },
         "1.7.0-rc1": {
-            "Version": "1.7.0-rc1+0.x86.linux.gnu"
+            "Version": "1.7.0-rc1+0.x86.linux.musl"
         },
         "1.7.0-rc1~x86": {
-            "Version": "1.7.0-rc1+0.x86.linux.gnu"
+            "Version": "1.7.0-rc1+0.x86.linux.musl"
         },
         "1.7.0-rc2": {
-            "Version": "1.7.0-rc2+0.x86.linux.gnu"
+            "Version": "1.7.0-rc2+0.x86.linux.musl"
         },
         "1.7.0-rc2~x86": {
-            "Version": "1.7.0-rc2+0.x86.linux.gnu"
+            "Version": "1.7.0-rc2+0.x86.linux.musl"
         },
         "1.7.0-rc3": {
-            "Version": "1.7.0-rc3+0.x86.linux.gnu"
+            "Version": "1.7.0-rc3+0.x86.linux.musl"
         },
         "1.7.0-rc3~x86": {
-            "Version": "1.7.0-rc3+0.x86.linux.gnu"
+            "Version": "1.7.0-rc3+0.x86.linux.musl"
         },
         "1.7.0~x86": {
-            "Version": "1.7.0+0.x86.linux.gnu"
+            "Version": "1.7.0+0.x86.linux.musl"
         },
         "1.7.1": {
-            "Version": "1.7.1+0.x86.linux.gnu"
+            "Version": "1.7.1+0.x86.linux.musl"
         },
         "1.7.1~x86": {
-            "Version": "1.7.1+0.x86.linux.gnu"
+            "Version": "1.7.1+0.x86.linux.musl"
         },
         "1.7.2": {
-            "Version": "1.7.2+0.x86.linux.gnu"
+            "Version": "1.7.2+0.x86.linux.musl"
         },
         "1.7.2~x86": {
-            "Version": "1.7.2+0.x86.linux.gnu"
+            "Version": "1.7.2+0.x86.linux.musl"
         },
         "1.7.3": {
-            "Version": "1.7.3+0.x86.linux.gnu"
+            "Version": "1.7.3+0.x86.linux.musl"
         },
         "1.7.3~x86": {
-            "Version": "1.7.3+0.x86.linux.gnu"
+            "Version": "1.7.3+0.x86.linux.musl"
         },
         "1.7~x86": {
-            "Version": "1.7.3+0.x86.linux.gnu"
+            "Version": "1.7.3+0.x86.linux.musl"
         },
         "1.8": {
-            "Version": "1.8.5+0.x86.linux.gnu"
+            "Version": "1.8.5+0.x86.linux.musl"
         },
         "1.8.0": {
-            "Version": "1.8.0+0.x86.linux.gnu"
+            "Version": "1.8.0+0.x86.linux.musl"
         },
         "1.8.0-beta1": {
-            "Version": "1.8.0-beta1+0.x86.linux.gnu"
+            "Version": "1.8.0-beta1+0.x86.linux.musl"
         },
         "1.8.0-beta1~x86": {
-            "Version": "1.8.0-beta1+0.x86.linux.gnu"
+            "Version": "1.8.0-beta1+0.x86.linux.musl"
         },
         "1.8.0-beta2": {
-            "Version": "1.8.0-beta2+0.x86.linux.gnu"
+            "Version": "1.8.0-beta2+0.x86.linux.musl"
         },
         "1.8.0-beta2~x86": {
-            "Version": "1.8.0-beta2+0.x86.linux.gnu"
+            "Version": "1.8.0-beta2+0.x86.linux.musl"
         },
         "1.8.0-beta3": {
-            "Version": "1.8.0-beta3+0.x86.linux.gnu"
+            "Version": "1.8.0-beta3+0.x86.linux.musl"
         },
         "1.8.0-beta3~x86": {
-            "Version": "1.8.0-beta3+0.x86.linux.gnu"
+            "Version": "1.8.0-beta3+0.x86.linux.musl"
         },
         "1.8.0-rc1": {
-            "Version": "1.8.0-rc1+0.x86.linux.gnu"
+            "Version": "1.8.0-rc1+0.x86.linux.musl"
         },
         "1.8.0-rc1~x86": {
-            "Version": "1.8.0-rc1+0.x86.linux.gnu"
+            "Version": "1.8.0-rc1+0.x86.linux.musl"
         },
         "1.8.0-rc2": {
-            "Version": "1.8.0-rc2+0.x86.linux.gnu"
+            "Version": "1.8.0-rc2+0.x86.linux.musl"
         },
         "1.8.0-rc2~x86": {
-            "Version": "1.8.0-rc2+0.x86.linux.gnu"
+            "Version": "1.8.0-rc2+0.x86.linux.musl"
         },
         "1.8.0-rc3": {
-            "Version": "1.8.0-rc3+0.x86.linux.gnu"
+            "Version": "1.8.0-rc3+0.x86.linux.musl"
         },
         "1.8.0-rc3~x86": {
-            "Version": "1.8.0-rc3+0.x86.linux.gnu"
+            "Version": "1.8.0-rc3+0.x86.linux.musl"
         },
         "1.8.0-rc4": {
-            "Version": "1.8.0-rc4+0.x86.linux.gnu"
+            "Version": "1.8.0-rc4+0.x86.linux.musl"
         },
         "1.8.0-rc4~x86": {
-            "Version": "1.8.0-rc4+0.x86.linux.gnu"
+            "Version": "1.8.0-rc4+0.x86.linux.musl"
         },
         "1.8.0~x86": {
-            "Version": "1.8.0+0.x86.linux.gnu"
+            "Version": "1.8.0+0.x86.linux.musl"
         },
         "1.8.1": {
-            "Version": "1.8.1+0.x86.linux.gnu"
+            "Version": "1.8.1+0.x86.linux.musl"
         },
         "1.8.1~x86": {
-            "Version": "1.8.1+0.x86.linux.gnu"
+            "Version": "1.8.1+0.x86.linux.musl"
         },
         "1.8.2": {
-            "Version": "1.8.2+0.x86.linux.gnu"
+            "Version": "1.8.2+0.x86.linux.musl"
         },
         "1.8.2~x86": {
-            "Version": "1.8.2+0.x86.linux.gnu"
+            "Version": "1.8.2+0.x86.linux.musl"
         },
         "1.8.3": {
-            "Version": "1.8.3+0.x86.linux.gnu"
+            "Version": "1.8.3+0.x86.linux.musl"
         },
         "1.8.3~x86": {
-            "Version": "1.8.3+0.x86.linux.gnu"
+            "Version": "1.8.3+0.x86.linux.musl"
         },
         "1.8.4": {
-            "Version": "1.8.4+0.x86.linux.gnu"
+            "Version": "1.8.4+0.x86.linux.musl"
         },
         "1.8.4~x86": {
-            "Version": "1.8.4+0.x86.linux.gnu"
+            "Version": "1.8.4+0.x86.linux.musl"
         },
         "1.8.5": {
-            "Version": "1.8.5+0.x86.linux.gnu"
+            "Version": "1.8.5+0.x86.linux.musl"
         },
         "1.8.5~x86": {
-            "Version": "1.8.5+0.x86.linux.gnu"
+            "Version": "1.8.5+0.x86.linux.musl"
         },
         "1.8~x86": {
-            "Version": "1.8.5+0.x86.linux.gnu"
+            "Version": "1.8.5+0.x86.linux.musl"
         },
         "1.9": {
-            "Version": "1.9.4+0.x86.linux.gnu"
+            "Version": "1.9.4+0.x86.linux.musl"
         },
         "1.9.0": {
-            "Version": "1.9.0+0.x86.linux.gnu"
+            "Version": "1.9.0+0.x86.linux.musl"
         },
         "1.9.0-alpha1": {
-            "Version": "1.9.0-alpha1+0.x86.linux.gnu"
+            "Version": "1.9.0-alpha1+0.x86.linux.musl"
         },
         "1.9.0-alpha1~x86": {
-            "Version": "1.9.0-alpha1+0.x86.linux.gnu"
+            "Version": "1.9.0-alpha1+0.x86.linux.musl"
         },
         "1.9.0-beta1": {
-            "Version": "1.9.0-beta1+0.x86.linux.gnu"
+            "Version": "1.9.0-beta1+0.x86.linux.musl"
         },
         "1.9.0-beta1~x86": {
-            "Version": "1.9.0-beta1+0.x86.linux.gnu"
+            "Version": "1.9.0-beta1+0.x86.linux.musl"
         },
         "1.9.0-beta2": {
-            "Version": "1.9.0-beta2+0.x86.linux.gnu"
+            "Version": "1.9.0-beta2+0.x86.linux.musl"
         },
         "1.9.0-beta2~x86": {
-            "Version": "1.9.0-beta2+0.x86.linux.gnu"
+            "Version": "1.9.0-beta2+0.x86.linux.musl"
         },
         "1.9.0-beta3": {
-            "Version": "1.9.0-beta3+0.x86.linux.gnu"
+            "Version": "1.9.0-beta3+0.x86.linux.musl"
         },
         "1.9.0-beta3~x86": {
-            "Version": "1.9.0-beta3+0.x86.linux.gnu"
+            "Version": "1.9.0-beta3+0.x86.linux.musl"
         },
         "1.9.0-beta4": {
-            "Version": "1.9.0-beta4+0.x86.linux.gnu"
+            "Version": "1.9.0-beta4+0.x86.linux.musl"
         },
         "1.9.0-beta4~x86": {
-            "Version": "1.9.0-beta4+0.x86.linux.gnu"
+            "Version": "1.9.0-beta4+0.x86.linux.musl"
         },
         "1.9.0-rc1": {
-            "Version": "1.9.0-rc1+0.x86.linux.gnu"
+            "Version": "1.9.0-rc1+0.x86.linux.musl"
         },
         "1.9.0-rc1~x86": {
-            "Version": "1.9.0-rc1+0.x86.linux.gnu"
+            "Version": "1.9.0-rc1+0.x86.linux.musl"
         },
         "1.9.0-rc2": {
-            "Version": "1.9.0-rc2+0.x86.linux.gnu"
+            "Version": "1.9.0-rc2+0.x86.linux.musl"
         },
         "1.9.0-rc2~x86": {
-            "Version": "1.9.0-rc2+0.x86.linux.gnu"
+            "Version": "1.9.0-rc2+0.x86.linux.musl"
         },
         "1.9.0-rc3": {
-            "Version": "1.9.0-rc3+0.x86.linux.gnu"
+            "Version": "1.9.0-rc3+0.x86.linux.musl"
         },
         "1.9.0-rc3~x86": {
-            "Version": "1.9.0-rc3+0.x86.linux.gnu"
+            "Version": "1.9.0-rc3+0.x86.linux.musl"
         },
         "1.9.0~x86": {
-            "Version": "1.9.0+0.x86.linux.gnu"
+            "Version": "1.9.0+0.x86.linux.musl"
         },
         "1.9.1": {
-            "Version": "1.9.1+0.x86.linux.gnu"
+            "Version": "1.9.1+0.x86.linux.musl"
         },
         "1.9.1~x86": {
-            "Version": "1.9.1+0.x86.linux.gnu"
+            "Version": "1.9.1+0.x86.linux.musl"
         },
         "1.9.2": {
-            "Version": "1.9.2+0.x86.linux.gnu"
+            "Version": "1.9.2+0.x86.linux.musl"
         },
         "1.9.2~x86": {
-            "Version": "1.9.2+0.x86.linux.gnu"
+            "Version": "1.9.2+0.x86.linux.musl"
         },
         "1.9.3": {
-            "Version": "1.9.3+0.x86.linux.gnu"
+            "Version": "1.9.3+0.x86.linux.musl"
         },
         "1.9.3~x86": {
-            "Version": "1.9.3+0.x86.linux.gnu"
+            "Version": "1.9.3+0.x86.linux.musl"
         },
         "1.9.4": {
-            "Version": "1.9.4+0.x86.linux.gnu"
+            "Version": "1.9.4+0.x86.linux.musl"
         },
         "1.9.4~x86": {
-            "Version": "1.9.4+0.x86.linux.gnu"
+            "Version": "1.9.4+0.x86.linux.musl"
         },
         "1.9~x86": {
-            "Version": "1.9.4+0.x86.linux.gnu"
+            "Version": "1.9.4+0.x86.linux.musl"
         },
         "1~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "alpha": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "alpha~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "beta": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "beta~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "lts": {
-            "Version": "1.6.7+0.x86.linux.gnu"
+            "Version": "1.6.7+0.x86.linux.musl"
         },
         "lts~x86": {
-            "Version": "1.6.7+0.x86.linux.gnu"
+            "Version": "1.6.7+0.x86.linux.musl"
         },
         "rc": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "rc~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "release": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "release~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         }
     },
     "Version": "1.0.36"

--- a/versiondb/versiondb-x86_64-unknown-linux-musl.json
+++ b/versiondb/versiondb-x86_64-unknown-linux-musl.json
@@ -1,2337 +1,2337 @@
 {
     "AvailableVersions": {
-        "0.3.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.1-linux-i686.tar.gz"
+        "0.3.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.1-musl-i686.tar.gz"
         },
-        "0.3.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.1-linux-x86_64.tar.gz"
+        "0.3.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.1-musl-x86_64.tar.gz"
         },
-        "0.3.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.2-linux-i686.tar.gz"
+        "0.3.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.2-musl-i686.tar.gz"
         },
-        "0.3.2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.2-linux-x86_64.tar.gz"
+        "0.3.2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.2-musl-x86_64.tar.gz"
         },
-        "0.3.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.3-linux-i686.tar.gz"
+        "0.3.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.3-musl-i686.tar.gz"
         },
-        "0.3.3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.3-linux-x86_64.tar.gz"
+        "0.3.3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.3-musl-x86_64.tar.gz"
         },
-        "0.3.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.4-linux-i686.tar.gz"
+        "0.3.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.4-musl-i686.tar.gz"
         },
-        "0.3.4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.4-linux-x86_64.tar.gz"
+        "0.3.4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.4-musl-x86_64.tar.gz"
         },
-        "0.3.5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.5-linux-i686.tar.gz"
+        "0.3.5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.5-musl-i686.tar.gz"
         },
-        "0.3.5+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.5-linux-x86_64.tar.gz"
+        "0.3.5+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.5-musl-x86_64.tar.gz"
         },
-        "0.3.6+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.6-linux-i686.tar.gz"
+        "0.3.6+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.6-musl-i686.tar.gz"
         },
-        "0.3.6+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.6-linux-x86_64.tar.gz"
+        "0.3.6+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.6-musl-x86_64.tar.gz"
         },
-        "0.3.7+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.7-linux-i686.tar.gz"
+        "0.3.7+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.7-musl-i686.tar.gz"
         },
-        "0.3.7+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.7-linux-x86_64.tar.gz"
+        "0.3.7+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.7-musl-x86_64.tar.gz"
         },
-        "0.3.8+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.8-linux-i686.tar.gz"
+        "0.3.8+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.8-musl-i686.tar.gz"
         },
-        "0.3.8+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.8-linux-x86_64.tar.gz"
+        "0.3.8+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.8-musl-x86_64.tar.gz"
         },
-        "0.3.9+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.9-linux-i686.tar.gz"
+        "0.3.9+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.9-musl-i686.tar.gz"
         },
-        "0.3.9+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.9-linux-x86_64.tar.gz"
+        "0.3.9+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.9-musl-x86_64.tar.gz"
         },
-        "0.3.10+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.10-linux-i686.tar.gz"
+        "0.3.10+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.10-musl-i686.tar.gz"
         },
-        "0.3.10+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.10-linux-x86_64.tar.gz"
+        "0.3.10+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.10-musl-x86_64.tar.gz"
         },
-        "0.3.11+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.11-linux-i686.tar.gz"
+        "0.3.11+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.11-musl-i686.tar.gz"
         },
-        "0.3.11+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.11-linux-x86_64.tar.gz"
+        "0.3.11+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.11-musl-x86_64.tar.gz"
         },
-        "0.3.12+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.3/julia-0.3.12-linux-i686.tar.gz"
+        "0.3.12+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.3/julia-0.3.12-musl-i686.tar.gz"
         },
-        "0.3.12+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.3/julia-0.3.12-linux-x86_64.tar.gz"
+        "0.3.12+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.3/julia-0.3.12-musl-x86_64.tar.gz"
         },
-        "0.4.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.0-rc1-linux-i686.tar.gz"
+        "0.4.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.0-rc1-musl-i686.tar.gz"
         },
-        "0.4.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.0-rc1-linux-x86_64.tar.gz"
+        "0.4.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.0-rc1-musl-x86_64.tar.gz"
         },
-        "0.4.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.0-rc2-linux-i686.tar.gz"
+        "0.4.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.0-rc2-musl-i686.tar.gz"
         },
-        "0.4.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.0-rc2-linux-x86_64.tar.gz"
+        "0.4.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.0-rc2-musl-x86_64.tar.gz"
         },
-        "0.4.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.0-rc3-linux-i686.tar.gz"
+        "0.4.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.0-rc3-musl-i686.tar.gz"
         },
-        "0.4.0-rc3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.0-rc3-linux-x86_64.tar.gz"
+        "0.4.0-rc3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.0-rc3-musl-x86_64.tar.gz"
         },
-        "0.4.0-rc4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.0-rc4-linux-i686.tar.gz"
+        "0.4.0-rc4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.0-rc4-musl-i686.tar.gz"
         },
-        "0.4.0-rc4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.0-rc4-linux-x86_64.tar.gz"
+        "0.4.0-rc4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.0-rc4-musl-x86_64.tar.gz"
         },
-        "0.4.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.0-linux-i686.tar.gz"
+        "0.4.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.0-musl-i686.tar.gz"
         },
-        "0.4.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.0-linux-x86_64.tar.gz"
+        "0.4.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.0-musl-x86_64.tar.gz"
         },
-        "0.4.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.1-linux-i686.tar.gz"
+        "0.4.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.1-musl-i686.tar.gz"
         },
-        "0.4.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.1-linux-x86_64.tar.gz"
+        "0.4.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.1-musl-x86_64.tar.gz"
         },
-        "0.4.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.2-linux-i686.tar.gz"
+        "0.4.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.2-musl-i686.tar.gz"
         },
-        "0.4.2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.2-linux-x86_64.tar.gz"
+        "0.4.2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.2-musl-x86_64.tar.gz"
         },
-        "0.4.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.3-linux-i686.tar.gz"
+        "0.4.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.3-musl-i686.tar.gz"
         },
-        "0.4.3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.3-linux-x86_64.tar.gz"
+        "0.4.3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.3-musl-x86_64.tar.gz"
         },
-        "0.4.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.4-linux-i686.tar.gz"
+        "0.4.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.4-musl-i686.tar.gz"
         },
-        "0.4.4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.4-linux-x86_64.tar.gz"
+        "0.4.4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.4-musl-x86_64.tar.gz"
         },
-        "0.4.5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.5-linux-i686.tar.gz"
+        "0.4.5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.5-musl-i686.tar.gz"
         },
-        "0.4.5+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.5-linux-x86_64.tar.gz"
+        "0.4.5+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.5-musl-x86_64.tar.gz"
         },
-        "0.4.6+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.6-linux-i686.tar.gz"
+        "0.4.6+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.6-musl-i686.tar.gz"
         },
-        "0.4.6+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.6-linux-x86_64.tar.gz"
+        "0.4.6+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.6-musl-x86_64.tar.gz"
         },
-        "0.4.7+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.4/julia-0.4.7-linux-i686.tar.gz"
+        "0.4.7+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.4/julia-0.4.7-musl-i686.tar.gz"
         },
-        "0.4.7+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.4/julia-0.4.7-linux-x86_64.tar.gz"
+        "0.4.7+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.4/julia-0.4.7-musl-x86_64.tar.gz"
         },
-        "0.5.0-rc0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-rc0-linux-i686.tar.gz"
+        "0.5.0-rc0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-rc0-musl-i686.tar.gz"
         },
-        "0.5.0-rc0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.5/julia-0.5.0-rc0-linux-x86_64.tar.gz"
+        "0.5.0-rc0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.5/julia-0.5.0-rc0-musl-x86_64.tar.gz"
         },
-        "0.5.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-rc1-linux-i686.tar.gz"
+        "0.5.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-rc1-musl-i686.tar.gz"
         },
-        "0.5.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.5/julia-0.5.0-rc1-linux-x86_64.tar.gz"
+        "0.5.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.5/julia-0.5.0-rc1-musl-x86_64.tar.gz"
         },
-        "0.5.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-rc2-linux-i686.tar.gz"
+        "0.5.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-rc2-musl-i686.tar.gz"
         },
-        "0.5.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.5/julia-0.5.0-rc2-linux-x86_64.tar.gz"
+        "0.5.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.5/julia-0.5.0-rc2-musl-x86_64.tar.gz"
         },
-        "0.5.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-rc3-linux-i686.tar.gz"
+        "0.5.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-rc3-musl-i686.tar.gz"
         },
-        "0.5.0-rc3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.5/julia-0.5.0-rc3-linux-x86_64.tar.gz"
+        "0.5.0-rc3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.5/julia-0.5.0-rc3-musl-x86_64.tar.gz"
         },
-        "0.5.0-rc4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-rc4-linux-i686.tar.gz"
+        "0.5.0-rc4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-rc4-musl-i686.tar.gz"
         },
-        "0.5.0-rc4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.5/julia-0.5.0-rc4-linux-x86_64.tar.gz"
+        "0.5.0-rc4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.5/julia-0.5.0-rc4-musl-x86_64.tar.gz"
         },
-        "0.5.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.0-linux-i686.tar.gz"
+        "0.5.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.0-musl-i686.tar.gz"
         },
-        "0.5.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.5/julia-0.5.0-linux-x86_64.tar.gz"
+        "0.5.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.5/julia-0.5.0-musl-x86_64.tar.gz"
         },
-        "0.5.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.1-linux-i686.tar.gz"
+        "0.5.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.1-musl-i686.tar.gz"
         },
-        "0.5.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.5/julia-0.5.1-linux-x86_64.tar.gz"
+        "0.5.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.5/julia-0.5.1-musl-x86_64.tar.gz"
         },
-        "0.5.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.5/julia-0.5.2-linux-i686.tar.gz"
+        "0.5.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.5/julia-0.5.2-musl-i686.tar.gz"
         },
-        "0.5.2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.5/julia-0.5.2-linux-x86_64.tar.gz"
+        "0.5.2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.5/julia-0.5.2-musl-x86_64.tar.gz"
         },
-        "0.6.0-pre.alpha+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-pre.alpha-linux-i686.tar.gz"
+        "0.6.0-pre.alpha+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-pre.alpha-musl-i686.tar.gz"
         },
-        "0.6.0-pre.alpha+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.6/julia-0.6.0-pre.alpha-linux-x86_64.tar.gz"
+        "0.6.0-pre.alpha+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.6/julia-0.6.0-pre.alpha-musl-x86_64.tar.gz"
         },
-        "0.6.0-pre.beta+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-pre.beta-linux-i686.tar.gz"
+        "0.6.0-pre.beta+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-pre.beta-musl-i686.tar.gz"
         },
-        "0.6.0-pre.beta+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.6/julia-0.6.0-pre.beta-linux-x86_64.tar.gz"
+        "0.6.0-pre.beta+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.6/julia-0.6.0-pre.beta-musl-x86_64.tar.gz"
         },
-        "0.6.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-rc1-linux-i686.tar.gz"
+        "0.6.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-rc1-musl-i686.tar.gz"
         },
-        "0.6.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.6/julia-0.6.0-rc1-linux-x86_64.tar.gz"
+        "0.6.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.6/julia-0.6.0-rc1-musl-x86_64.tar.gz"
         },
-        "0.6.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-rc2-linux-i686.tar.gz"
+        "0.6.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-rc2-musl-i686.tar.gz"
         },
-        "0.6.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.6/julia-0.6.0-rc2-linux-x86_64.tar.gz"
+        "0.6.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.6/julia-0.6.0-rc2-musl-x86_64.tar.gz"
         },
-        "0.6.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-rc3-linux-i686.tar.gz"
+        "0.6.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-rc3-musl-i686.tar.gz"
         },
-        "0.6.0-rc3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.6/julia-0.6.0-rc3-linux-x86_64.tar.gz"
+        "0.6.0-rc3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.6/julia-0.6.0-rc3-musl-x86_64.tar.gz"
         },
-        "0.6.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.0-linux-i686.tar.gz"
+        "0.6.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.0-musl-i686.tar.gz"
         },
-        "0.6.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.6/julia-0.6.0-linux-x86_64.tar.gz"
+        "0.6.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.6/julia-0.6.0-musl-x86_64.tar.gz"
         },
-        "0.6.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.1-linux-i686.tar.gz"
+        "0.6.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.1-musl-i686.tar.gz"
         },
-        "0.6.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.6/julia-0.6.1-linux-x86_64.tar.gz"
+        "0.6.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.6/julia-0.6.1-musl-x86_64.tar.gz"
         },
-        "0.6.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.2-linux-i686.tar.gz"
+        "0.6.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.2-musl-i686.tar.gz"
         },
-        "0.6.2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.6/julia-0.6.2-linux-x86_64.tar.gz"
+        "0.6.2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.6/julia-0.6.2-musl-x86_64.tar.gz"
         },
-        "0.6.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.3-linux-i686.tar.gz"
+        "0.6.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.3-musl-i686.tar.gz"
         },
-        "0.6.3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.6/julia-0.6.3-linux-x86_64.tar.gz"
+        "0.6.3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.6/julia-0.6.3-musl-x86_64.tar.gz"
         },
-        "0.6.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.6/julia-0.6.4-linux-i686.tar.gz"
+        "0.6.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.6/julia-0.6.4-musl-i686.tar.gz"
         },
-        "0.6.4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.6/julia-0.6.4-linux-x86_64.tar.gz"
+        "0.6.4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.6/julia-0.6.4-musl-x86_64.tar.gz"
         },
-        "0.7.0-alpha+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-alpha-linux-i686.tar.gz"
+        "0.7.0-alpha+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-alpha-musl-i686.tar.gz"
         },
-        "0.7.0-alpha+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.7/julia-0.7.0-alpha-linux-x86_64.tar.gz"
+        "0.7.0-alpha+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.7/julia-0.7.0-alpha-musl-x86_64.tar.gz"
         },
-        "0.7.0-beta+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-beta-linux-i686.tar.gz"
+        "0.7.0-beta+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-beta-musl-i686.tar.gz"
         },
-        "0.7.0-beta+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.7/julia-0.7.0-beta-linux-x86_64.tar.gz"
+        "0.7.0-beta+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.7/julia-0.7.0-beta-musl-x86_64.tar.gz"
         },
-        "0.7.0-beta2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-beta2-linux-i686.tar.gz"
+        "0.7.0-beta2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-beta2-musl-i686.tar.gz"
         },
-        "0.7.0-beta2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.7/julia-0.7.0-beta2-linux-x86_64.tar.gz"
+        "0.7.0-beta2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.7/julia-0.7.0-beta2-musl-x86_64.tar.gz"
         },
-        "0.7.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-rc1-linux-i686.tar.gz"
+        "0.7.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-rc1-musl-i686.tar.gz"
         },
-        "0.7.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.7/julia-0.7.0-rc1-linux-x86_64.tar.gz"
+        "0.7.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.7/julia-0.7.0-rc1-musl-x86_64.tar.gz"
         },
-        "0.7.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-rc2-linux-i686.tar.gz"
+        "0.7.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-rc2-musl-i686.tar.gz"
         },
-        "0.7.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.7/julia-0.7.0-rc2-linux-x86_64.tar.gz"
+        "0.7.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.7/julia-0.7.0-rc2-musl-x86_64.tar.gz"
         },
-        "0.7.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-rc3-linux-i686.tar.gz"
+        "0.7.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-rc3-musl-i686.tar.gz"
         },
-        "0.7.0-rc3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.7/julia-0.7.0-rc3-linux-x86_64.tar.gz"
+        "0.7.0-rc3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.7/julia-0.7.0-rc3-musl-x86_64.tar.gz"
         },
-        "0.7.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/0.7/julia-0.7.0-linux-i686.tar.gz"
+        "0.7.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/0.7/julia-0.7.0-musl-i686.tar.gz"
         },
-        "0.7.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz"
+        "0.7.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/0.7/julia-0.7.0-musl-x86_64.tar.gz"
         },
-        "1.0.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.0-rc1-linux-i686.tar.gz"
+        "1.0.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.0-rc1-musl-i686.tar.gz"
         },
-        "1.0.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.0/julia-1.0.0-rc1-linux-x86_64.tar.gz"
+        "1.0.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.0/julia-1.0.0-rc1-musl-x86_64.tar.gz"
         },
-        "1.0.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.0-linux-i686.tar.gz"
+        "1.0.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.0-musl-i686.tar.gz"
         },
-        "1.0.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.0/julia-1.0.0-linux-x86_64.tar.gz"
+        "1.0.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.0/julia-1.0.0-musl-x86_64.tar.gz"
         },
-        "1.0.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.1-linux-i686.tar.gz"
+        "1.0.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.1-musl-i686.tar.gz"
         },
-        "1.0.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.0/julia-1.0.1-linux-x86_64.tar.gz"
+        "1.0.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.0/julia-1.0.1-musl-x86_64.tar.gz"
         },
-        "1.0.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.2-linux-i686.tar.gz"
+        "1.0.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.2-musl-i686.tar.gz"
         },
-        "1.0.2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.0/julia-1.0.2-linux-x86_64.tar.gz"
+        "1.0.2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.0/julia-1.0.2-musl-x86_64.tar.gz"
         },
-        "1.0.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.3-linux-i686.tar.gz"
+        "1.0.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.3-musl-i686.tar.gz"
         },
-        "1.0.3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.0/julia-1.0.3-linux-x86_64.tar.gz"
+        "1.0.3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.0/julia-1.0.3-musl-x86_64.tar.gz"
         },
-        "1.0.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.4-linux-i686.tar.gz"
+        "1.0.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.4-musl-i686.tar.gz"
         },
-        "1.0.4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.0/julia-1.0.4-linux-x86_64.tar.gz"
+        "1.0.4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.0/julia-1.0.4-musl-x86_64.tar.gz"
         },
-        "1.0.5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.0/julia-1.0.5-linux-i686.tar.gz"
+        "1.0.5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.0/julia-1.0.5-musl-i686.tar.gz"
         },
-        "1.0.5+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.0/julia-1.0.5-linux-x86_64.tar.gz"
+        "1.0.5+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.0/julia-1.0.5-musl-x86_64.tar.gz"
         },
-        "1.1.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.1/julia-1.1.0-rc1-linux-i686.tar.gz"
+        "1.1.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.1/julia-1.1.0-rc1-musl-i686.tar.gz"
         },
-        "1.1.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.1/julia-1.1.0-rc1-linux-x86_64.tar.gz"
+        "1.1.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.1/julia-1.1.0-rc1-musl-x86_64.tar.gz"
         },
-        "1.1.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.1/julia-1.1.0-rc2-linux-i686.tar.gz"
+        "1.1.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.1/julia-1.1.0-rc2-musl-i686.tar.gz"
         },
-        "1.1.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.1/julia-1.1.0-rc2-linux-x86_64.tar.gz"
+        "1.1.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.1/julia-1.1.0-rc2-musl-x86_64.tar.gz"
         },
-        "1.1.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.1/julia-1.1.0-linux-i686.tar.gz"
+        "1.1.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.1/julia-1.1.0-musl-i686.tar.gz"
         },
-        "1.1.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.1/julia-1.1.0-linux-x86_64.tar.gz"
+        "1.1.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.1/julia-1.1.0-musl-x86_64.tar.gz"
         },
-        "1.1.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.1/julia-1.1.1-linux-i686.tar.gz"
+        "1.1.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.1/julia-1.1.1-musl-i686.tar.gz"
         },
-        "1.1.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.1/julia-1.1.1-linux-x86_64.tar.gz"
+        "1.1.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.1/julia-1.1.1-musl-x86_64.tar.gz"
         },
-        "1.2.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.2/julia-1.2.0-rc1-linux-i686.tar.gz"
+        "1.2.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.2/julia-1.2.0-rc1-musl-i686.tar.gz"
         },
-        "1.2.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.2/julia-1.2.0-rc1-linux-x86_64.tar.gz"
+        "1.2.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.2/julia-1.2.0-rc1-musl-x86_64.tar.gz"
         },
-        "1.2.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.2/julia-1.2.0-rc2-linux-i686.tar.gz"
+        "1.2.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.2/julia-1.2.0-rc2-musl-i686.tar.gz"
         },
-        "1.2.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.2/julia-1.2.0-rc2-linux-x86_64.tar.gz"
+        "1.2.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.2/julia-1.2.0-rc2-musl-x86_64.tar.gz"
         },
-        "1.2.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.2/julia-1.2.0-rc3-linux-i686.tar.gz"
+        "1.2.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.2/julia-1.2.0-rc3-musl-i686.tar.gz"
         },
-        "1.2.0-rc3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.2/julia-1.2.0-rc3-linux-x86_64.tar.gz"
+        "1.2.0-rc3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.2/julia-1.2.0-rc3-musl-x86_64.tar.gz"
         },
-        "1.2.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.2/julia-1.2.0-linux-i686.tar.gz"
+        "1.2.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.2/julia-1.2.0-musl-i686.tar.gz"
         },
-        "1.2.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.2/julia-1.2.0-linux-x86_64.tar.gz"
+        "1.2.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.2/julia-1.2.0-musl-x86_64.tar.gz"
         },
-        "1.3.0-alpha+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-alpha-linux-i686.tar.gz"
+        "1.3.0-alpha+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-alpha-musl-i686.tar.gz"
         },
-        "1.3.0-alpha+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.3/julia-1.3.0-alpha-linux-x86_64.tar.gz"
+        "1.3.0-alpha+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.3/julia-1.3.0-alpha-musl-x86_64.tar.gz"
         },
-        "1.3.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-rc1-linux-i686.tar.gz"
+        "1.3.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-rc1-musl-i686.tar.gz"
         },
-        "1.3.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.3/julia-1.3.0-rc1-linux-x86_64.tar.gz"
+        "1.3.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.3/julia-1.3.0-rc1-musl-x86_64.tar.gz"
         },
-        "1.3.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-rc2-linux-i686.tar.gz"
+        "1.3.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-rc2-musl-i686.tar.gz"
         },
-        "1.3.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.3/julia-1.3.0-rc2-linux-x86_64.tar.gz"
+        "1.3.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.3/julia-1.3.0-rc2-musl-x86_64.tar.gz"
         },
-        "1.3.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-rc3-linux-i686.tar.gz"
+        "1.3.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-rc3-musl-i686.tar.gz"
         },
-        "1.3.0-rc3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.3/julia-1.3.0-rc3-linux-x86_64.tar.gz"
+        "1.3.0-rc3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.3/julia-1.3.0-rc3-musl-x86_64.tar.gz"
         },
-        "1.3.0-rc4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-rc4-linux-i686.tar.gz"
+        "1.3.0-rc4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-rc4-musl-i686.tar.gz"
         },
-        "1.3.0-rc4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.3/julia-1.3.0-rc4-linux-x86_64.tar.gz"
+        "1.3.0-rc4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.3/julia-1.3.0-rc4-musl-x86_64.tar.gz"
         },
-        "1.3.0-rc5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-rc5-linux-i686.tar.gz"
+        "1.3.0-rc5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-rc5-musl-i686.tar.gz"
         },
-        "1.3.0-rc5+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.3/julia-1.3.0-rc5-linux-x86_64.tar.gz"
+        "1.3.0-rc5+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.3/julia-1.3.0-rc5-musl-x86_64.tar.gz"
         },
-        "1.3.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.0-linux-i686.tar.gz"
+        "1.3.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.0-musl-i686.tar.gz"
         },
-        "1.3.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.3/julia-1.3.0-linux-x86_64.tar.gz"
+        "1.3.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.3/julia-1.3.0-musl-x86_64.tar.gz"
         },
-        "1.3.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.3/julia-1.3.1-linux-i686.tar.gz"
+        "1.3.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.3/julia-1.3.1-musl-i686.tar.gz"
         },
-        "1.3.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.3/julia-1.3.1-linux-x86_64.tar.gz"
+        "1.3.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.3/julia-1.3.1-musl-x86_64.tar.gz"
         },
-        "1.4.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.4/julia-1.4.0-rc1-linux-i686.tar.gz"
+        "1.4.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.4/julia-1.4.0-rc1-musl-i686.tar.gz"
         },
-        "1.4.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.4/julia-1.4.0-rc1-linux-x86_64.tar.gz"
+        "1.4.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.4/julia-1.4.0-rc1-musl-x86_64.tar.gz"
         },
-        "1.4.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.4/julia-1.4.0-rc2-linux-i686.tar.gz"
+        "1.4.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.4/julia-1.4.0-rc2-musl-i686.tar.gz"
         },
-        "1.4.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.4/julia-1.4.0-rc2-linux-x86_64.tar.gz"
+        "1.4.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.4/julia-1.4.0-rc2-musl-x86_64.tar.gz"
         },
-        "1.4.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.4/julia-1.4.0-linux-i686.tar.gz"
+        "1.4.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.4/julia-1.4.0-musl-i686.tar.gz"
         },
-        "1.4.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.4/julia-1.4.0-linux-x86_64.tar.gz"
+        "1.4.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.4/julia-1.4.0-musl-x86_64.tar.gz"
         },
-        "1.4.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.4/julia-1.4.1-linux-i686.tar.gz"
+        "1.4.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.4/julia-1.4.1-musl-i686.tar.gz"
         },
-        "1.4.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.4/julia-1.4.1-linux-x86_64.tar.gz"
+        "1.4.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.4/julia-1.4.1-musl-x86_64.tar.gz"
         },
-        "1.4.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.4/julia-1.4.2-linux-i686.tar.gz"
+        "1.4.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.4/julia-1.4.2-musl-i686.tar.gz"
         },
-        "1.4.2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz"
+        "1.4.2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.4/julia-1.4.2-musl-x86_64.tar.gz"
         },
-        "1.5.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.0-beta1-linux-i686.tar.gz"
+        "1.5.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.0-beta1-musl-i686.tar.gz"
         },
-        "1.5.0-beta1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.5/julia-1.5.0-beta1-linux-x86_64.tar.gz"
+        "1.5.0-beta1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.5/julia-1.5.0-beta1-musl-x86_64.tar.gz"
         },
-        "1.5.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.0-rc1-linux-i686.tar.gz"
+        "1.5.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.0-rc1-musl-i686.tar.gz"
         },
-        "1.5.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.5/julia-1.5.0-rc1-linux-x86_64.tar.gz"
+        "1.5.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.5/julia-1.5.0-rc1-musl-x86_64.tar.gz"
         },
-        "1.5.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.0-rc2-linux-i686.tar.gz"
+        "1.5.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.0-rc2-musl-i686.tar.gz"
         },
-        "1.5.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.5/julia-1.5.0-rc2-linux-x86_64.tar.gz"
+        "1.5.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.5/julia-1.5.0-rc2-musl-x86_64.tar.gz"
         },
-        "1.5.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.0-linux-i686.tar.gz"
+        "1.5.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.0-musl-i686.tar.gz"
         },
-        "1.5.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.5/julia-1.5.0-linux-x86_64.tar.gz"
+        "1.5.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.5/julia-1.5.0-musl-x86_64.tar.gz"
         },
-        "1.5.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.1-linux-i686.tar.gz"
+        "1.5.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.1-musl-i686.tar.gz"
         },
-        "1.5.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.5/julia-1.5.1-linux-x86_64.tar.gz"
+        "1.5.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.5/julia-1.5.1-musl-x86_64.tar.gz"
         },
-        "1.5.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.2-linux-i686.tar.gz"
+        "1.5.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.2-musl-i686.tar.gz"
         },
-        "1.5.2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.5/julia-1.5.2-linux-x86_64.tar.gz"
+        "1.5.2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.5/julia-1.5.2-musl-x86_64.tar.gz"
         },
-        "1.5.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.3-linux-i686.tar.gz"
+        "1.5.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.3-musl-i686.tar.gz"
         },
-        "1.5.3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.5/julia-1.5.3-linux-x86_64.tar.gz"
+        "1.5.3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.5/julia-1.5.3-musl-x86_64.tar.gz"
         },
-        "1.5.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.5/julia-1.5.4-linux-i686.tar.gz"
+        "1.5.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.5/julia-1.5.4-musl-i686.tar.gz"
         },
-        "1.5.4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.5/julia-1.5.4-linux-x86_64.tar.gz"
+        "1.5.4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.5/julia-1.5.4-musl-x86_64.tar.gz"
         },
-        "1.6.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.0-beta1-linux-i686.tar.gz"
+        "1.6.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.0-beta1-musl-i686.tar.gz"
         },
-        "1.6.0-beta1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.0-beta1-linux-x86_64.tar.gz"
+        "1.6.0-beta1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.0-beta1-musl-x86_64.tar.gz"
         },
-        "1.6.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.0-rc1-linux-i686.tar.gz"
+        "1.6.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.0-rc1-musl-i686.tar.gz"
         },
-        "1.6.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.0-rc1-linux-x86_64.tar.gz"
+        "1.6.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.0-rc1-musl-x86_64.tar.gz"
         },
-        "1.6.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.0-rc2-linux-i686.tar.gz"
+        "1.6.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.0-rc2-musl-i686.tar.gz"
         },
-        "1.6.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.0-rc2-linux-x86_64.tar.gz"
+        "1.6.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.0-rc2-musl-x86_64.tar.gz"
         },
-        "1.6.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.0-rc3-linux-i686.tar.gz"
+        "1.6.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.0-rc3-musl-i686.tar.gz"
         },
-        "1.6.0-rc3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.0-rc3-linux-x86_64.tar.gz"
+        "1.6.0-rc3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.0-rc3-musl-x86_64.tar.gz"
         },
-        "1.6.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.0-linux-i686.tar.gz"
+        "1.6.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.0-musl-i686.tar.gz"
         },
-        "1.6.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.0-linux-x86_64.tar.gz"
+        "1.6.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.0-musl-x86_64.tar.gz"
         },
-        "1.6.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.1-linux-i686.tar.gz"
+        "1.6.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.1-musl-i686.tar.gz"
         },
-        "1.6.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.1-linux-x86_64.tar.gz"
+        "1.6.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.1-musl-x86_64.tar.gz"
         },
-        "1.6.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.2-linux-i686.tar.gz"
+        "1.6.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.2-musl-i686.tar.gz"
         },
-        "1.6.2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.2-linux-x86_64.tar.gz"
+        "1.6.2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.2-musl-x86_64.tar.gz"
         },
-        "1.6.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.3-linux-i686.tar.gz"
+        "1.6.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.3-musl-i686.tar.gz"
         },
-        "1.6.3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.3-linux-x86_64.tar.gz"
+        "1.6.3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.3-musl-x86_64.tar.gz"
         },
-        "1.6.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.4-linux-i686.tar.gz"
+        "1.6.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.4-musl-i686.tar.gz"
         },
-        "1.6.4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.4-linux-x86_64.tar.gz"
+        "1.6.4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.4-musl-x86_64.tar.gz"
         },
-        "1.6.5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.5-linux-i686.tar.gz"
+        "1.6.5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.5-musl-i686.tar.gz"
         },
-        "1.6.5+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.5-linux-x86_64.tar.gz"
+        "1.6.5+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.5-musl-x86_64.tar.gz"
         },
-        "1.6.6+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.6-linux-i686.tar.gz"
+        "1.6.6+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.6-musl-i686.tar.gz"
         },
-        "1.6.6+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.6-linux-x86_64.tar.gz"
+        "1.6.6+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.6-musl-x86_64.tar.gz"
         },
-        "1.6.7+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.6/julia-1.6.7-linux-i686.tar.gz"
+        "1.6.7+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.6/julia-1.6.7-musl-i686.tar.gz"
         },
-        "1.6.7+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.6/julia-1.6.7-linux-x86_64.tar.gz"
+        "1.6.7+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.6/julia-1.6.7-musl-x86_64.tar.gz"
         },
-        "1.7.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-beta1-linux-i686.tar.gz"
+        "1.7.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-beta1-musl-i686.tar.gz"
         },
-        "1.7.0-beta1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.7/julia-1.7.0-beta1-linux-x86_64.tar.gz"
+        "1.7.0-beta1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.7/julia-1.7.0-beta1-musl-x86_64.tar.gz"
         },
-        "1.7.0-beta2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-beta2-linux-i686.tar.gz"
+        "1.7.0-beta2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-beta2-musl-i686.tar.gz"
         },
-        "1.7.0-beta2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.7/julia-1.7.0-beta2-linux-x86_64.tar.gz"
+        "1.7.0-beta2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.7/julia-1.7.0-beta2-musl-x86_64.tar.gz"
         },
-        "1.7.0-beta3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-beta3-linux-i686.tar.gz"
+        "1.7.0-beta3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-beta3-musl-i686.tar.gz"
         },
-        "1.7.0-beta3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.7/julia-1.7.0-beta3-linux-x86_64.tar.gz"
+        "1.7.0-beta3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.7/julia-1.7.0-beta3-musl-x86_64.tar.gz"
         },
-        "1.7.0-beta4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-beta4-linux-i686.tar.gz"
+        "1.7.0-beta4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-beta4-musl-i686.tar.gz"
         },
-        "1.7.0-beta4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.7/julia-1.7.0-beta4-linux-x86_64.tar.gz"
+        "1.7.0-beta4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.7/julia-1.7.0-beta4-musl-x86_64.tar.gz"
         },
-        "1.7.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-rc1-linux-i686.tar.gz"
+        "1.7.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-rc1-musl-i686.tar.gz"
         },
-        "1.7.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.7/julia-1.7.0-rc1-linux-x86_64.tar.gz"
+        "1.7.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.7/julia-1.7.0-rc1-musl-x86_64.tar.gz"
         },
-        "1.7.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-rc2-linux-i686.tar.gz"
+        "1.7.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-rc2-musl-i686.tar.gz"
         },
-        "1.7.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.7/julia-1.7.0-rc2-linux-x86_64.tar.gz"
+        "1.7.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.7/julia-1.7.0-rc2-musl-x86_64.tar.gz"
         },
-        "1.7.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-rc3-linux-i686.tar.gz"
+        "1.7.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-rc3-musl-i686.tar.gz"
         },
-        "1.7.0-rc3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.7/julia-1.7.0-rc3-linux-x86_64.tar.gz"
+        "1.7.0-rc3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.7/julia-1.7.0-rc3-musl-x86_64.tar.gz"
         },
-        "1.7.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.0-linux-i686.tar.gz"
+        "1.7.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.0-musl-i686.tar.gz"
         },
-        "1.7.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.7/julia-1.7.0-linux-x86_64.tar.gz"
+        "1.7.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.7/julia-1.7.0-musl-x86_64.tar.gz"
         },
-        "1.7.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.1-linux-i686.tar.gz"
+        "1.7.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.1-musl-i686.tar.gz"
         },
-        "1.7.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.7/julia-1.7.1-linux-x86_64.tar.gz"
+        "1.7.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.7/julia-1.7.1-musl-x86_64.tar.gz"
         },
-        "1.7.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.2-linux-i686.tar.gz"
+        "1.7.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.2-musl-i686.tar.gz"
         },
-        "1.7.2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.7/julia-1.7.2-linux-x86_64.tar.gz"
+        "1.7.2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.7/julia-1.7.2-musl-x86_64.tar.gz"
         },
-        "1.7.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.7/julia-1.7.3-linux-i686.tar.gz"
+        "1.7.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.7/julia-1.7.3-musl-i686.tar.gz"
         },
-        "1.7.3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.7/julia-1.7.3-linux-x86_64.tar.gz"
+        "1.7.3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.7/julia-1.7.3-musl-x86_64.tar.gz"
         },
-        "1.8.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-beta1-linux-i686.tar.gz"
+        "1.8.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-beta1-musl-i686.tar.gz"
         },
-        "1.8.0-beta1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.0-beta1-linux-x86_64.tar.gz"
+        "1.8.0-beta1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.0-beta1-musl-x86_64.tar.gz"
         },
-        "1.8.0-beta2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-beta2-linux-i686.tar.gz"
+        "1.8.0-beta2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-beta2-musl-i686.tar.gz"
         },
-        "1.8.0-beta3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-beta3-linux-i686.tar.gz"
+        "1.8.0-beta3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-beta3-musl-i686.tar.gz"
         },
-        "1.8.0-beta3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.0-beta3-linux-x86_64.tar.gz"
+        "1.8.0-beta3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.0-beta3-musl-x86_64.tar.gz"
         },
-        "1.8.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-rc1-linux-i686.tar.gz"
+        "1.8.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-rc1-musl-i686.tar.gz"
         },
-        "1.8.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.0-rc1-linux-x86_64.tar.gz"
+        "1.8.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.0-rc1-musl-x86_64.tar.gz"
         },
-        "1.8.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-rc2-linux-i686.tar.gz"
+        "1.8.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-rc2-musl-i686.tar.gz"
         },
-        "1.8.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.0-rc2-linux-x86_64.tar.gz"
+        "1.8.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.0-rc2-musl-x86_64.tar.gz"
         },
-        "1.8.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-rc3-linux-i686.tar.gz"
+        "1.8.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-rc3-musl-i686.tar.gz"
         },
-        "1.8.0-rc3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.0-rc3-linux-x86_64.tar.gz"
+        "1.8.0-rc3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.0-rc3-musl-x86_64.tar.gz"
         },
-        "1.8.0-rc4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-rc4-linux-i686.tar.gz"
+        "1.8.0-rc4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-rc4-musl-i686.tar.gz"
         },
-        "1.8.0-rc4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.0-rc4-linux-x86_64.tar.gz"
+        "1.8.0-rc4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.0-rc4-musl-x86_64.tar.gz"
         },
-        "1.8.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.0-linux-i686.tar.gz"
+        "1.8.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.0-musl-i686.tar.gz"
         },
-        "1.8.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.0-linux-x86_64.tar.gz"
+        "1.8.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.0-musl-x86_64.tar.gz"
         },
-        "1.8.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.1-linux-i686.tar.gz"
+        "1.8.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.1-musl-i686.tar.gz"
         },
-        "1.8.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.1-linux-x86_64.tar.gz"
+        "1.8.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.1-musl-x86_64.tar.gz"
         },
-        "1.8.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.2-linux-i686.tar.gz"
+        "1.8.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.2-musl-i686.tar.gz"
         },
-        "1.8.2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.2-linux-x86_64.tar.gz"
+        "1.8.2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.2-musl-x86_64.tar.gz"
         },
-        "1.8.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.3-linux-i686.tar.gz"
+        "1.8.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.3-musl-i686.tar.gz"
         },
-        "1.8.3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.3-linux-x86_64.tar.gz"
+        "1.8.3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.3-musl-x86_64.tar.gz"
         },
-        "1.8.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.4-linux-i686.tar.gz"
+        "1.8.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.4-musl-i686.tar.gz"
         },
-        "1.8.4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.4-linux-x86_64.tar.gz"
+        "1.8.4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.4-musl-x86_64.tar.gz"
         },
-        "1.8.5+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.8/julia-1.8.5-linux-i686.tar.gz"
+        "1.8.5+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.8/julia-1.8.5-musl-i686.tar.gz"
         },
-        "1.8.5+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.8/julia-1.8.5-linux-x86_64.tar.gz"
+        "1.8.5+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.8/julia-1.8.5-musl-x86_64.tar.gz"
         },
-        "1.9.0-alpha1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-alpha1-linux-i686.tar.gz"
+        "1.9.0-alpha1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-alpha1-musl-i686.tar.gz"
         },
-        "1.9.0-alpha1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.0-alpha1-linux-x86_64.tar.gz"
+        "1.9.0-alpha1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.0-alpha1-musl-x86_64.tar.gz"
         },
-        "1.9.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-beta1-linux-i686.tar.gz"
+        "1.9.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-beta1-musl-i686.tar.gz"
         },
-        "1.9.0-beta1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.0-beta1-linux-x86_64.tar.gz"
+        "1.9.0-beta1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.0-beta1-musl-x86_64.tar.gz"
         },
-        "1.9.0-beta2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-beta2-linux-i686.tar.gz"
+        "1.9.0-beta2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-beta2-musl-i686.tar.gz"
         },
-        "1.9.0-beta2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.0-beta2-linux-x86_64.tar.gz"
+        "1.9.0-beta2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.0-beta2-musl-x86_64.tar.gz"
         },
-        "1.9.0-beta3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-beta3-linux-i686.tar.gz"
+        "1.9.0-beta3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-beta3-musl-i686.tar.gz"
         },
-        "1.9.0-beta3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.0-beta3-linux-x86_64.tar.gz"
+        "1.9.0-beta3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.0-beta3-musl-x86_64.tar.gz"
         },
-        "1.9.0-beta4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-beta4-linux-i686.tar.gz"
+        "1.9.0-beta4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-beta4-musl-i686.tar.gz"
         },
-        "1.9.0-beta4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.0-beta4-linux-x86_64.tar.gz"
+        "1.9.0-beta4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.0-beta4-musl-x86_64.tar.gz"
         },
-        "1.9.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-rc1-linux-i686.tar.gz"
+        "1.9.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-rc1-musl-i686.tar.gz"
         },
-        "1.9.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.0-rc1-linux-x86_64.tar.gz"
+        "1.9.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.0-rc1-musl-x86_64.tar.gz"
         },
-        "1.9.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-rc2-linux-i686.tar.gz"
+        "1.9.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-rc2-musl-i686.tar.gz"
         },
-        "1.9.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.0-rc2-linux-x86_64.tar.gz"
+        "1.9.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.0-rc2-musl-x86_64.tar.gz"
         },
-        "1.9.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-rc3-linux-i686.tar.gz"
+        "1.9.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-rc3-musl-i686.tar.gz"
         },
-        "1.9.0-rc3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.0-rc3-linux-x86_64.tar.gz"
+        "1.9.0-rc3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.0-rc3-musl-x86_64.tar.gz"
         },
-        "1.9.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.0-linux-i686.tar.gz"
+        "1.9.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.0-musl-i686.tar.gz"
         },
-        "1.9.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.0-linux-x86_64.tar.gz"
+        "1.9.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.0-musl-x86_64.tar.gz"
         },
-        "1.9.1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.1-linux-i686.tar.gz"
+        "1.9.1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.1-musl-i686.tar.gz"
         },
-        "1.9.1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.1-linux-x86_64.tar.gz"
+        "1.9.1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.1-musl-x86_64.tar.gz"
         },
-        "1.9.2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.2-linux-i686.tar.gz"
+        "1.9.2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.2-musl-i686.tar.gz"
         },
-        "1.9.2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.2-linux-x86_64.tar.gz"
+        "1.9.2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.2-musl-x86_64.tar.gz"
         },
-        "1.9.3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.3-linux-i686.tar.gz"
+        "1.9.3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.3-musl-i686.tar.gz"
         },
-        "1.9.3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.3-linux-x86_64.tar.gz"
+        "1.9.3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.3-musl-x86_64.tar.gz"
         },
-        "1.9.4+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.9/julia-1.9.4-linux-i686.tar.gz"
+        "1.9.4+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.9/julia-1.9.4-musl-i686.tar.gz"
         },
-        "1.9.4+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.9/julia-1.9.4-linux-x86_64.tar.gz"
+        "1.9.4+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.9/julia-1.9.4-musl-x86_64.tar.gz"
         },
-        "1.10.0-alpha1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-alpha1-linux-i686.tar.gz"
+        "1.10.0-alpha1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-alpha1-musl-i686.tar.gz"
         },
-        "1.10.0-alpha1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.10/julia-1.10.0-alpha1-linux-x86_64.tar.gz"
+        "1.10.0-alpha1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.10/julia-1.10.0-alpha1-musl-x86_64.tar.gz"
         },
-        "1.10.0-beta1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-beta1-linux-i686.tar.gz"
+        "1.10.0-beta1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-beta1-musl-i686.tar.gz"
         },
-        "1.10.0-beta1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.10/julia-1.10.0-beta1-linux-x86_64.tar.gz"
+        "1.10.0-beta1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.10/julia-1.10.0-beta1-musl-x86_64.tar.gz"
         },
-        "1.10.0-beta2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-beta2-linux-i686.tar.gz"
+        "1.10.0-beta2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-beta2-musl-i686.tar.gz"
         },
-        "1.10.0-beta2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.10/julia-1.10.0-beta2-linux-x86_64.tar.gz"
+        "1.10.0-beta2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.10/julia-1.10.0-beta2-musl-x86_64.tar.gz"
         },
-        "1.10.0-beta3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-beta3-linux-i686.tar.gz"
+        "1.10.0-beta3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-beta3-musl-i686.tar.gz"
         },
-        "1.10.0-beta3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.10/julia-1.10.0-beta3-linux-x86_64.tar.gz"
+        "1.10.0-beta3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.10/julia-1.10.0-beta3-musl-x86_64.tar.gz"
         },
-        "1.10.0-rc1+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-rc1-linux-i686.tar.gz"
+        "1.10.0-rc1+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-rc1-musl-i686.tar.gz"
         },
-        "1.10.0-rc1+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.10/julia-1.10.0-rc1-linux-x86_64.tar.gz"
+        "1.10.0-rc1+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.10/julia-1.10.0-rc1-musl-x86_64.tar.gz"
         },
-        "1.10.0-rc2+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-rc2-linux-i686.tar.gz"
+        "1.10.0-rc2+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-rc2-musl-i686.tar.gz"
         },
-        "1.10.0-rc2+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.10/julia-1.10.0-rc2-linux-x86_64.tar.gz"
+        "1.10.0-rc2+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.10/julia-1.10.0-rc2-musl-x86_64.tar.gz"
         },
-        "1.10.0-rc3+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-rc3-linux-i686.tar.gz"
+        "1.10.0-rc3+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-rc3-musl-i686.tar.gz"
         },
-        "1.10.0-rc3+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.10/julia-1.10.0-rc3-linux-x86_64.tar.gz"
+        "1.10.0-rc3+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.10/julia-1.10.0-rc3-musl-x86_64.tar.gz"
         },
-        "1.10.0+0.x86.linux.gnu": {
-            "UrlPath": "bin/linux/x86/1.10/julia-1.10.0-linux-i686.tar.gz"
+        "1.10.0+0.x86.linux.musl": {
+            "UrlPath": "bin/musl/x86/1.10/julia-1.10.0-musl-i686.tar.gz"
         },
-        "1.10.0+0.x64.linux.gnu": {
-            "UrlPath": "bin/linux/x64/1.10/julia-1.10.0-linux-x86_64.tar.gz"
+        "1.10.0+0.x64.linux.musl": {
+            "UrlPath": "bin/musl/x64/1.10/julia-1.10.0-musl-x86_64.tar.gz"
         }
     },
     "AvailableChannels": {
         "0": {
-            "Version": "0.7.0+0.x64.linux.gnu"
+            "Version": "0.7.0+0.x64.linux.musl"
         },
         "0.3": {
-            "Version": "0.3.12+0.x64.linux.gnu"
+            "Version": "0.3.12+0.x64.linux.musl"
         },
         "0.3.1": {
-            "Version": "0.3.1+0.x64.linux.gnu"
+            "Version": "0.3.1+0.x64.linux.musl"
         },
         "0.3.10": {
-            "Version": "0.3.10+0.x64.linux.gnu"
+            "Version": "0.3.10+0.x64.linux.musl"
         },
         "0.3.10~x64": {
-            "Version": "0.3.10+0.x64.linux.gnu"
+            "Version": "0.3.10+0.x64.linux.musl"
         },
         "0.3.10~x86": {
-            "Version": "0.3.10+0.x86.linux.gnu"
+            "Version": "0.3.10+0.x86.linux.musl"
         },
         "0.3.11": {
-            "Version": "0.3.11+0.x64.linux.gnu"
+            "Version": "0.3.11+0.x64.linux.musl"
         },
         "0.3.11~x64": {
-            "Version": "0.3.11+0.x64.linux.gnu"
+            "Version": "0.3.11+0.x64.linux.musl"
         },
         "0.3.11~x86": {
-            "Version": "0.3.11+0.x86.linux.gnu"
+            "Version": "0.3.11+0.x86.linux.musl"
         },
         "0.3.12": {
-            "Version": "0.3.12+0.x64.linux.gnu"
+            "Version": "0.3.12+0.x64.linux.musl"
         },
         "0.3.12~x64": {
-            "Version": "0.3.12+0.x64.linux.gnu"
+            "Version": "0.3.12+0.x64.linux.musl"
         },
         "0.3.12~x86": {
-            "Version": "0.3.12+0.x86.linux.gnu"
+            "Version": "0.3.12+0.x86.linux.musl"
         },
         "0.3.1~x64": {
-            "Version": "0.3.1+0.x64.linux.gnu"
+            "Version": "0.3.1+0.x64.linux.musl"
         },
         "0.3.1~x86": {
-            "Version": "0.3.1+0.x86.linux.gnu"
+            "Version": "0.3.1+0.x86.linux.musl"
         },
         "0.3.2": {
-            "Version": "0.3.2+0.x64.linux.gnu"
+            "Version": "0.3.2+0.x64.linux.musl"
         },
         "0.3.2~x64": {
-            "Version": "0.3.2+0.x64.linux.gnu"
+            "Version": "0.3.2+0.x64.linux.musl"
         },
         "0.3.2~x86": {
-            "Version": "0.3.2+0.x86.linux.gnu"
+            "Version": "0.3.2+0.x86.linux.musl"
         },
         "0.3.3": {
-            "Version": "0.3.3+0.x64.linux.gnu"
+            "Version": "0.3.3+0.x64.linux.musl"
         },
         "0.3.3~x64": {
-            "Version": "0.3.3+0.x64.linux.gnu"
+            "Version": "0.3.3+0.x64.linux.musl"
         },
         "0.3.3~x86": {
-            "Version": "0.3.3+0.x86.linux.gnu"
+            "Version": "0.3.3+0.x86.linux.musl"
         },
         "0.3.4": {
-            "Version": "0.3.4+0.x64.linux.gnu"
+            "Version": "0.3.4+0.x64.linux.musl"
         },
         "0.3.4~x64": {
-            "Version": "0.3.4+0.x64.linux.gnu"
+            "Version": "0.3.4+0.x64.linux.musl"
         },
         "0.3.4~x86": {
-            "Version": "0.3.4+0.x86.linux.gnu"
+            "Version": "0.3.4+0.x86.linux.musl"
         },
         "0.3.5": {
-            "Version": "0.3.5+0.x64.linux.gnu"
+            "Version": "0.3.5+0.x64.linux.musl"
         },
         "0.3.5~x64": {
-            "Version": "0.3.5+0.x64.linux.gnu"
+            "Version": "0.3.5+0.x64.linux.musl"
         },
         "0.3.5~x86": {
-            "Version": "0.3.5+0.x86.linux.gnu"
+            "Version": "0.3.5+0.x86.linux.musl"
         },
         "0.3.6": {
-            "Version": "0.3.6+0.x64.linux.gnu"
+            "Version": "0.3.6+0.x64.linux.musl"
         },
         "0.3.6~x64": {
-            "Version": "0.3.6+0.x64.linux.gnu"
+            "Version": "0.3.6+0.x64.linux.musl"
         },
         "0.3.6~x86": {
-            "Version": "0.3.6+0.x86.linux.gnu"
+            "Version": "0.3.6+0.x86.linux.musl"
         },
         "0.3.7": {
-            "Version": "0.3.7+0.x64.linux.gnu"
+            "Version": "0.3.7+0.x64.linux.musl"
         },
         "0.3.7~x64": {
-            "Version": "0.3.7+0.x64.linux.gnu"
+            "Version": "0.3.7+0.x64.linux.musl"
         },
         "0.3.7~x86": {
-            "Version": "0.3.7+0.x86.linux.gnu"
+            "Version": "0.3.7+0.x86.linux.musl"
         },
         "0.3.8": {
-            "Version": "0.3.8+0.x64.linux.gnu"
+            "Version": "0.3.8+0.x64.linux.musl"
         },
         "0.3.8~x64": {
-            "Version": "0.3.8+0.x64.linux.gnu"
+            "Version": "0.3.8+0.x64.linux.musl"
         },
         "0.3.8~x86": {
-            "Version": "0.3.8+0.x86.linux.gnu"
+            "Version": "0.3.8+0.x86.linux.musl"
         },
         "0.3.9": {
-            "Version": "0.3.9+0.x64.linux.gnu"
+            "Version": "0.3.9+0.x64.linux.musl"
         },
         "0.3.9~x64": {
-            "Version": "0.3.9+0.x64.linux.gnu"
+            "Version": "0.3.9+0.x64.linux.musl"
         },
         "0.3.9~x86": {
-            "Version": "0.3.9+0.x86.linux.gnu"
+            "Version": "0.3.9+0.x86.linux.musl"
         },
         "0.3~x64": {
-            "Version": "0.3.12+0.x64.linux.gnu"
+            "Version": "0.3.12+0.x64.linux.musl"
         },
         "0.3~x86": {
-            "Version": "0.3.12+0.x86.linux.gnu"
+            "Version": "0.3.12+0.x86.linux.musl"
         },
         "0.4": {
-            "Version": "0.4.7+0.x64.linux.gnu"
+            "Version": "0.4.7+0.x64.linux.musl"
         },
         "0.4.0": {
-            "Version": "0.4.0+0.x64.linux.gnu"
+            "Version": "0.4.0+0.x64.linux.musl"
         },
         "0.4.0-rc1": {
-            "Version": "0.4.0-rc1+0.x64.linux.gnu"
+            "Version": "0.4.0-rc1+0.x64.linux.musl"
         },
         "0.4.0-rc1~x64": {
-            "Version": "0.4.0-rc1+0.x64.linux.gnu"
+            "Version": "0.4.0-rc1+0.x64.linux.musl"
         },
         "0.4.0-rc1~x86": {
-            "Version": "0.4.0-rc1+0.x86.linux.gnu"
+            "Version": "0.4.0-rc1+0.x86.linux.musl"
         },
         "0.4.0-rc2": {
-            "Version": "0.4.0-rc2+0.x64.linux.gnu"
+            "Version": "0.4.0-rc2+0.x64.linux.musl"
         },
         "0.4.0-rc2~x64": {
-            "Version": "0.4.0-rc2+0.x64.linux.gnu"
+            "Version": "0.4.0-rc2+0.x64.linux.musl"
         },
         "0.4.0-rc2~x86": {
-            "Version": "0.4.0-rc2+0.x86.linux.gnu"
+            "Version": "0.4.0-rc2+0.x86.linux.musl"
         },
         "0.4.0-rc3": {
-            "Version": "0.4.0-rc3+0.x64.linux.gnu"
+            "Version": "0.4.0-rc3+0.x64.linux.musl"
         },
         "0.4.0-rc3~x64": {
-            "Version": "0.4.0-rc3+0.x64.linux.gnu"
+            "Version": "0.4.0-rc3+0.x64.linux.musl"
         },
         "0.4.0-rc3~x86": {
-            "Version": "0.4.0-rc3+0.x86.linux.gnu"
+            "Version": "0.4.0-rc3+0.x86.linux.musl"
         },
         "0.4.0-rc4": {
-            "Version": "0.4.0-rc4+0.x64.linux.gnu"
+            "Version": "0.4.0-rc4+0.x64.linux.musl"
         },
         "0.4.0-rc4~x64": {
-            "Version": "0.4.0-rc4+0.x64.linux.gnu"
+            "Version": "0.4.0-rc4+0.x64.linux.musl"
         },
         "0.4.0-rc4~x86": {
-            "Version": "0.4.0-rc4+0.x86.linux.gnu"
+            "Version": "0.4.0-rc4+0.x86.linux.musl"
         },
         "0.4.0~x64": {
-            "Version": "0.4.0+0.x64.linux.gnu"
+            "Version": "0.4.0+0.x64.linux.musl"
         },
         "0.4.0~x86": {
-            "Version": "0.4.0+0.x86.linux.gnu"
+            "Version": "0.4.0+0.x86.linux.musl"
         },
         "0.4.1": {
-            "Version": "0.4.1+0.x64.linux.gnu"
+            "Version": "0.4.1+0.x64.linux.musl"
         },
         "0.4.1~x64": {
-            "Version": "0.4.1+0.x64.linux.gnu"
+            "Version": "0.4.1+0.x64.linux.musl"
         },
         "0.4.1~x86": {
-            "Version": "0.4.1+0.x86.linux.gnu"
+            "Version": "0.4.1+0.x86.linux.musl"
         },
         "0.4.2": {
-            "Version": "0.4.2+0.x64.linux.gnu"
+            "Version": "0.4.2+0.x64.linux.musl"
         },
         "0.4.2~x64": {
-            "Version": "0.4.2+0.x64.linux.gnu"
+            "Version": "0.4.2+0.x64.linux.musl"
         },
         "0.4.2~x86": {
-            "Version": "0.4.2+0.x86.linux.gnu"
+            "Version": "0.4.2+0.x86.linux.musl"
         },
         "0.4.3": {
-            "Version": "0.4.3+0.x64.linux.gnu"
+            "Version": "0.4.3+0.x64.linux.musl"
         },
         "0.4.3~x64": {
-            "Version": "0.4.3+0.x64.linux.gnu"
+            "Version": "0.4.3+0.x64.linux.musl"
         },
         "0.4.3~x86": {
-            "Version": "0.4.3+0.x86.linux.gnu"
+            "Version": "0.4.3+0.x86.linux.musl"
         },
         "0.4.4": {
-            "Version": "0.4.4+0.x64.linux.gnu"
+            "Version": "0.4.4+0.x64.linux.musl"
         },
         "0.4.4~x64": {
-            "Version": "0.4.4+0.x64.linux.gnu"
+            "Version": "0.4.4+0.x64.linux.musl"
         },
         "0.4.4~x86": {
-            "Version": "0.4.4+0.x86.linux.gnu"
+            "Version": "0.4.4+0.x86.linux.musl"
         },
         "0.4.5": {
-            "Version": "0.4.5+0.x64.linux.gnu"
+            "Version": "0.4.5+0.x64.linux.musl"
         },
         "0.4.5~x64": {
-            "Version": "0.4.5+0.x64.linux.gnu"
+            "Version": "0.4.5+0.x64.linux.musl"
         },
         "0.4.5~x86": {
-            "Version": "0.4.5+0.x86.linux.gnu"
+            "Version": "0.4.5+0.x86.linux.musl"
         },
         "0.4.6": {
-            "Version": "0.4.6+0.x64.linux.gnu"
+            "Version": "0.4.6+0.x64.linux.musl"
         },
         "0.4.6~x64": {
-            "Version": "0.4.6+0.x64.linux.gnu"
+            "Version": "0.4.6+0.x64.linux.musl"
         },
         "0.4.6~x86": {
-            "Version": "0.4.6+0.x86.linux.gnu"
+            "Version": "0.4.6+0.x86.linux.musl"
         },
         "0.4.7": {
-            "Version": "0.4.7+0.x64.linux.gnu"
+            "Version": "0.4.7+0.x64.linux.musl"
         },
         "0.4.7~x64": {
-            "Version": "0.4.7+0.x64.linux.gnu"
+            "Version": "0.4.7+0.x64.linux.musl"
         },
         "0.4.7~x86": {
-            "Version": "0.4.7+0.x86.linux.gnu"
+            "Version": "0.4.7+0.x86.linux.musl"
         },
         "0.4~x64": {
-            "Version": "0.4.7+0.x64.linux.gnu"
+            "Version": "0.4.7+0.x64.linux.musl"
         },
         "0.4~x86": {
-            "Version": "0.4.7+0.x86.linux.gnu"
+            "Version": "0.4.7+0.x86.linux.musl"
         },
         "0.5": {
-            "Version": "0.5.2+0.x64.linux.gnu"
+            "Version": "0.5.2+0.x64.linux.musl"
         },
         "0.5.0": {
-            "Version": "0.5.0+0.x64.linux.gnu"
+            "Version": "0.5.0+0.x64.linux.musl"
         },
         "0.5.0-rc0": {
-            "Version": "0.5.0-rc0+0.x64.linux.gnu"
+            "Version": "0.5.0-rc0+0.x64.linux.musl"
         },
         "0.5.0-rc0~x64": {
-            "Version": "0.5.0-rc0+0.x64.linux.gnu"
+            "Version": "0.5.0-rc0+0.x64.linux.musl"
         },
         "0.5.0-rc0~x86": {
-            "Version": "0.5.0-rc0+0.x86.linux.gnu"
+            "Version": "0.5.0-rc0+0.x86.linux.musl"
         },
         "0.5.0-rc1": {
-            "Version": "0.5.0-rc1+0.x64.linux.gnu"
+            "Version": "0.5.0-rc1+0.x64.linux.musl"
         },
         "0.5.0-rc1~x64": {
-            "Version": "0.5.0-rc1+0.x64.linux.gnu"
+            "Version": "0.5.0-rc1+0.x64.linux.musl"
         },
         "0.5.0-rc1~x86": {
-            "Version": "0.5.0-rc1+0.x86.linux.gnu"
+            "Version": "0.5.0-rc1+0.x86.linux.musl"
         },
         "0.5.0-rc2": {
-            "Version": "0.5.0-rc2+0.x64.linux.gnu"
+            "Version": "0.5.0-rc2+0.x64.linux.musl"
         },
         "0.5.0-rc2~x64": {
-            "Version": "0.5.0-rc2+0.x64.linux.gnu"
+            "Version": "0.5.0-rc2+0.x64.linux.musl"
         },
         "0.5.0-rc2~x86": {
-            "Version": "0.5.0-rc2+0.x86.linux.gnu"
+            "Version": "0.5.0-rc2+0.x86.linux.musl"
         },
         "0.5.0-rc3": {
-            "Version": "0.5.0-rc3+0.x64.linux.gnu"
+            "Version": "0.5.0-rc3+0.x64.linux.musl"
         },
         "0.5.0-rc3~x64": {
-            "Version": "0.5.0-rc3+0.x64.linux.gnu"
+            "Version": "0.5.0-rc3+0.x64.linux.musl"
         },
         "0.5.0-rc3~x86": {
-            "Version": "0.5.0-rc3+0.x86.linux.gnu"
+            "Version": "0.5.0-rc3+0.x86.linux.musl"
         },
         "0.5.0-rc4": {
-            "Version": "0.5.0-rc4+0.x64.linux.gnu"
+            "Version": "0.5.0-rc4+0.x64.linux.musl"
         },
         "0.5.0-rc4~x64": {
-            "Version": "0.5.0-rc4+0.x64.linux.gnu"
+            "Version": "0.5.0-rc4+0.x64.linux.musl"
         },
         "0.5.0-rc4~x86": {
-            "Version": "0.5.0-rc4+0.x86.linux.gnu"
+            "Version": "0.5.0-rc4+0.x86.linux.musl"
         },
         "0.5.0~x64": {
-            "Version": "0.5.0+0.x64.linux.gnu"
+            "Version": "0.5.0+0.x64.linux.musl"
         },
         "0.5.0~x86": {
-            "Version": "0.5.0+0.x86.linux.gnu"
+            "Version": "0.5.0+0.x86.linux.musl"
         },
         "0.5.1": {
-            "Version": "0.5.1+0.x64.linux.gnu"
+            "Version": "0.5.1+0.x64.linux.musl"
         },
         "0.5.1~x64": {
-            "Version": "0.5.1+0.x64.linux.gnu"
+            "Version": "0.5.1+0.x64.linux.musl"
         },
         "0.5.1~x86": {
-            "Version": "0.5.1+0.x86.linux.gnu"
+            "Version": "0.5.1+0.x86.linux.musl"
         },
         "0.5.2": {
-            "Version": "0.5.2+0.x64.linux.gnu"
+            "Version": "0.5.2+0.x64.linux.musl"
         },
         "0.5.2~x64": {
-            "Version": "0.5.2+0.x64.linux.gnu"
+            "Version": "0.5.2+0.x64.linux.musl"
         },
         "0.5.2~x86": {
-            "Version": "0.5.2+0.x86.linux.gnu"
+            "Version": "0.5.2+0.x86.linux.musl"
         },
         "0.5~x64": {
-            "Version": "0.5.2+0.x64.linux.gnu"
+            "Version": "0.5.2+0.x64.linux.musl"
         },
         "0.5~x86": {
-            "Version": "0.5.2+0.x86.linux.gnu"
+            "Version": "0.5.2+0.x86.linux.musl"
         },
         "0.6": {
-            "Version": "0.6.4+0.x64.linux.gnu"
+            "Version": "0.6.4+0.x64.linux.musl"
         },
         "0.6.0": {
-            "Version": "0.6.0+0.x64.linux.gnu"
+            "Version": "0.6.0+0.x64.linux.musl"
         },
         "0.6.0-pre.alpha": {
-            "Version": "0.6.0-pre.alpha+0.x64.linux.gnu"
+            "Version": "0.6.0-pre.alpha+0.x64.linux.musl"
         },
         "0.6.0-pre.alpha~x64": {
-            "Version": "0.6.0-pre.alpha+0.x64.linux.gnu"
+            "Version": "0.6.0-pre.alpha+0.x64.linux.musl"
         },
         "0.6.0-pre.alpha~x86": {
-            "Version": "0.6.0-pre.alpha+0.x86.linux.gnu"
+            "Version": "0.6.0-pre.alpha+0.x86.linux.musl"
         },
         "0.6.0-pre.beta": {
-            "Version": "0.6.0-pre.beta+0.x64.linux.gnu"
+            "Version": "0.6.0-pre.beta+0.x64.linux.musl"
         },
         "0.6.0-pre.beta~x64": {
-            "Version": "0.6.0-pre.beta+0.x64.linux.gnu"
+            "Version": "0.6.0-pre.beta+0.x64.linux.musl"
         },
         "0.6.0-pre.beta~x86": {
-            "Version": "0.6.0-pre.beta+0.x86.linux.gnu"
+            "Version": "0.6.0-pre.beta+0.x86.linux.musl"
         },
         "0.6.0-rc1": {
-            "Version": "0.6.0-rc1+0.x64.linux.gnu"
+            "Version": "0.6.0-rc1+0.x64.linux.musl"
         },
         "0.6.0-rc1~x64": {
-            "Version": "0.6.0-rc1+0.x64.linux.gnu"
+            "Version": "0.6.0-rc1+0.x64.linux.musl"
         },
         "0.6.0-rc1~x86": {
-            "Version": "0.6.0-rc1+0.x86.linux.gnu"
+            "Version": "0.6.0-rc1+0.x86.linux.musl"
         },
         "0.6.0-rc2": {
-            "Version": "0.6.0-rc2+0.x64.linux.gnu"
+            "Version": "0.6.0-rc2+0.x64.linux.musl"
         },
         "0.6.0-rc2~x64": {
-            "Version": "0.6.0-rc2+0.x64.linux.gnu"
+            "Version": "0.6.0-rc2+0.x64.linux.musl"
         },
         "0.6.0-rc2~x86": {
-            "Version": "0.6.0-rc2+0.x86.linux.gnu"
+            "Version": "0.6.0-rc2+0.x86.linux.musl"
         },
         "0.6.0-rc3": {
-            "Version": "0.6.0-rc3+0.x64.linux.gnu"
+            "Version": "0.6.0-rc3+0.x64.linux.musl"
         },
         "0.6.0-rc3~x64": {
-            "Version": "0.6.0-rc3+0.x64.linux.gnu"
+            "Version": "0.6.0-rc3+0.x64.linux.musl"
         },
         "0.6.0-rc3~x86": {
-            "Version": "0.6.0-rc3+0.x86.linux.gnu"
+            "Version": "0.6.0-rc3+0.x86.linux.musl"
         },
         "0.6.0~x64": {
-            "Version": "0.6.0+0.x64.linux.gnu"
+            "Version": "0.6.0+0.x64.linux.musl"
         },
         "0.6.0~x86": {
-            "Version": "0.6.0+0.x86.linux.gnu"
+            "Version": "0.6.0+0.x86.linux.musl"
         },
         "0.6.1": {
-            "Version": "0.6.1+0.x64.linux.gnu"
+            "Version": "0.6.1+0.x64.linux.musl"
         },
         "0.6.1~x64": {
-            "Version": "0.6.1+0.x64.linux.gnu"
+            "Version": "0.6.1+0.x64.linux.musl"
         },
         "0.6.1~x86": {
-            "Version": "0.6.1+0.x86.linux.gnu"
+            "Version": "0.6.1+0.x86.linux.musl"
         },
         "0.6.2": {
-            "Version": "0.6.2+0.x64.linux.gnu"
+            "Version": "0.6.2+0.x64.linux.musl"
         },
         "0.6.2~x64": {
-            "Version": "0.6.2+0.x64.linux.gnu"
+            "Version": "0.6.2+0.x64.linux.musl"
         },
         "0.6.2~x86": {
-            "Version": "0.6.2+0.x86.linux.gnu"
+            "Version": "0.6.2+0.x86.linux.musl"
         },
         "0.6.3": {
-            "Version": "0.6.3+0.x64.linux.gnu"
+            "Version": "0.6.3+0.x64.linux.musl"
         },
         "0.6.3~x64": {
-            "Version": "0.6.3+0.x64.linux.gnu"
+            "Version": "0.6.3+0.x64.linux.musl"
         },
         "0.6.3~x86": {
-            "Version": "0.6.3+0.x86.linux.gnu"
+            "Version": "0.6.3+0.x86.linux.musl"
         },
         "0.6.4": {
-            "Version": "0.6.4+0.x64.linux.gnu"
+            "Version": "0.6.4+0.x64.linux.musl"
         },
         "0.6.4~x64": {
-            "Version": "0.6.4+0.x64.linux.gnu"
+            "Version": "0.6.4+0.x64.linux.musl"
         },
         "0.6.4~x86": {
-            "Version": "0.6.4+0.x86.linux.gnu"
+            "Version": "0.6.4+0.x86.linux.musl"
         },
         "0.6~x64": {
-            "Version": "0.6.4+0.x64.linux.gnu"
+            "Version": "0.6.4+0.x64.linux.musl"
         },
         "0.6~x86": {
-            "Version": "0.6.4+0.x86.linux.gnu"
+            "Version": "0.6.4+0.x86.linux.musl"
         },
         "0.7": {
-            "Version": "0.7.0+0.x64.linux.gnu"
+            "Version": "0.7.0+0.x64.linux.musl"
         },
         "0.7.0": {
-            "Version": "0.7.0+0.x64.linux.gnu"
+            "Version": "0.7.0+0.x64.linux.musl"
         },
         "0.7.0-alpha": {
-            "Version": "0.7.0-alpha+0.x64.linux.gnu"
+            "Version": "0.7.0-alpha+0.x64.linux.musl"
         },
         "0.7.0-alpha~x64": {
-            "Version": "0.7.0-alpha+0.x64.linux.gnu"
+            "Version": "0.7.0-alpha+0.x64.linux.musl"
         },
         "0.7.0-alpha~x86": {
-            "Version": "0.7.0-alpha+0.x86.linux.gnu"
+            "Version": "0.7.0-alpha+0.x86.linux.musl"
         },
         "0.7.0-beta": {
-            "Version": "0.7.0-beta+0.x64.linux.gnu"
+            "Version": "0.7.0-beta+0.x64.linux.musl"
         },
         "0.7.0-beta2": {
-            "Version": "0.7.0-beta2+0.x64.linux.gnu"
+            "Version": "0.7.0-beta2+0.x64.linux.musl"
         },
         "0.7.0-beta2~x64": {
-            "Version": "0.7.0-beta2+0.x64.linux.gnu"
+            "Version": "0.7.0-beta2+0.x64.linux.musl"
         },
         "0.7.0-beta2~x86": {
-            "Version": "0.7.0-beta2+0.x86.linux.gnu"
+            "Version": "0.7.0-beta2+0.x86.linux.musl"
         },
         "0.7.0-beta~x64": {
-            "Version": "0.7.0-beta+0.x64.linux.gnu"
+            "Version": "0.7.0-beta+0.x64.linux.musl"
         },
         "0.7.0-beta~x86": {
-            "Version": "0.7.0-beta+0.x86.linux.gnu"
+            "Version": "0.7.0-beta+0.x86.linux.musl"
         },
         "0.7.0-rc1": {
-            "Version": "0.7.0-rc1+0.x64.linux.gnu"
+            "Version": "0.7.0-rc1+0.x64.linux.musl"
         },
         "0.7.0-rc1~x64": {
-            "Version": "0.7.0-rc1+0.x64.linux.gnu"
+            "Version": "0.7.0-rc1+0.x64.linux.musl"
         },
         "0.7.0-rc1~x86": {
-            "Version": "0.7.0-rc1+0.x86.linux.gnu"
+            "Version": "0.7.0-rc1+0.x86.linux.musl"
         },
         "0.7.0-rc2": {
-            "Version": "0.7.0-rc2+0.x64.linux.gnu"
+            "Version": "0.7.0-rc2+0.x64.linux.musl"
         },
         "0.7.0-rc2~x64": {
-            "Version": "0.7.0-rc2+0.x64.linux.gnu"
+            "Version": "0.7.0-rc2+0.x64.linux.musl"
         },
         "0.7.0-rc2~x86": {
-            "Version": "0.7.0-rc2+0.x86.linux.gnu"
+            "Version": "0.7.0-rc2+0.x86.linux.musl"
         },
         "0.7.0-rc3": {
-            "Version": "0.7.0-rc3+0.x64.linux.gnu"
+            "Version": "0.7.0-rc3+0.x64.linux.musl"
         },
         "0.7.0-rc3~x64": {
-            "Version": "0.7.0-rc3+0.x64.linux.gnu"
+            "Version": "0.7.0-rc3+0.x64.linux.musl"
         },
         "0.7.0-rc3~x86": {
-            "Version": "0.7.0-rc3+0.x86.linux.gnu"
+            "Version": "0.7.0-rc3+0.x86.linux.musl"
         },
         "0.7.0~x64": {
-            "Version": "0.7.0+0.x64.linux.gnu"
+            "Version": "0.7.0+0.x64.linux.musl"
         },
         "0.7.0~x86": {
-            "Version": "0.7.0+0.x86.linux.gnu"
+            "Version": "0.7.0+0.x86.linux.musl"
         },
         "0.7~x64": {
-            "Version": "0.7.0+0.x64.linux.gnu"
+            "Version": "0.7.0+0.x64.linux.musl"
         },
         "0.7~x86": {
-            "Version": "0.7.0+0.x86.linux.gnu"
+            "Version": "0.7.0+0.x86.linux.musl"
         },
         "0~x64": {
-            "Version": "0.7.0+0.x64.linux.gnu"
+            "Version": "0.7.0+0.x64.linux.musl"
         },
         "0~x86": {
-            "Version": "0.7.0+0.x86.linux.gnu"
+            "Version": "0.7.0+0.x86.linux.musl"
         },
         "1": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "1.0": {
-            "Version": "1.0.5+0.x64.linux.gnu"
+            "Version": "1.0.5+0.x64.linux.musl"
         },
         "1.0.0": {
-            "Version": "1.0.0+0.x64.linux.gnu"
+            "Version": "1.0.0+0.x64.linux.musl"
         },
         "1.0.0-rc1": {
-            "Version": "1.0.0-rc1+0.x64.linux.gnu"
+            "Version": "1.0.0-rc1+0.x64.linux.musl"
         },
         "1.0.0-rc1~x64": {
-            "Version": "1.0.0-rc1+0.x64.linux.gnu"
+            "Version": "1.0.0-rc1+0.x64.linux.musl"
         },
         "1.0.0-rc1~x86": {
-            "Version": "1.0.0-rc1+0.x86.linux.gnu"
+            "Version": "1.0.0-rc1+0.x86.linux.musl"
         },
         "1.0.0~x64": {
-            "Version": "1.0.0+0.x64.linux.gnu"
+            "Version": "1.0.0+0.x64.linux.musl"
         },
         "1.0.0~x86": {
-            "Version": "1.0.0+0.x86.linux.gnu"
+            "Version": "1.0.0+0.x86.linux.musl"
         },
         "1.0.1": {
-            "Version": "1.0.1+0.x64.linux.gnu"
+            "Version": "1.0.1+0.x64.linux.musl"
         },
         "1.0.1~x64": {
-            "Version": "1.0.1+0.x64.linux.gnu"
+            "Version": "1.0.1+0.x64.linux.musl"
         },
         "1.0.1~x86": {
-            "Version": "1.0.1+0.x86.linux.gnu"
+            "Version": "1.0.1+0.x86.linux.musl"
         },
         "1.0.2": {
-            "Version": "1.0.2+0.x64.linux.gnu"
+            "Version": "1.0.2+0.x64.linux.musl"
         },
         "1.0.2~x64": {
-            "Version": "1.0.2+0.x64.linux.gnu"
+            "Version": "1.0.2+0.x64.linux.musl"
         },
         "1.0.2~x86": {
-            "Version": "1.0.2+0.x86.linux.gnu"
+            "Version": "1.0.2+0.x86.linux.musl"
         },
         "1.0.3": {
-            "Version": "1.0.3+0.x64.linux.gnu"
+            "Version": "1.0.3+0.x64.linux.musl"
         },
         "1.0.3~x64": {
-            "Version": "1.0.3+0.x64.linux.gnu"
+            "Version": "1.0.3+0.x64.linux.musl"
         },
         "1.0.3~x86": {
-            "Version": "1.0.3+0.x86.linux.gnu"
+            "Version": "1.0.3+0.x86.linux.musl"
         },
         "1.0.4": {
-            "Version": "1.0.4+0.x64.linux.gnu"
+            "Version": "1.0.4+0.x64.linux.musl"
         },
         "1.0.4~x64": {
-            "Version": "1.0.4+0.x64.linux.gnu"
+            "Version": "1.0.4+0.x64.linux.musl"
         },
         "1.0.4~x86": {
-            "Version": "1.0.4+0.x86.linux.gnu"
+            "Version": "1.0.4+0.x86.linux.musl"
         },
         "1.0.5": {
-            "Version": "1.0.5+0.x64.linux.gnu"
+            "Version": "1.0.5+0.x64.linux.musl"
         },
         "1.0.5~x64": {
-            "Version": "1.0.5+0.x64.linux.gnu"
+            "Version": "1.0.5+0.x64.linux.musl"
         },
         "1.0.5~x86": {
-            "Version": "1.0.5+0.x86.linux.gnu"
+            "Version": "1.0.5+0.x86.linux.musl"
         },
         "1.0~x64": {
-            "Version": "1.0.5+0.x64.linux.gnu"
+            "Version": "1.0.5+0.x64.linux.musl"
         },
         "1.0~x86": {
-            "Version": "1.0.5+0.x86.linux.gnu"
+            "Version": "1.0.5+0.x86.linux.musl"
         },
         "1.1": {
-            "Version": "1.1.1+0.x64.linux.gnu"
+            "Version": "1.1.1+0.x64.linux.musl"
         },
         "1.1.0": {
-            "Version": "1.1.0+0.x64.linux.gnu"
+            "Version": "1.1.0+0.x64.linux.musl"
         },
         "1.1.0-rc1": {
-            "Version": "1.1.0-rc1+0.x64.linux.gnu"
+            "Version": "1.1.0-rc1+0.x64.linux.musl"
         },
         "1.1.0-rc1~x64": {
-            "Version": "1.1.0-rc1+0.x64.linux.gnu"
+            "Version": "1.1.0-rc1+0.x64.linux.musl"
         },
         "1.1.0-rc1~x86": {
-            "Version": "1.1.0-rc1+0.x86.linux.gnu"
+            "Version": "1.1.0-rc1+0.x86.linux.musl"
         },
         "1.1.0-rc2": {
-            "Version": "1.1.0-rc2+0.x64.linux.gnu"
+            "Version": "1.1.0-rc2+0.x64.linux.musl"
         },
         "1.1.0-rc2~x64": {
-            "Version": "1.1.0-rc2+0.x64.linux.gnu"
+            "Version": "1.1.0-rc2+0.x64.linux.musl"
         },
         "1.1.0-rc2~x86": {
-            "Version": "1.1.0-rc2+0.x86.linux.gnu"
+            "Version": "1.1.0-rc2+0.x86.linux.musl"
         },
         "1.1.0~x64": {
-            "Version": "1.1.0+0.x64.linux.gnu"
+            "Version": "1.1.0+0.x64.linux.musl"
         },
         "1.1.0~x86": {
-            "Version": "1.1.0+0.x86.linux.gnu"
+            "Version": "1.1.0+0.x86.linux.musl"
         },
         "1.1.1": {
-            "Version": "1.1.1+0.x64.linux.gnu"
+            "Version": "1.1.1+0.x64.linux.musl"
         },
         "1.1.1~x64": {
-            "Version": "1.1.1+0.x64.linux.gnu"
+            "Version": "1.1.1+0.x64.linux.musl"
         },
         "1.1.1~x86": {
-            "Version": "1.1.1+0.x86.linux.gnu"
+            "Version": "1.1.1+0.x86.linux.musl"
         },
         "1.10": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "1.10.0": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "1.10.0-alpha1": {
-            "Version": "1.10.0-alpha1+0.x64.linux.gnu"
+            "Version": "1.10.0-alpha1+0.x64.linux.musl"
         },
         "1.10.0-alpha1~x64": {
-            "Version": "1.10.0-alpha1+0.x64.linux.gnu"
+            "Version": "1.10.0-alpha1+0.x64.linux.musl"
         },
         "1.10.0-alpha1~x86": {
-            "Version": "1.10.0-alpha1+0.x86.linux.gnu"
+            "Version": "1.10.0-alpha1+0.x86.linux.musl"
         },
         "1.10.0-beta1": {
-            "Version": "1.10.0-beta1+0.x64.linux.gnu"
+            "Version": "1.10.0-beta1+0.x64.linux.musl"
         },
         "1.10.0-beta1~x64": {
-            "Version": "1.10.0-beta1+0.x64.linux.gnu"
+            "Version": "1.10.0-beta1+0.x64.linux.musl"
         },
         "1.10.0-beta1~x86": {
-            "Version": "1.10.0-beta1+0.x86.linux.gnu"
+            "Version": "1.10.0-beta1+0.x86.linux.musl"
         },
         "1.10.0-beta2": {
-            "Version": "1.10.0-beta2+0.x64.linux.gnu"
+            "Version": "1.10.0-beta2+0.x64.linux.musl"
         },
         "1.10.0-beta2~x64": {
-            "Version": "1.10.0-beta2+0.x64.linux.gnu"
+            "Version": "1.10.0-beta2+0.x64.linux.musl"
         },
         "1.10.0-beta2~x86": {
-            "Version": "1.10.0-beta2+0.x86.linux.gnu"
+            "Version": "1.10.0-beta2+0.x86.linux.musl"
         },
         "1.10.0-beta3": {
-            "Version": "1.10.0-beta3+0.x64.linux.gnu"
+            "Version": "1.10.0-beta3+0.x64.linux.musl"
         },
         "1.10.0-beta3~x64": {
-            "Version": "1.10.0-beta3+0.x64.linux.gnu"
+            "Version": "1.10.0-beta3+0.x64.linux.musl"
         },
         "1.10.0-beta3~x86": {
-            "Version": "1.10.0-beta3+0.x86.linux.gnu"
+            "Version": "1.10.0-beta3+0.x86.linux.musl"
         },
         "1.10.0-rc1": {
-            "Version": "1.10.0-rc1+0.x64.linux.gnu"
+            "Version": "1.10.0-rc1+0.x64.linux.musl"
         },
         "1.10.0-rc1~x64": {
-            "Version": "1.10.0-rc1+0.x64.linux.gnu"
+            "Version": "1.10.0-rc1+0.x64.linux.musl"
         },
         "1.10.0-rc1~x86": {
-            "Version": "1.10.0-rc1+0.x86.linux.gnu"
+            "Version": "1.10.0-rc1+0.x86.linux.musl"
         },
         "1.10.0-rc2": {
-            "Version": "1.10.0-rc2+0.x64.linux.gnu"
+            "Version": "1.10.0-rc2+0.x64.linux.musl"
         },
         "1.10.0-rc2~x64": {
-            "Version": "1.10.0-rc2+0.x64.linux.gnu"
+            "Version": "1.10.0-rc2+0.x64.linux.musl"
         },
         "1.10.0-rc2~x86": {
-            "Version": "1.10.0-rc2+0.x86.linux.gnu"
+            "Version": "1.10.0-rc2+0.x86.linux.musl"
         },
         "1.10.0-rc3": {
-            "Version": "1.10.0-rc3+0.x64.linux.gnu"
+            "Version": "1.10.0-rc3+0.x64.linux.musl"
         },
         "1.10.0-rc3~x64": {
-            "Version": "1.10.0-rc3+0.x64.linux.gnu"
+            "Version": "1.10.0-rc3+0.x64.linux.musl"
         },
         "1.10.0-rc3~x86": {
-            "Version": "1.10.0-rc3+0.x86.linux.gnu"
+            "Version": "1.10.0-rc3+0.x86.linux.musl"
         },
         "1.10.0~x64": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "1.10.0~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "1.10~x64": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "1.10~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "1.1~x64": {
-            "Version": "1.1.1+0.x64.linux.gnu"
+            "Version": "1.1.1+0.x64.linux.musl"
         },
         "1.1~x86": {
-            "Version": "1.1.1+0.x86.linux.gnu"
+            "Version": "1.1.1+0.x86.linux.musl"
         },
         "1.2": {
-            "Version": "1.2.0+0.x64.linux.gnu"
+            "Version": "1.2.0+0.x64.linux.musl"
         },
         "1.2.0": {
-            "Version": "1.2.0+0.x64.linux.gnu"
+            "Version": "1.2.0+0.x64.linux.musl"
         },
         "1.2.0-rc1": {
-            "Version": "1.2.0-rc1+0.x64.linux.gnu"
+            "Version": "1.2.0-rc1+0.x64.linux.musl"
         },
         "1.2.0-rc1~x64": {
-            "Version": "1.2.0-rc1+0.x64.linux.gnu"
+            "Version": "1.2.0-rc1+0.x64.linux.musl"
         },
         "1.2.0-rc1~x86": {
-            "Version": "1.2.0-rc1+0.x86.linux.gnu"
+            "Version": "1.2.0-rc1+0.x86.linux.musl"
         },
         "1.2.0-rc2": {
-            "Version": "1.2.0-rc2+0.x64.linux.gnu"
+            "Version": "1.2.0-rc2+0.x64.linux.musl"
         },
         "1.2.0-rc2~x64": {
-            "Version": "1.2.0-rc2+0.x64.linux.gnu"
+            "Version": "1.2.0-rc2+0.x64.linux.musl"
         },
         "1.2.0-rc2~x86": {
-            "Version": "1.2.0-rc2+0.x86.linux.gnu"
+            "Version": "1.2.0-rc2+0.x86.linux.musl"
         },
         "1.2.0-rc3": {
-            "Version": "1.2.0-rc3+0.x64.linux.gnu"
+            "Version": "1.2.0-rc3+0.x64.linux.musl"
         },
         "1.2.0-rc3~x64": {
-            "Version": "1.2.0-rc3+0.x64.linux.gnu"
+            "Version": "1.2.0-rc3+0.x64.linux.musl"
         },
         "1.2.0-rc3~x86": {
-            "Version": "1.2.0-rc3+0.x86.linux.gnu"
+            "Version": "1.2.0-rc3+0.x86.linux.musl"
         },
         "1.2.0~x64": {
-            "Version": "1.2.0+0.x64.linux.gnu"
+            "Version": "1.2.0+0.x64.linux.musl"
         },
         "1.2.0~x86": {
-            "Version": "1.2.0+0.x86.linux.gnu"
+            "Version": "1.2.0+0.x86.linux.musl"
         },
         "1.2~x64": {
-            "Version": "1.2.0+0.x64.linux.gnu"
+            "Version": "1.2.0+0.x64.linux.musl"
         },
         "1.2~x86": {
-            "Version": "1.2.0+0.x86.linux.gnu"
+            "Version": "1.2.0+0.x86.linux.musl"
         },
         "1.3": {
-            "Version": "1.3.1+0.x64.linux.gnu"
+            "Version": "1.3.1+0.x64.linux.musl"
         },
         "1.3.0": {
-            "Version": "1.3.0+0.x64.linux.gnu"
+            "Version": "1.3.0+0.x64.linux.musl"
         },
         "1.3.0-alpha": {
-            "Version": "1.3.0-alpha+0.x64.linux.gnu"
+            "Version": "1.3.0-alpha+0.x64.linux.musl"
         },
         "1.3.0-alpha~x64": {
-            "Version": "1.3.0-alpha+0.x64.linux.gnu"
+            "Version": "1.3.0-alpha+0.x64.linux.musl"
         },
         "1.3.0-alpha~x86": {
-            "Version": "1.3.0-alpha+0.x86.linux.gnu"
+            "Version": "1.3.0-alpha+0.x86.linux.musl"
         },
         "1.3.0-rc1": {
-            "Version": "1.3.0-rc1+0.x64.linux.gnu"
+            "Version": "1.3.0-rc1+0.x64.linux.musl"
         },
         "1.3.0-rc1~x64": {
-            "Version": "1.3.0-rc1+0.x64.linux.gnu"
+            "Version": "1.3.0-rc1+0.x64.linux.musl"
         },
         "1.3.0-rc1~x86": {
-            "Version": "1.3.0-rc1+0.x86.linux.gnu"
+            "Version": "1.3.0-rc1+0.x86.linux.musl"
         },
         "1.3.0-rc2": {
-            "Version": "1.3.0-rc2+0.x64.linux.gnu"
+            "Version": "1.3.0-rc2+0.x64.linux.musl"
         },
         "1.3.0-rc2~x64": {
-            "Version": "1.3.0-rc2+0.x64.linux.gnu"
+            "Version": "1.3.0-rc2+0.x64.linux.musl"
         },
         "1.3.0-rc2~x86": {
-            "Version": "1.3.0-rc2+0.x86.linux.gnu"
+            "Version": "1.3.0-rc2+0.x86.linux.musl"
         },
         "1.3.0-rc3": {
-            "Version": "1.3.0-rc3+0.x64.linux.gnu"
+            "Version": "1.3.0-rc3+0.x64.linux.musl"
         },
         "1.3.0-rc3~x64": {
-            "Version": "1.3.0-rc3+0.x64.linux.gnu"
+            "Version": "1.3.0-rc3+0.x64.linux.musl"
         },
         "1.3.0-rc3~x86": {
-            "Version": "1.3.0-rc3+0.x86.linux.gnu"
+            "Version": "1.3.0-rc3+0.x86.linux.musl"
         },
         "1.3.0-rc4": {
-            "Version": "1.3.0-rc4+0.x64.linux.gnu"
+            "Version": "1.3.0-rc4+0.x64.linux.musl"
         },
         "1.3.0-rc4~x64": {
-            "Version": "1.3.0-rc4+0.x64.linux.gnu"
+            "Version": "1.3.0-rc4+0.x64.linux.musl"
         },
         "1.3.0-rc4~x86": {
-            "Version": "1.3.0-rc4+0.x86.linux.gnu"
+            "Version": "1.3.0-rc4+0.x86.linux.musl"
         },
         "1.3.0-rc5": {
-            "Version": "1.3.0-rc5+0.x64.linux.gnu"
+            "Version": "1.3.0-rc5+0.x64.linux.musl"
         },
         "1.3.0-rc5~x64": {
-            "Version": "1.3.0-rc5+0.x64.linux.gnu"
+            "Version": "1.3.0-rc5+0.x64.linux.musl"
         },
         "1.3.0-rc5~x86": {
-            "Version": "1.3.0-rc5+0.x86.linux.gnu"
+            "Version": "1.3.0-rc5+0.x86.linux.musl"
         },
         "1.3.0~x64": {
-            "Version": "1.3.0+0.x64.linux.gnu"
+            "Version": "1.3.0+0.x64.linux.musl"
         },
         "1.3.0~x86": {
-            "Version": "1.3.0+0.x86.linux.gnu"
+            "Version": "1.3.0+0.x86.linux.musl"
         },
         "1.3.1": {
-            "Version": "1.3.1+0.x64.linux.gnu"
+            "Version": "1.3.1+0.x64.linux.musl"
         },
         "1.3.1~x64": {
-            "Version": "1.3.1+0.x64.linux.gnu"
+            "Version": "1.3.1+0.x64.linux.musl"
         },
         "1.3.1~x86": {
-            "Version": "1.3.1+0.x86.linux.gnu"
+            "Version": "1.3.1+0.x86.linux.musl"
         },
         "1.3~x64": {
-            "Version": "1.3.1+0.x64.linux.gnu"
+            "Version": "1.3.1+0.x64.linux.musl"
         },
         "1.3~x86": {
-            "Version": "1.3.1+0.x86.linux.gnu"
+            "Version": "1.3.1+0.x86.linux.musl"
         },
         "1.4": {
-            "Version": "1.4.2+0.x64.linux.gnu"
+            "Version": "1.4.2+0.x64.linux.musl"
         },
         "1.4.0": {
-            "Version": "1.4.0+0.x64.linux.gnu"
+            "Version": "1.4.0+0.x64.linux.musl"
         },
         "1.4.0-rc1": {
-            "Version": "1.4.0-rc1+0.x64.linux.gnu"
+            "Version": "1.4.0-rc1+0.x64.linux.musl"
         },
         "1.4.0-rc1~x64": {
-            "Version": "1.4.0-rc1+0.x64.linux.gnu"
+            "Version": "1.4.0-rc1+0.x64.linux.musl"
         },
         "1.4.0-rc1~x86": {
-            "Version": "1.4.0-rc1+0.x86.linux.gnu"
+            "Version": "1.4.0-rc1+0.x86.linux.musl"
         },
         "1.4.0-rc2": {
-            "Version": "1.4.0-rc2+0.x64.linux.gnu"
+            "Version": "1.4.0-rc2+0.x64.linux.musl"
         },
         "1.4.0-rc2~x64": {
-            "Version": "1.4.0-rc2+0.x64.linux.gnu"
+            "Version": "1.4.0-rc2+0.x64.linux.musl"
         },
         "1.4.0-rc2~x86": {
-            "Version": "1.4.0-rc2+0.x86.linux.gnu"
+            "Version": "1.4.0-rc2+0.x86.linux.musl"
         },
         "1.4.0~x64": {
-            "Version": "1.4.0+0.x64.linux.gnu"
+            "Version": "1.4.0+0.x64.linux.musl"
         },
         "1.4.0~x86": {
-            "Version": "1.4.0+0.x86.linux.gnu"
+            "Version": "1.4.0+0.x86.linux.musl"
         },
         "1.4.1": {
-            "Version": "1.4.1+0.x64.linux.gnu"
+            "Version": "1.4.1+0.x64.linux.musl"
         },
         "1.4.1~x64": {
-            "Version": "1.4.1+0.x64.linux.gnu"
+            "Version": "1.4.1+0.x64.linux.musl"
         },
         "1.4.1~x86": {
-            "Version": "1.4.1+0.x86.linux.gnu"
+            "Version": "1.4.1+0.x86.linux.musl"
         },
         "1.4.2": {
-            "Version": "1.4.2+0.x64.linux.gnu"
+            "Version": "1.4.2+0.x64.linux.musl"
         },
         "1.4.2~x64": {
-            "Version": "1.4.2+0.x64.linux.gnu"
+            "Version": "1.4.2+0.x64.linux.musl"
         },
         "1.4.2~x86": {
-            "Version": "1.4.2+0.x86.linux.gnu"
+            "Version": "1.4.2+0.x86.linux.musl"
         },
         "1.4~x64": {
-            "Version": "1.4.2+0.x64.linux.gnu"
+            "Version": "1.4.2+0.x64.linux.musl"
         },
         "1.4~x86": {
-            "Version": "1.4.2+0.x86.linux.gnu"
+            "Version": "1.4.2+0.x86.linux.musl"
         },
         "1.5": {
-            "Version": "1.5.4+0.x64.linux.gnu"
+            "Version": "1.5.4+0.x64.linux.musl"
         },
         "1.5.0": {
-            "Version": "1.5.0+0.x64.linux.gnu"
+            "Version": "1.5.0+0.x64.linux.musl"
         },
         "1.5.0-beta1": {
-            "Version": "1.5.0-beta1+0.x64.linux.gnu"
+            "Version": "1.5.0-beta1+0.x64.linux.musl"
         },
         "1.5.0-beta1~x64": {
-            "Version": "1.5.0-beta1+0.x64.linux.gnu"
+            "Version": "1.5.0-beta1+0.x64.linux.musl"
         },
         "1.5.0-beta1~x86": {
-            "Version": "1.5.0-beta1+0.x86.linux.gnu"
+            "Version": "1.5.0-beta1+0.x86.linux.musl"
         },
         "1.5.0-rc1": {
-            "Version": "1.5.0-rc1+0.x64.linux.gnu"
+            "Version": "1.5.0-rc1+0.x64.linux.musl"
         },
         "1.5.0-rc1~x64": {
-            "Version": "1.5.0-rc1+0.x64.linux.gnu"
+            "Version": "1.5.0-rc1+0.x64.linux.musl"
         },
         "1.5.0-rc1~x86": {
-            "Version": "1.5.0-rc1+0.x86.linux.gnu"
+            "Version": "1.5.0-rc1+0.x86.linux.musl"
         },
         "1.5.0-rc2": {
-            "Version": "1.5.0-rc2+0.x64.linux.gnu"
+            "Version": "1.5.0-rc2+0.x64.linux.musl"
         },
         "1.5.0-rc2~x64": {
-            "Version": "1.5.0-rc2+0.x64.linux.gnu"
+            "Version": "1.5.0-rc2+0.x64.linux.musl"
         },
         "1.5.0-rc2~x86": {
-            "Version": "1.5.0-rc2+0.x86.linux.gnu"
+            "Version": "1.5.0-rc2+0.x86.linux.musl"
         },
         "1.5.0~x64": {
-            "Version": "1.5.0+0.x64.linux.gnu"
+            "Version": "1.5.0+0.x64.linux.musl"
         },
         "1.5.0~x86": {
-            "Version": "1.5.0+0.x86.linux.gnu"
+            "Version": "1.5.0+0.x86.linux.musl"
         },
         "1.5.1": {
-            "Version": "1.5.1+0.x64.linux.gnu"
+            "Version": "1.5.1+0.x64.linux.musl"
         },
         "1.5.1~x64": {
-            "Version": "1.5.1+0.x64.linux.gnu"
+            "Version": "1.5.1+0.x64.linux.musl"
         },
         "1.5.1~x86": {
-            "Version": "1.5.1+0.x86.linux.gnu"
+            "Version": "1.5.1+0.x86.linux.musl"
         },
         "1.5.2": {
-            "Version": "1.5.2+0.x64.linux.gnu"
+            "Version": "1.5.2+0.x64.linux.musl"
         },
         "1.5.2~x64": {
-            "Version": "1.5.2+0.x64.linux.gnu"
+            "Version": "1.5.2+0.x64.linux.musl"
         },
         "1.5.2~x86": {
-            "Version": "1.5.2+0.x86.linux.gnu"
+            "Version": "1.5.2+0.x86.linux.musl"
         },
         "1.5.3": {
-            "Version": "1.5.3+0.x64.linux.gnu"
+            "Version": "1.5.3+0.x64.linux.musl"
         },
         "1.5.3~x64": {
-            "Version": "1.5.3+0.x64.linux.gnu"
+            "Version": "1.5.3+0.x64.linux.musl"
         },
         "1.5.3~x86": {
-            "Version": "1.5.3+0.x86.linux.gnu"
+            "Version": "1.5.3+0.x86.linux.musl"
         },
         "1.5.4": {
-            "Version": "1.5.4+0.x64.linux.gnu"
+            "Version": "1.5.4+0.x64.linux.musl"
         },
         "1.5.4~x64": {
-            "Version": "1.5.4+0.x64.linux.gnu"
+            "Version": "1.5.4+0.x64.linux.musl"
         },
         "1.5.4~x86": {
-            "Version": "1.5.4+0.x86.linux.gnu"
+            "Version": "1.5.4+0.x86.linux.musl"
         },
         "1.5~x64": {
-            "Version": "1.5.4+0.x64.linux.gnu"
+            "Version": "1.5.4+0.x64.linux.musl"
         },
         "1.5~x86": {
-            "Version": "1.5.4+0.x86.linux.gnu"
+            "Version": "1.5.4+0.x86.linux.musl"
         },
         "1.6": {
-            "Version": "1.6.7+0.x64.linux.gnu"
+            "Version": "1.6.7+0.x64.linux.musl"
         },
         "1.6.0": {
-            "Version": "1.6.0+0.x64.linux.gnu"
+            "Version": "1.6.0+0.x64.linux.musl"
         },
         "1.6.0-beta1": {
-            "Version": "1.6.0-beta1+0.x64.linux.gnu"
+            "Version": "1.6.0-beta1+0.x64.linux.musl"
         },
         "1.6.0-beta1~x64": {
-            "Version": "1.6.0-beta1+0.x64.linux.gnu"
+            "Version": "1.6.0-beta1+0.x64.linux.musl"
         },
         "1.6.0-beta1~x86": {
-            "Version": "1.6.0-beta1+0.x86.linux.gnu"
+            "Version": "1.6.0-beta1+0.x86.linux.musl"
         },
         "1.6.0-rc1": {
-            "Version": "1.6.0-rc1+0.x64.linux.gnu"
+            "Version": "1.6.0-rc1+0.x64.linux.musl"
         },
         "1.6.0-rc1~x64": {
-            "Version": "1.6.0-rc1+0.x64.linux.gnu"
+            "Version": "1.6.0-rc1+0.x64.linux.musl"
         },
         "1.6.0-rc1~x86": {
-            "Version": "1.6.0-rc1+0.x86.linux.gnu"
+            "Version": "1.6.0-rc1+0.x86.linux.musl"
         },
         "1.6.0-rc2": {
-            "Version": "1.6.0-rc2+0.x64.linux.gnu"
+            "Version": "1.6.0-rc2+0.x64.linux.musl"
         },
         "1.6.0-rc2~x64": {
-            "Version": "1.6.0-rc2+0.x64.linux.gnu"
+            "Version": "1.6.0-rc2+0.x64.linux.musl"
         },
         "1.6.0-rc2~x86": {
-            "Version": "1.6.0-rc2+0.x86.linux.gnu"
+            "Version": "1.6.0-rc2+0.x86.linux.musl"
         },
         "1.6.0-rc3": {
-            "Version": "1.6.0-rc3+0.x64.linux.gnu"
+            "Version": "1.6.0-rc3+0.x64.linux.musl"
         },
         "1.6.0-rc3~x64": {
-            "Version": "1.6.0-rc3+0.x64.linux.gnu"
+            "Version": "1.6.0-rc3+0.x64.linux.musl"
         },
         "1.6.0-rc3~x86": {
-            "Version": "1.6.0-rc3+0.x86.linux.gnu"
+            "Version": "1.6.0-rc3+0.x86.linux.musl"
         },
         "1.6.0~x64": {
-            "Version": "1.6.0+0.x64.linux.gnu"
+            "Version": "1.6.0+0.x64.linux.musl"
         },
         "1.6.0~x86": {
-            "Version": "1.6.0+0.x86.linux.gnu"
+            "Version": "1.6.0+0.x86.linux.musl"
         },
         "1.6.1": {
-            "Version": "1.6.1+0.x64.linux.gnu"
+            "Version": "1.6.1+0.x64.linux.musl"
         },
         "1.6.1~x64": {
-            "Version": "1.6.1+0.x64.linux.gnu"
+            "Version": "1.6.1+0.x64.linux.musl"
         },
         "1.6.1~x86": {
-            "Version": "1.6.1+0.x86.linux.gnu"
+            "Version": "1.6.1+0.x86.linux.musl"
         },
         "1.6.2": {
-            "Version": "1.6.2+0.x64.linux.gnu"
+            "Version": "1.6.2+0.x64.linux.musl"
         },
         "1.6.2~x64": {
-            "Version": "1.6.2+0.x64.linux.gnu"
+            "Version": "1.6.2+0.x64.linux.musl"
         },
         "1.6.2~x86": {
-            "Version": "1.6.2+0.x86.linux.gnu"
+            "Version": "1.6.2+0.x86.linux.musl"
         },
         "1.6.3": {
-            "Version": "1.6.3+0.x64.linux.gnu"
+            "Version": "1.6.3+0.x64.linux.musl"
         },
         "1.6.3~x64": {
-            "Version": "1.6.3+0.x64.linux.gnu"
+            "Version": "1.6.3+0.x64.linux.musl"
         },
         "1.6.3~x86": {
-            "Version": "1.6.3+0.x86.linux.gnu"
+            "Version": "1.6.3+0.x86.linux.musl"
         },
         "1.6.4": {
-            "Version": "1.6.4+0.x64.linux.gnu"
+            "Version": "1.6.4+0.x64.linux.musl"
         },
         "1.6.4~x64": {
-            "Version": "1.6.4+0.x64.linux.gnu"
+            "Version": "1.6.4+0.x64.linux.musl"
         },
         "1.6.4~x86": {
-            "Version": "1.6.4+0.x86.linux.gnu"
+            "Version": "1.6.4+0.x86.linux.musl"
         },
         "1.6.5": {
-            "Version": "1.6.5+0.x64.linux.gnu"
+            "Version": "1.6.5+0.x64.linux.musl"
         },
         "1.6.5~x64": {
-            "Version": "1.6.5+0.x64.linux.gnu"
+            "Version": "1.6.5+0.x64.linux.musl"
         },
         "1.6.5~x86": {
-            "Version": "1.6.5+0.x86.linux.gnu"
+            "Version": "1.6.5+0.x86.linux.musl"
         },
         "1.6.6": {
-            "Version": "1.6.6+0.x64.linux.gnu"
+            "Version": "1.6.6+0.x64.linux.musl"
         },
         "1.6.6~x64": {
-            "Version": "1.6.6+0.x64.linux.gnu"
+            "Version": "1.6.6+0.x64.linux.musl"
         },
         "1.6.6~x86": {
-            "Version": "1.6.6+0.x86.linux.gnu"
+            "Version": "1.6.6+0.x86.linux.musl"
         },
         "1.6.7": {
-            "Version": "1.6.7+0.x64.linux.gnu"
+            "Version": "1.6.7+0.x64.linux.musl"
         },
         "1.6.7~x64": {
-            "Version": "1.6.7+0.x64.linux.gnu"
+            "Version": "1.6.7+0.x64.linux.musl"
         },
         "1.6.7~x86": {
-            "Version": "1.6.7+0.x86.linux.gnu"
+            "Version": "1.6.7+0.x86.linux.musl"
         },
         "1.6~x64": {
-            "Version": "1.6.7+0.x64.linux.gnu"
+            "Version": "1.6.7+0.x64.linux.musl"
         },
         "1.6~x86": {
-            "Version": "1.6.7+0.x86.linux.gnu"
+            "Version": "1.6.7+0.x86.linux.musl"
         },
         "1.7": {
-            "Version": "1.7.3+0.x64.linux.gnu"
+            "Version": "1.7.3+0.x64.linux.musl"
         },
         "1.7.0": {
-            "Version": "1.7.0+0.x64.linux.gnu"
+            "Version": "1.7.0+0.x64.linux.musl"
         },
         "1.7.0-beta1": {
-            "Version": "1.7.0-beta1+0.x64.linux.gnu"
+            "Version": "1.7.0-beta1+0.x64.linux.musl"
         },
         "1.7.0-beta1~x64": {
-            "Version": "1.7.0-beta1+0.x64.linux.gnu"
+            "Version": "1.7.0-beta1+0.x64.linux.musl"
         },
         "1.7.0-beta1~x86": {
-            "Version": "1.7.0-beta1+0.x86.linux.gnu"
+            "Version": "1.7.0-beta1+0.x86.linux.musl"
         },
         "1.7.0-beta2": {
-            "Version": "1.7.0-beta2+0.x64.linux.gnu"
+            "Version": "1.7.0-beta2+0.x64.linux.musl"
         },
         "1.7.0-beta2~x64": {
-            "Version": "1.7.0-beta2+0.x64.linux.gnu"
+            "Version": "1.7.0-beta2+0.x64.linux.musl"
         },
         "1.7.0-beta2~x86": {
-            "Version": "1.7.0-beta2+0.x86.linux.gnu"
+            "Version": "1.7.0-beta2+0.x86.linux.musl"
         },
         "1.7.0-beta3": {
-            "Version": "1.7.0-beta3+0.x64.linux.gnu"
+            "Version": "1.7.0-beta3+0.x64.linux.musl"
         },
         "1.7.0-beta3~x64": {
-            "Version": "1.7.0-beta3+0.x64.linux.gnu"
+            "Version": "1.7.0-beta3+0.x64.linux.musl"
         },
         "1.7.0-beta3~x86": {
-            "Version": "1.7.0-beta3+0.x86.linux.gnu"
+            "Version": "1.7.0-beta3+0.x86.linux.musl"
         },
         "1.7.0-beta4": {
-            "Version": "1.7.0-beta4+0.x64.linux.gnu"
+            "Version": "1.7.0-beta4+0.x64.linux.musl"
         },
         "1.7.0-beta4~x64": {
-            "Version": "1.7.0-beta4+0.x64.linux.gnu"
+            "Version": "1.7.0-beta4+0.x64.linux.musl"
         },
         "1.7.0-beta4~x86": {
-            "Version": "1.7.0-beta4+0.x86.linux.gnu"
+            "Version": "1.7.0-beta4+0.x86.linux.musl"
         },
         "1.7.0-rc1": {
-            "Version": "1.7.0-rc1+0.x64.linux.gnu"
+            "Version": "1.7.0-rc1+0.x64.linux.musl"
         },
         "1.7.0-rc1~x64": {
-            "Version": "1.7.0-rc1+0.x64.linux.gnu"
+            "Version": "1.7.0-rc1+0.x64.linux.musl"
         },
         "1.7.0-rc1~x86": {
-            "Version": "1.7.0-rc1+0.x86.linux.gnu"
+            "Version": "1.7.0-rc1+0.x86.linux.musl"
         },
         "1.7.0-rc2": {
-            "Version": "1.7.0-rc2+0.x64.linux.gnu"
+            "Version": "1.7.0-rc2+0.x64.linux.musl"
         },
         "1.7.0-rc2~x64": {
-            "Version": "1.7.0-rc2+0.x64.linux.gnu"
+            "Version": "1.7.0-rc2+0.x64.linux.musl"
         },
         "1.7.0-rc2~x86": {
-            "Version": "1.7.0-rc2+0.x86.linux.gnu"
+            "Version": "1.7.0-rc2+0.x86.linux.musl"
         },
         "1.7.0-rc3": {
-            "Version": "1.7.0-rc3+0.x64.linux.gnu"
+            "Version": "1.7.0-rc3+0.x64.linux.musl"
         },
         "1.7.0-rc3~x64": {
-            "Version": "1.7.0-rc3+0.x64.linux.gnu"
+            "Version": "1.7.0-rc3+0.x64.linux.musl"
         },
         "1.7.0-rc3~x86": {
-            "Version": "1.7.0-rc3+0.x86.linux.gnu"
+            "Version": "1.7.0-rc3+0.x86.linux.musl"
         },
         "1.7.0~x64": {
-            "Version": "1.7.0+0.x64.linux.gnu"
+            "Version": "1.7.0+0.x64.linux.musl"
         },
         "1.7.0~x86": {
-            "Version": "1.7.0+0.x86.linux.gnu"
+            "Version": "1.7.0+0.x86.linux.musl"
         },
         "1.7.1": {
-            "Version": "1.7.1+0.x64.linux.gnu"
+            "Version": "1.7.1+0.x64.linux.musl"
         },
         "1.7.1~x64": {
-            "Version": "1.7.1+0.x64.linux.gnu"
+            "Version": "1.7.1+0.x64.linux.musl"
         },
         "1.7.1~x86": {
-            "Version": "1.7.1+0.x86.linux.gnu"
+            "Version": "1.7.1+0.x86.linux.musl"
         },
         "1.7.2": {
-            "Version": "1.7.2+0.x64.linux.gnu"
+            "Version": "1.7.2+0.x64.linux.musl"
         },
         "1.7.2~x64": {
-            "Version": "1.7.2+0.x64.linux.gnu"
+            "Version": "1.7.2+0.x64.linux.musl"
         },
         "1.7.2~x86": {
-            "Version": "1.7.2+0.x86.linux.gnu"
+            "Version": "1.7.2+0.x86.linux.musl"
         },
         "1.7.3": {
-            "Version": "1.7.3+0.x64.linux.gnu"
+            "Version": "1.7.3+0.x64.linux.musl"
         },
         "1.7.3~x64": {
-            "Version": "1.7.3+0.x64.linux.gnu"
+            "Version": "1.7.3+0.x64.linux.musl"
         },
         "1.7.3~x86": {
-            "Version": "1.7.3+0.x86.linux.gnu"
+            "Version": "1.7.3+0.x86.linux.musl"
         },
         "1.7~x64": {
-            "Version": "1.7.3+0.x64.linux.gnu"
+            "Version": "1.7.3+0.x64.linux.musl"
         },
         "1.7~x86": {
-            "Version": "1.7.3+0.x86.linux.gnu"
+            "Version": "1.7.3+0.x86.linux.musl"
         },
         "1.8": {
-            "Version": "1.8.5+0.x64.linux.gnu"
+            "Version": "1.8.5+0.x64.linux.musl"
         },
         "1.8.0": {
-            "Version": "1.8.0+0.x64.linux.gnu"
+            "Version": "1.8.0+0.x64.linux.musl"
         },
         "1.8.0-beta1": {
-            "Version": "1.8.0-beta1+0.x64.linux.gnu"
+            "Version": "1.8.0-beta1+0.x64.linux.musl"
         },
         "1.8.0-beta1~x64": {
-            "Version": "1.8.0-beta1+0.x64.linux.gnu"
+            "Version": "1.8.0-beta1+0.x64.linux.musl"
         },
         "1.8.0-beta1~x86": {
-            "Version": "1.8.0-beta1+0.x86.linux.gnu"
+            "Version": "1.8.0-beta1+0.x86.linux.musl"
         },
         "1.8.0-beta2": {
-            "Version": "1.8.0-beta2+0.x86.linux.gnu"
+            "Version": "1.8.0-beta2+0.x86.linux.musl"
         },
         "1.8.0-beta2~x86": {
-            "Version": "1.8.0-beta2+0.x86.linux.gnu"
+            "Version": "1.8.0-beta2+0.x86.linux.musl"
         },
         "1.8.0-beta3": {
-            "Version": "1.8.0-beta3+0.x64.linux.gnu"
+            "Version": "1.8.0-beta3+0.x64.linux.musl"
         },
         "1.8.0-beta3~x64": {
-            "Version": "1.8.0-beta3+0.x64.linux.gnu"
+            "Version": "1.8.0-beta3+0.x64.linux.musl"
         },
         "1.8.0-beta3~x86": {
-            "Version": "1.8.0-beta3+0.x86.linux.gnu"
+            "Version": "1.8.0-beta3+0.x86.linux.musl"
         },
         "1.8.0-rc1": {
-            "Version": "1.8.0-rc1+0.x64.linux.gnu"
+            "Version": "1.8.0-rc1+0.x64.linux.musl"
         },
         "1.8.0-rc1~x64": {
-            "Version": "1.8.0-rc1+0.x64.linux.gnu"
+            "Version": "1.8.0-rc1+0.x64.linux.musl"
         },
         "1.8.0-rc1~x86": {
-            "Version": "1.8.0-rc1+0.x86.linux.gnu"
+            "Version": "1.8.0-rc1+0.x86.linux.musl"
         },
         "1.8.0-rc2": {
-            "Version": "1.8.0-rc2+0.x64.linux.gnu"
+            "Version": "1.8.0-rc2+0.x64.linux.musl"
         },
         "1.8.0-rc2~x64": {
-            "Version": "1.8.0-rc2+0.x64.linux.gnu"
+            "Version": "1.8.0-rc2+0.x64.linux.musl"
         },
         "1.8.0-rc2~x86": {
-            "Version": "1.8.0-rc2+0.x86.linux.gnu"
+            "Version": "1.8.0-rc2+0.x86.linux.musl"
         },
         "1.8.0-rc3": {
-            "Version": "1.8.0-rc3+0.x64.linux.gnu"
+            "Version": "1.8.0-rc3+0.x64.linux.musl"
         },
         "1.8.0-rc3~x64": {
-            "Version": "1.8.0-rc3+0.x64.linux.gnu"
+            "Version": "1.8.0-rc3+0.x64.linux.musl"
         },
         "1.8.0-rc3~x86": {
-            "Version": "1.8.0-rc3+0.x86.linux.gnu"
+            "Version": "1.8.0-rc3+0.x86.linux.musl"
         },
         "1.8.0-rc4": {
-            "Version": "1.8.0-rc4+0.x64.linux.gnu"
+            "Version": "1.8.0-rc4+0.x64.linux.musl"
         },
         "1.8.0-rc4~x64": {
-            "Version": "1.8.0-rc4+0.x64.linux.gnu"
+            "Version": "1.8.0-rc4+0.x64.linux.musl"
         },
         "1.8.0-rc4~x86": {
-            "Version": "1.8.0-rc4+0.x86.linux.gnu"
+            "Version": "1.8.0-rc4+0.x86.linux.musl"
         },
         "1.8.0~x64": {
-            "Version": "1.8.0+0.x64.linux.gnu"
+            "Version": "1.8.0+0.x64.linux.musl"
         },
         "1.8.0~x86": {
-            "Version": "1.8.0+0.x86.linux.gnu"
+            "Version": "1.8.0+0.x86.linux.musl"
         },
         "1.8.1": {
-            "Version": "1.8.1+0.x64.linux.gnu"
+            "Version": "1.8.1+0.x64.linux.musl"
         },
         "1.8.1~x64": {
-            "Version": "1.8.1+0.x64.linux.gnu"
+            "Version": "1.8.1+0.x64.linux.musl"
         },
         "1.8.1~x86": {
-            "Version": "1.8.1+0.x86.linux.gnu"
+            "Version": "1.8.1+0.x86.linux.musl"
         },
         "1.8.2": {
-            "Version": "1.8.2+0.x64.linux.gnu"
+            "Version": "1.8.2+0.x64.linux.musl"
         },
         "1.8.2~x64": {
-            "Version": "1.8.2+0.x64.linux.gnu"
+            "Version": "1.8.2+0.x64.linux.musl"
         },
         "1.8.2~x86": {
-            "Version": "1.8.2+0.x86.linux.gnu"
+            "Version": "1.8.2+0.x86.linux.musl"
         },
         "1.8.3": {
-            "Version": "1.8.3+0.x64.linux.gnu"
+            "Version": "1.8.3+0.x64.linux.musl"
         },
         "1.8.3~x64": {
-            "Version": "1.8.3+0.x64.linux.gnu"
+            "Version": "1.8.3+0.x64.linux.musl"
         },
         "1.8.3~x86": {
-            "Version": "1.8.3+0.x86.linux.gnu"
+            "Version": "1.8.3+0.x86.linux.musl"
         },
         "1.8.4": {
-            "Version": "1.8.4+0.x64.linux.gnu"
+            "Version": "1.8.4+0.x64.linux.musl"
         },
         "1.8.4~x64": {
-            "Version": "1.8.4+0.x64.linux.gnu"
+            "Version": "1.8.4+0.x64.linux.musl"
         },
         "1.8.4~x86": {
-            "Version": "1.8.4+0.x86.linux.gnu"
+            "Version": "1.8.4+0.x86.linux.musl"
         },
         "1.8.5": {
-            "Version": "1.8.5+0.x64.linux.gnu"
+            "Version": "1.8.5+0.x64.linux.musl"
         },
         "1.8.5~x64": {
-            "Version": "1.8.5+0.x64.linux.gnu"
+            "Version": "1.8.5+0.x64.linux.musl"
         },
         "1.8.5~x86": {
-            "Version": "1.8.5+0.x86.linux.gnu"
+            "Version": "1.8.5+0.x86.linux.musl"
         },
         "1.8~x64": {
-            "Version": "1.8.5+0.x64.linux.gnu"
+            "Version": "1.8.5+0.x64.linux.musl"
         },
         "1.8~x86": {
-            "Version": "1.8.5+0.x86.linux.gnu"
+            "Version": "1.8.5+0.x86.linux.musl"
         },
         "1.9": {
-            "Version": "1.9.4+0.x64.linux.gnu"
+            "Version": "1.9.4+0.x64.linux.musl"
         },
         "1.9.0": {
-            "Version": "1.9.0+0.x64.linux.gnu"
+            "Version": "1.9.0+0.x64.linux.musl"
         },
         "1.9.0-alpha1": {
-            "Version": "1.9.0-alpha1+0.x64.linux.gnu"
+            "Version": "1.9.0-alpha1+0.x64.linux.musl"
         },
         "1.9.0-alpha1~x64": {
-            "Version": "1.9.0-alpha1+0.x64.linux.gnu"
+            "Version": "1.9.0-alpha1+0.x64.linux.musl"
         },
         "1.9.0-alpha1~x86": {
-            "Version": "1.9.0-alpha1+0.x86.linux.gnu"
+            "Version": "1.9.0-alpha1+0.x86.linux.musl"
         },
         "1.9.0-beta1": {
-            "Version": "1.9.0-beta1+0.x64.linux.gnu"
+            "Version": "1.9.0-beta1+0.x64.linux.musl"
         },
         "1.9.0-beta1~x64": {
-            "Version": "1.9.0-beta1+0.x64.linux.gnu"
+            "Version": "1.9.0-beta1+0.x64.linux.musl"
         },
         "1.9.0-beta1~x86": {
-            "Version": "1.9.0-beta1+0.x86.linux.gnu"
+            "Version": "1.9.0-beta1+0.x86.linux.musl"
         },
         "1.9.0-beta2": {
-            "Version": "1.9.0-beta2+0.x64.linux.gnu"
+            "Version": "1.9.0-beta2+0.x64.linux.musl"
         },
         "1.9.0-beta2~x64": {
-            "Version": "1.9.0-beta2+0.x64.linux.gnu"
+            "Version": "1.9.0-beta2+0.x64.linux.musl"
         },
         "1.9.0-beta2~x86": {
-            "Version": "1.9.0-beta2+0.x86.linux.gnu"
+            "Version": "1.9.0-beta2+0.x86.linux.musl"
         },
         "1.9.0-beta3": {
-            "Version": "1.9.0-beta3+0.x64.linux.gnu"
+            "Version": "1.9.0-beta3+0.x64.linux.musl"
         },
         "1.9.0-beta3~x64": {
-            "Version": "1.9.0-beta3+0.x64.linux.gnu"
+            "Version": "1.9.0-beta3+0.x64.linux.musl"
         },
         "1.9.0-beta3~x86": {
-            "Version": "1.9.0-beta3+0.x86.linux.gnu"
+            "Version": "1.9.0-beta3+0.x86.linux.musl"
         },
         "1.9.0-beta4": {
-            "Version": "1.9.0-beta4+0.x64.linux.gnu"
+            "Version": "1.9.0-beta4+0.x64.linux.musl"
         },
         "1.9.0-beta4~x64": {
-            "Version": "1.9.0-beta4+0.x64.linux.gnu"
+            "Version": "1.9.0-beta4+0.x64.linux.musl"
         },
         "1.9.0-beta4~x86": {
-            "Version": "1.9.0-beta4+0.x86.linux.gnu"
+            "Version": "1.9.0-beta4+0.x86.linux.musl"
         },
         "1.9.0-rc1": {
-            "Version": "1.9.0-rc1+0.x64.linux.gnu"
+            "Version": "1.9.0-rc1+0.x64.linux.musl"
         },
         "1.9.0-rc1~x64": {
-            "Version": "1.9.0-rc1+0.x64.linux.gnu"
+            "Version": "1.9.0-rc1+0.x64.linux.musl"
         },
         "1.9.0-rc1~x86": {
-            "Version": "1.9.0-rc1+0.x86.linux.gnu"
+            "Version": "1.9.0-rc1+0.x86.linux.musl"
         },
         "1.9.0-rc2": {
-            "Version": "1.9.0-rc2+0.x64.linux.gnu"
+            "Version": "1.9.0-rc2+0.x64.linux.musl"
         },
         "1.9.0-rc2~x64": {
-            "Version": "1.9.0-rc2+0.x64.linux.gnu"
+            "Version": "1.9.0-rc2+0.x64.linux.musl"
         },
         "1.9.0-rc2~x86": {
-            "Version": "1.9.0-rc2+0.x86.linux.gnu"
+            "Version": "1.9.0-rc2+0.x86.linux.musl"
         },
         "1.9.0-rc3": {
-            "Version": "1.9.0-rc3+0.x64.linux.gnu"
+            "Version": "1.9.0-rc3+0.x64.linux.musl"
         },
         "1.9.0-rc3~x64": {
-            "Version": "1.9.0-rc3+0.x64.linux.gnu"
+            "Version": "1.9.0-rc3+0.x64.linux.musl"
         },
         "1.9.0-rc3~x86": {
-            "Version": "1.9.0-rc3+0.x86.linux.gnu"
+            "Version": "1.9.0-rc3+0.x86.linux.musl"
         },
         "1.9.0~x64": {
-            "Version": "1.9.0+0.x64.linux.gnu"
+            "Version": "1.9.0+0.x64.linux.musl"
         },
         "1.9.0~x86": {
-            "Version": "1.9.0+0.x86.linux.gnu"
+            "Version": "1.9.0+0.x86.linux.musl"
         },
         "1.9.1": {
-            "Version": "1.9.1+0.x64.linux.gnu"
+            "Version": "1.9.1+0.x64.linux.musl"
         },
         "1.9.1~x64": {
-            "Version": "1.9.1+0.x64.linux.gnu"
+            "Version": "1.9.1+0.x64.linux.musl"
         },
         "1.9.1~x86": {
-            "Version": "1.9.1+0.x86.linux.gnu"
+            "Version": "1.9.1+0.x86.linux.musl"
         },
         "1.9.2": {
-            "Version": "1.9.2+0.x64.linux.gnu"
+            "Version": "1.9.2+0.x64.linux.musl"
         },
         "1.9.2~x64": {
-            "Version": "1.9.2+0.x64.linux.gnu"
+            "Version": "1.9.2+0.x64.linux.musl"
         },
         "1.9.2~x86": {
-            "Version": "1.9.2+0.x86.linux.gnu"
+            "Version": "1.9.2+0.x86.linux.musl"
         },
         "1.9.3": {
-            "Version": "1.9.3+0.x64.linux.gnu"
+            "Version": "1.9.3+0.x64.linux.musl"
         },
         "1.9.3~x64": {
-            "Version": "1.9.3+0.x64.linux.gnu"
+            "Version": "1.9.3+0.x64.linux.musl"
         },
         "1.9.3~x86": {
-            "Version": "1.9.3+0.x86.linux.gnu"
+            "Version": "1.9.3+0.x86.linux.musl"
         },
         "1.9.4": {
-            "Version": "1.9.4+0.x64.linux.gnu"
+            "Version": "1.9.4+0.x64.linux.musl"
         },
         "1.9.4~x64": {
-            "Version": "1.9.4+0.x64.linux.gnu"
+            "Version": "1.9.4+0.x64.linux.musl"
         },
         "1.9.4~x86": {
-            "Version": "1.9.4+0.x86.linux.gnu"
+            "Version": "1.9.4+0.x86.linux.musl"
         },
         "1.9~x64": {
-            "Version": "1.9.4+0.x64.linux.gnu"
+            "Version": "1.9.4+0.x64.linux.musl"
         },
         "1.9~x86": {
-            "Version": "1.9.4+0.x86.linux.gnu"
+            "Version": "1.9.4+0.x86.linux.musl"
         },
         "1~x64": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "1~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "alpha": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "alpha~x64": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "alpha~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "beta": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "beta~x64": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "beta~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "lts": {
-            "Version": "1.6.7+0.x64.linux.gnu"
+            "Version": "1.6.7+0.x64.linux.musl"
         },
         "lts~x64": {
-            "Version": "1.6.7+0.x64.linux.gnu"
+            "Version": "1.6.7+0.x64.linux.musl"
         },
         "lts~x86": {
-            "Version": "1.6.7+0.x86.linux.gnu"
+            "Version": "1.6.7+0.x86.linux.musl"
         },
         "rc": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "rc~x64": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "rc~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         },
         "release": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "release~x64": {
-            "Version": "1.10.0+0.x64.linux.gnu"
+            "Version": "1.10.0+0.x64.linux.musl"
         },
         "release~x86": {
-            "Version": "1.10.0+0.x86.linux.gnu"
+            "Version": "1.10.0+0.x86.linux.musl"
         }
     },
     "Version": "1.0.36"


### PR DESCRIPTION
Resolves #762 

While attempting to package Juliaup for Alpine Linux (musl libc) I experienced [failures](https://gitlab.alpinelinux.org/strophy/aports/-/jobs/1195473) during `cargo test` due to `juliaup` incorrectly downloading glibc binaries to a musl libc system.

```
     Running tests/channel_selection.rs (target/debug/deps/channel_selection-ec83ce41afe3622d)
running 1 test
test channel_selection ... FAILED
failures:
---- channel_selection stdout ----
thread 'channel_selection' panicked at 'Unexpected failure.
code=1
stderr=``````
Error: The Julia launcher failed to start Julia.
Caused by:
    No such file or directory (os error 2)
\```
\```
command=`JULIAUP_DEPOT_PATH="/tmp/.tmphOgVTW" JULIA_DEPOT_PATH="/tmp/.tmphOgVTW" "/builds/strophy/aports/testing/juliaup/src/juliaup-1.12.5/target/debug/julialauncher" "-e" "print(VERSION)"`
code=1
stdout=""
stderr=```
Error: The Julia launcher failed to start Julia.
Caused by:
    No such file or directory (os error 2)
\```
', /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/core/src/ops/function.rs:250:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
failures:
    channel_selection
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 39.29s
error: test failed, to rerun pass `--test channel_selection`
>>> ERROR: juliaup: check failed
```

`No such file or directory` occurs while trying to execute the binary on a system where `/lib64/ld-linux-x86-64.so.2` is not present. This PR adjusts the download links in the versiondb directory, and naively attempts to update what I think is the generator script for these files. I don't see any tests for this generator, and I'm not sure how to actually build and execute Julia code. I was however able to successfully build a package based on this branch, so cargo tests work on musl now.