### PR TITLE
Alternate short channel matching support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,4 +356,7 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 
+# Apple junk
+*.DS_Store
+
 !/src/bin

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ To launch a specific Julia version, say in channel `release`, run `julia +releas
 
 The Julia launcher `julia` automatically determines which specific version of Julia to launch. There are several ways to control and override which Juliaup channel should be used:
 
-1. A command line Julia version specifier, such as `julia +release`.
+1. A command line Julia version specifier, such as `julia +release`. For non-version channels, any unambiguous installed channel prefix will launch that channel.
 2. The `JULIAUP_CHANNEL` environment variable.
 3. A directory override, set with the `juliaup override set` command.
 3. The default Juliaup channel.

--- a/src/global_paths.rs
+++ b/src/global_paths.rs
@@ -55,7 +55,9 @@ fn get_default_juliaup_home_path() -> Result<PathBuf> {
 
 pub fn get_paths() -> Result<GlobalPaths> {
     let juliauphome = get_juliaup_home_path()?;
-
+    return get_paths_from_home_path(juliauphome);
+}
+pub fn get_paths_from_home_path(juliauphome: PathBuf) -> Result<GlobalPaths> {
     #[cfg(feature = "selfupdate")]
     let my_own_path = std::env::current_exe()
         .with_context(|| "Could not determine the path of the running exe.")?;

--- a/tests/channel_selection.rs
+++ b/tests/channel_selection.rs
@@ -174,8 +174,7 @@ fn channel_selection() {
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .env("JULIAUP_DEPOT_PATH", depot_dir.path())
         .assert()
-        .success()
-        .stdout("");
+        .success();
 
     Command::cargo_bin("julia")
         .unwrap()
@@ -193,8 +192,7 @@ fn channel_selection() {
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .env("JULIAUP_DEPOT_PATH", depot_dir.path())
         .assert()
-        .success()
-        .stdout("");
+        .success();
 
     Command::cargo_bin("julia")
         .unwrap()

--- a/tests/channel_selection.rs
+++ b/tests/channel_selection.rs
@@ -151,4 +151,57 @@ fn channel_selection() {
         .assert()
         .failure()
         .stderr("ERROR: `nightly` is not installed. Please run `juliaup add nightly` to install channel or version.\n");
+
+    // Now testing short channel matching
+    // At this point, installed channels are: 1.6.7, 1.7.3, 1.8.5
+
+    // Test that incomplete number matching does not autocomplete:
+    // https://github.com/JuliaLang/juliaup/pull/838#issuecomment-2206640506
+    Command::cargo_bin("julia")
+        .unwrap()
+        .arg("+1.8")
+        .arg("-v")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .failure();
+
+    // Test that completion works only when it should for words
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("release")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("julia")
+        .unwrap()
+        .arg("+r")
+        .arg("-v")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success();
+
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("rc")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    Command::cargo_bin("julia")
+        .unwrap()
+        .arg("+r")
+        .arg("-v")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .failure();
 }


### PR DESCRIPTION
Closes #836 and closes #830.

If the channel is the prefix for one and only one installed channel, use that, otherwise old behaviour. This behaves more like the julia command line arguments

Should work with any installed channel including linked channels instead of a hard-coded few.