### PR TITLE
Replace unmaintained action-rs actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,13 +191,12 @@ jobs:
       with:
         platform: x86
         version: 12.2.0
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: ${{matrix.toolchain}}
-        default: true
         target: ${{matrix.target}}
     - name: Release build
-      uses: actions-rs/cargo@v1
+      uses: clechasseur/rs-cargo@v2
       with:
         command: build
         use-cross: ${{ matrix.os == 'ubuntu' }}
@@ -279,13 +278,12 @@ jobs:
       with:
         platform: x86
         version: 12.2.0
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: ${{matrix.toolchain}}
-        default: true
         target: ${{matrix.target}}
     - name: Test
-      uses: actions-rs/cargo@v1
+      uses: clechasseur/rs-cargo@v2
       with:
         command: test
         use-cross: ${{ matrix.os == 'ubuntu' }}
@@ -554,15 +552,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install AzureSignTool
       run: dotnet tool install --global AzureSignTool
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install cargo-msix
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: cargo-msix
+      run: cargo install cargo-msix
     - name: Install StoreBroker
       run: Install-Module -Name StoreBroker -Force
     - name: Download and extract bundled Julia versions
@@ -607,15 +599,9 @@ jobs:
         name: juliaup-x86_64-pc-windows-msvc-windowsappinstaller
         path: target\winappinstaller\x86_64-pc-windows-msvc\release
     - name: Build MSIX Windows Store
-      uses: actions-rs/cargo@v1
-      with:
-        command: msix
-        args: --release --bundle-name winstoremsix --source-build-output-path ${{ format('{0}/target/windowsstore', github.workspace) }}
+      run: cargo msix --release --bundle-name winstoremsix --source-build-output-path ${{ format('{0}/target/windowsstore', github.workspace) }}
     - name: Build MSIX App Installer
-      uses: actions-rs/cargo@v1
-      with:
-        command: msix
-        args: --release --bundle-name winappinstallermsix --source-build-output-path ${{ format('{0}/target/winappinstaller', github.workspace) }}
+      run: cargo msix --release --bundle-name winappinstallermsix --source-build-output-path ${{ format('{0}/target/winappinstaller', github.workspace) }}
     - name: Sign msix files
       run: |
         Get-ChildItem target\msix\winappinstallermsix | ForEach-Object {
@@ -1020,12 +1006,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Publish to creates.io
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
+        run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          components: rustfmt
       - name: Rustfmt check
         run: cargo fmt -- --check -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,13 +109,12 @@ jobs:
     - uses: actions/checkout@v4
     - if: ${{ contains(matrix.target, '-musl') }}
       run: sudo apt-get install musl-tools
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
-        default: true
         target: ${{matrix.target}}
     - name: Check build
-      uses: actions-rs/cargo@v1
+      uses: clechasseur/rs-cargo@v2
       with:
         command: check
         use-cross: ${{ matrix.os == 'ubuntu' }}
@@ -183,16 +182,12 @@ jobs:
       with:
         platform: x86
         version: 12.2.0
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: ${{matrix.toolchain}}
-        default: true
         target: ${{matrix.target}}
     - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --target ${{matrix.target}} --features ${{matrix.features}}
+      run: cargo test --target ${{matrix.target}} --features ${{matrix.features}}
       env:
         CARGO_TARGET_x86_64-unknown-linux-musl: ${{matrix.rustflags}}
         CARGO_TARGET_i686-unknown-linux-musl: ${{matrix.rustflags}}


### PR DESCRIPTION
The action-rs repositories were archived in October 2023. They use deprecated GH Action feature which will stop working at some point.

Replace `actions-rs/toolchain` by `actions-rust-lang/setup-rust-toolchain` which is different but similar enough for our purposes. It lacks the `default` argument but as far as I can tell it does not matter?

As a nice enhancement, the new action also sets up "Problem Matchers" which scan all output for `cargo` and `rustfmt` error messages which then are highlighted in the GitHub web interface.

That also means that as a replacement for `actions-rs/cargo` one can usually just call `cargo` directly. Well, except when `use-cross` is enabled... One could probably also call `cross` directly, but I decided to play it safe and just use `clechasseur/rs-cargo` instead, which is an improved fork of the original `actions-rs/cargo`.


Requires #782 -- so e.g. close and reopen this PR after #782 was merged to (hopefully) make it pass