### PR TITLE
fix `is_juliaup_installed` for invalid path

### DIFF
--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -132,7 +132,7 @@ struct Juliainstaller {
     #[clap(short = 'p', long = "path")]
     alternate_path: Option<String>,
     /// Control adding the Juliaup dir to the PATH
-    /// Use Option<bool> and default_value="yes" to force --add-to-path=[yes|no|0|1] instead of flag
+    /// Use Option<bool> and default_value="yes" to force --add_to_path=[yes|no|0|1] instead of flag
     #[clap(long = "add-to-path", value_parser = BoolishValueParser::new(), default_value = "yes")]
     add_to_path: Option<bool>,
     /// Manually specify the background self-update interval

--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -111,7 +111,7 @@ fn is_juliaup_installed() -> bool {
 
     match exit_status {
         Ok(status) => status.success(),
-        Err(_) => false  // failed to execute `juliaup` command
+        Err(_) => false, // failed to execute `juliaup` command
     }
 }
 

--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -107,9 +107,9 @@ fn is_juliaup_installed() -> bool {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .stdin(Stdio::null())
-        .status();
-
-    exit_status.is_ok()
+        .status()
+        .expect("failed to execute juliaup command");
+    exit_status.success()
 }
 
 #[derive(Parser)]
@@ -129,7 +129,7 @@ struct Juliainstaller {
     #[clap(short = 'p', long = "path")]
     alternate_path: Option<String>,
     /// Control adding the Juliaup dir to the PATH
-    /// Use Option<bool> and default_value="yes" to force --add_to_path=[yes|no|0|1] instead of flag
+    /// Use Option<bool> and default_value="yes" to force --add-to-path=[yes|no|0|1] instead of flag
     #[clap(long = "add-to-path", value_parser = BoolishValueParser::new(), default_value = "yes")]
     add_to_path: Option<bool>,
     /// Manually specify the background self-update interval
@@ -286,7 +286,8 @@ pub fn main() -> Result<()> {
 
     if paths.juliaupconfig.exists() {
         println!("While Juliaup does not seem to be installed on this system, there is a");
-        println!("Juliaup configuration file present from a previous installation.");
+        println!("Juliaup configuration file present from a previous installation:");
+        println!("{}", paths.juliaupconfig.display());
 
         if args.disable_confirmation_prompt {
             println!();

--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -107,9 +107,12 @@ fn is_juliaup_installed() -> bool {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .stdin(Stdio::null())
-        .status()
-        .expect("failed to execute juliaup command");
-    exit_status.success()
+        .status();
+
+    match exit_status {
+        Ok(status) => status.success(),
+        Err(_) => false  // failed to execute `juliaup` command
+    }
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
This PR:

- fixes https://github.com/JuliaLang/juliaup/issues/879;
- prints the Juliaup configuration file, if existing;
- ~~changes the `--add_to_path` description (`juliainstaller --help`) to match the command line argument `--add-to-path` (underscore -> dash)~~.