### PR TITLE
README: mention the `alpha` channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Here are some of the things you can do with `juliaup`:
 The available system provided channels are:
 - `release`: always points to the latest stable version.
 - `lts`: always points to the latest long term supported version.
+- `alpha`: always points to the latest alpha version if one exists. If a newer beta or release candidate exists, it will point to that, and if there is no alpha, beta, or rc candidate available it will point to the same version as the `release` channel.
 - `beta`: always points to the latest beta version if one exists. If a newer release candidate exists, it will point to that, and if there is neither a beta or rc candidate available it will point to the same version as the `release` channel.
 - `rc`: same as `beta`, but only starts with release candidate versions.
 - `nightly`: always points to the latest build from the `master` branch in the Julia repository.


### PR DESCRIPTION
Currently, the README mentions the `beta` and `rc` channels, but it does not mention the `alpha` channel.

This PR adds the `alpha` channel to the README.