### PR TITLE
Update julialauncher.rs update prompt message.

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -145,7 +145,7 @@ fn check_channel_uptodate(
         eprintln!("  juliaup update");
         eprintln!();
         eprintln!(
-            "to install Julia {} and update the `{}` channel to that version.",
+            "in your terminal shell to install Julia {} and update the `{}` channel to that version.",
             latest_version, channel
         );
     }


### PR DESCRIPTION
Attempts to avoid this mistake
```julia
julia> juliaup update
ERROR: syntax: extra token "update" after end of expression
```
by clarifying where to run the command presented in the banner.

(Auto-update in #57 would still be better.)