### PR TITLE
Init script: Added possiblity for overriding JULIAUP_VERSION

### DIFF
--- a/deploy/shellscript/juliaup-init.sh
+++ b/deploy/shellscript/juliaup-init.sh
@@ -25,7 +25,9 @@ set -u
 
 # If JULIAUP_SERVER is unset or empty, default it.
 JULIAUP_SERVER="${JULIAUP_SERVER:-https://julialang-s3.julialang.org}"
-JULIAUP_VERSION="THISISREPLACEDWITHREALVERSIONINGITHUBWORKFLOW"
+
+# If JULIAUP_VERSION is unset or empty, default it.
+JULIAUP_VERSION="${JULIAUP_VERSION:-THISISREPLACEDWITHREALVERSIONINGITHUBWORKFLOW}"
 
 #XXX: If you change anything here, please make the same changes in setup_mode.rs
 usage() {


### PR DESCRIPTION
This PR should make it possible to customize the juliaup version used, e.g., to lock the juliaup version used for reproducibility in a Dockerfile.