### PR TITLE
document -p

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ curl -fsSL https://install.julialang.org | sh -s -- <ARGS>
 Here `<ARGS>` should be replaced with one or more of the following arguments:
 - `--yes` (or `-y`): Run the installer in a non-interactive mode. All configuration values use their default.
 - `--default-channel <NAME>`: Configure the default channel. For example `--default-channel lts` would install the `lts` channel and configure it as the default.
+- `--path` (or `-p`): Install `juliaup` in a custom location.
 
 ### Software Repositories
 


### PR DESCRIPTION
I was using `juliaup` to install `julia` in a docker container (install as root in `/opt/juliaup` to be used by different user that is mapped into the container at deployment time) and had to download and look at the shellscript to learn about the `-p` option. I think this option should be documented in the `README.md`.