### PR TITLE
Don't detect ttyname if it is not needed

### DIFF
--- a/deploy/shellscript/juliaup-init.sh
+++ b/deploy/shellscript/juliaup-init.sh
@@ -130,9 +130,8 @@ main() {
         exit 1
     fi
 
-    _ttyname="/dev/$(ps -p $$ -o tty= | xargs)"
-
     if [ "$need_tty" = "yes" ]; then
+        _ttyname="/dev/$(ps -p $$ -o tty= | xargs)"
         ignore "$_file" THISISREPLACEDWITHCHANNELCONFIGINGITHUBWORKFLOW "$@" < "$_ttyname"
     else
         ignore "$_file" THISISREPLACEDWITHCHANNELCONFIGINGITHUBWORKFLOW "$@"


### PR DESCRIPTION
The code detecting the ttyname fails when `ps` is provided by busybox. With this change, one can at least use the installer non-interactively.

As suggested by @davidanthoff at https://github.com/JuliaLang/juliaup/issues/634#issuecomment-1540459942