### PR TITLE
improvement: new message for `juliaup self uninstall command` if feature `selfupdate` is disabled

### DIFF
--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -23,8 +23,15 @@ use juliaup::{
     command_config_backgroundselfupdate::run_command_config_backgroundselfupdate,
     command_config_modifypath::run_command_config_modifypath,
     command_config_startupselfupdate::run_command_config_startupselfupdate,
-    command_selfchannel::run_command_selfchannel, command_selfuninstall::run_command_selfuninstall,
+    command_selfchannel::run_command_selfchannel,
 };
+
+#[cfg(feature = "selfupdate")]
+use juliaup::command_selfuninstall::run_command_selfuninstall;
+
+#[cfg(not(feature = "selfupdate"))]
+use juliaup::command_selfuninstall::run_command_selfuninstall_unavailable;
+
 use log::info;
 
 #[derive(Parser)]
@@ -108,6 +115,11 @@ enum SelfSubCmd {
     Channel { channel: String },
     #[cfg(feature = "selfupdate")]
     /// Uninstall this version of juliaup from the system
+    Uninstall {},
+    #[cfg(not(feature = "selfupdate"))]
+    /// If `selfupdate` feature is not enabled, this
+    /// configures the Uninstall to just print an error message
+    /// that it is **unavailable**.
     Uninstall {},
 }
 
@@ -222,6 +234,8 @@ fn main() -> Result<()> {
             SelfSubCmd::Channel { channel } => run_command_selfchannel(channel, &paths),
             #[cfg(feature = "selfupdate")]
             SelfSubCmd::Uninstall {} => run_command_selfuninstall(&paths),
+            #[cfg(not(feature = "selfupdate"))]
+            SelfSubCmd::Uninstall {} => run_command_selfuninstall_unavailable(),
         },
     }
 }

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -117,9 +117,7 @@ enum SelfSubCmd {
     /// Uninstall this version of juliaup from the system
     Uninstall {},
     #[cfg(not(feature = "selfupdate"))]
-    /// If `selfupdate` feature is not enabled, this
-    /// configures the Uninstall to just print an error message
-    /// that it is **unavailable**.
+    /// Uninstall this version of juliaup from the system (UNAVAILABLE)
     Uninstall {},
 }
 

--- a/src/command_selfuninstall.rs
+++ b/src/command_selfuninstall.rs
@@ -117,3 +117,15 @@ pub fn run_command_selfuninstall(paths: &crate::global_paths::GlobalPaths) -> Re
 
     Ok(())
 }
+
+#[cfg(not(feature = "selfupdate"))]
+use anyhow::Result;
+
+#[cfg(not(feature = "selfupdate"))]
+pub fn run_command_selfuninstall_unavailable() -> Result<()> {
+    eprintln!("Self uninstall command is unavailable in this variant of Juliaup.
+This software was built with the intention of distributing it
+through a package manager other than cargo or upstream.");
+    Ok(())
+}
+

--- a/src/command_selfuninstall.rs
+++ b/src/command_selfuninstall.rs
@@ -123,9 +123,10 @@ use anyhow::Result;
 
 #[cfg(not(feature = "selfupdate"))]
 pub fn run_command_selfuninstall_unavailable() -> Result<()> {
-    eprintln!("Self uninstall command is unavailable in this variant of Juliaup.
+    eprintln!(
+        "Self uninstall command is unavailable in this variant of Juliaup.
 This software was built with the intention of distributing it
-through a package manager other than cargo or upstream.");
+through a package manager other than cargo or upstream."
+    );
     Ok(())
 }
-


### PR DESCRIPTION
supersedes #769 and fixes #752 

---

Off-topic but I may have found a bug. Not sure if the location of the binaries are hard-coded to the julia home folder to cause this. it should be `target/debug/<juliaup binaries>`

```
Do you really want to uninstall Julia? yes
Removing background self update task. Failed.
Removing startup self update configuration. Failed.
Removing PATH modifications in startup scripts. Failed.
Removing symlinks. Failed.
Deleting Juliaup home folder "/home/uncomfy/.julia/juliaup". Success.
Deleting julia symlink "/home/uncomfy/development/projects/juliaup/target/bin/julia". Failed.
Deleting julialauncher binary "/home/uncomfy/development/projects/juliaup/target/bin/julialauncher". Failed.
Deleting juliaup binary "/home/uncomfy/development/projects/juliaup/target/bin/juliaup". Failed.
Error: No such file or directory (os error 2)
```
