### PR TITLE
improvement: handling of selfuninstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ predicates = "3.0.3"
 
 [features]
 selfupdate = []
+distro-default = []
 windowsstore = []
 windowsappinstaller = []
 dummy = []

--- a/build.rs
+++ b/build.rs
@@ -62,4 +62,3 @@ fn main() -> Result<()> {
 
 #[cfg(all(feature = "selfupdate", feature = "distro-default"))]
 compile_error!("Compilation is not allowed. You can't compile with feature `selfupdate` and `distro-default` enabled together.");
-

--- a/build.rs
+++ b/build.rs
@@ -59,3 +59,7 @@ fn main() -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(all(feature = "selfupdate", feature = "distro-default"))]
+compile_error!("Compilation is not allowed. You can't compile with feature `selfupdate` and `distro-default` enabled together.");
+

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -12,6 +12,9 @@ use juliaup::command_link::run_command_link;
 use juliaup::command_list::run_command_list;
 use juliaup::command_override::{run_command_override_status, run_command_override_unset};
 use juliaup::command_remove::run_command_remove;
+// This can either be selfupdate or distro-default
+#[cfg(any(feature = "distro-default", feature = "selfupdate"))]
+use juliaup::command_selfuninstall::run_command_selfuninstall;
 use juliaup::command_selfupdate::run_command_selfupdate;
 use juliaup::command_status::run_command_status;
 use juliaup::command_update::run_command_update;
@@ -23,7 +26,7 @@ use juliaup::{
     command_config_backgroundselfupdate::run_command_config_backgroundselfupdate,
     command_config_modifypath::run_command_config_modifypath,
     command_config_startupselfupdate::run_command_config_startupselfupdate,
-    command_selfchannel::run_command_selfchannel, command_selfuninstall::run_command_selfuninstall,
+    command_selfchannel::run_command_selfchannel,
 };
 use log::info;
 
@@ -106,7 +109,7 @@ enum SelfSubCmd {
     #[cfg(feature = "selfupdate")]
     /// Configure the channel to use for juliaup updates
     Channel { channel: String },
-    #[cfg(feature = "selfupdate")]
+    #[cfg(any(feature = "selfupdate", feature = "distro-default"))]
     /// Uninstall this version of juliaup from the system
     Uninstall {},
 }
@@ -220,7 +223,7 @@ fn main() -> Result<()> {
             SelfSubCmd::Update {} => run_command_selfupdate(&paths),
             #[cfg(feature = "selfupdate")]
             SelfSubCmd::Channel { channel } => run_command_selfchannel(channel, &paths),
-            #[cfg(feature = "selfupdate")]
+            #[cfg(any(feature = "selfupdate", feature = "distro-default"))]
             SelfSubCmd::Uninstall {} => run_command_selfuninstall(&paths),
         },
     }

--- a/src/command_selfuninstall.rs
+++ b/src/command_selfuninstall.rs
@@ -1,5 +1,11 @@
-#[cfg(feature = "selfupdate")]
+#[cfg(any(feature = "distro-default", feature = "selfupdate"))]
 use anyhow::Result;
+
+#[cfg(feature = "distro-default")]
+pub fn run_command_selfuninstall(_paths: &crate::global_paths::GlobalPaths) -> Result<()> {
+    eprintln!("Self uninstall command is unavailable in this variant of Juliaup. This software was build with the intention of distributing it through a package manager other than cargo or provided by upstream.");
+    Ok(())
+}
 
 #[cfg(feature = "selfupdate")]
 pub fn run_command_selfuninstall(paths: &crate::global_paths::GlobalPaths) -> Result<()> {

--- a/src/command_selfuninstall.rs
+++ b/src/command_selfuninstall.rs
@@ -3,7 +3,11 @@ use anyhow::Result;
 
 #[cfg(feature = "distro-default")]
 pub fn run_command_selfuninstall(_paths: &crate::global_paths::GlobalPaths) -> Result<()> {
-    eprintln!("Self uninstall command is unavailable in this variant of Juliaup. This software was build with the intention of distributing it through a package manager other than cargo or provided by upstream.");
+    eprintln!(
+        "Self uninstall command is unavailable in this variant of Juliaup.
+This software was built with the intention of distributing it
+through a package manager other than cargo or provided by upstream."
+    );
     Ok(())
 }
 


### PR DESCRIPTION
We added the feature `distro-default` to let packagers configure the disablement of `selfupdate`. The build.rs file is adapted to raise a compiler error if both features are configured together.

Closes #752 