### PR TITLE
add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711124224,
+        "narHash": "sha256-l0zlN/3CiodvWDtfBOVxeTwYSRz93muVbXWSpaMjXxM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "56528ee42526794d413d6f244648aaee4a7b56c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "Julia installer and version multiplexer";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        version = cargoToml.package.version;
+        buildInputs = with pkgs; [
+          openssl
+        ] ++ (if pkgs.stdenv.isDarwin then [
+          darwin.apple_sdk.frameworks.SystemConfiguration
+        ] else [ ]);
+      in
+      {
+        packages.juliaup = pkgs.rustPlatform.buildRustPackage {
+          pname = "juliaup";
+          inherit version;
+
+          src = ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+
+          inherit buildInputs;
+
+          doCheck = false; # Disable tests
+
+          meta = with pkgs.lib; {
+            description = "Julia installer and version multiplexer";
+            homepage = "https://github.com/JuliaLang/juliaup";
+            license = licenses.mit;
+            maintainers = with maintainers; [ sjkelly ];
+          };
+        };
+
+        defaultPackage = self.packages.${system}.juliaup;
+
+        apps.juliaup = flake-utils.lib.mkApp {
+          drv = self.packages.${system}.juliaup;
+        };
+
+        defaultApp = self.apps.${system}.juliaup;
+      }
+    );
+}


### PR DESCRIPTION
This adds a flake.nix which can be used to build and
retrieve `juliaup` from the nix package manager.
It uses the `rustPlatform.buildRustPackage` function
from nixpkgs to build the Rust package, and the
23.11 pkg distribution.

Nix makes it easy to build and install `juliaup`,
either by running `nix build` or `nix run` in the project
directory or by referencing the flake from another nix configuration.
