### PR TITLE
Don't change terminal title

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -283,10 +283,6 @@ fn get_override_channel(
 }
 
 fn run_app() -> Result<i32> {
-    // Set console title
-    let term = Term::stdout();
-    term.set_title("Julia");
-
     let paths = get_paths().with_context(|| "Trying to load all global paths.")?;
 
     do_initial_setup(&paths.juliaupconfig)


### PR DESCRIPTION
Changing title is putting extra escape codes and "Julia" into STDOUT and messes up output when used with shell pipes or redirects.