### PR TITLE
feat(juliaup): Improve error message for juliaup self channel

### DIFF
--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use clap::builder::BoolishValueParser;
 use clap::Parser;
+use juliaup::cli::JuliaupChannel;
 
 #[cfg(feature = "selfupdate")]
 fn run_individual_config_wizard(
@@ -120,8 +121,8 @@ struct Juliainstaller {
     #[clap(long, default_value = "release")]
     default_channel: String,
     /// Juliaup channel
-    #[clap(long, default_value = "release")]
-    juliaup_channel: String,
+    #[clap(long, value_enum, default_value = "release")]
+    juliaup_channel: JuliaupChannel,
     /// Disable confirmation prompt
     #[clap(short = 'y', long = "yes")]
     disable_confirmation_prompt: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 #[derive(Parser)]
 #[clap(name = "Juliaup", version)]
@@ -73,6 +73,24 @@ pub enum OverrideSubCmd {
     },
 }
 
+#[derive(Debug, ValueEnum, Clone)]
+#[clap(rename_all = "lowercase")]
+pub enum JuliaupChannel {
+    Release,
+    ReleasePreview,
+    Dev,
+}
+
+impl JuliaupChannel {
+    pub fn to_lowercase(&self) -> &str {
+        match self {
+            JuliaupChannel::Release => "release",
+            JuliaupChannel::ReleasePreview => "releasepreview",
+            JuliaupChannel::Dev => "dev",
+        }
+    }
+}
+
 #[derive(Parser)]
 /// Manage this juliaup installation
 pub enum SelfSubCmd {
@@ -86,8 +104,8 @@ pub enum SelfSubCmd {
     #[command(arg_required_else_help = true)]
     /// Configure the channel to use for juliaup updates.
     Channel {
-        #[arg(value_parser=["release", "releasepreview", "dev"])]
-        channel: String,
+        #[arg(value_enum)]
+        channel: JuliaupChannel,
     },
     #[cfg(feature = "selfupdate")]
     /// Uninstall this version of juliaup from the system

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,8 +83,12 @@ pub enum SelfSubCmd {
     /// Update the Julia versions database and juliaup itself
     Update {},
     #[cfg(feature = "selfupdate")]
-    /// Configure the channel to use for juliaup updates
-    Channel { channel: String },
+    #[command(arg_required_else_help = true)]
+    /// Configure the channel to use for juliaup updates.
+    Channel {
+        #[arg(value_parser=["release", "releasepreview", "dev"])]
+        channel: String,
+    },
     #[cfg(feature = "selfupdate")]
     /// Uninstall this version of juliaup from the system
     Uninstall {},

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,10 +74,12 @@ pub enum OverrideSubCmd {
 }
 
 #[derive(Debug, ValueEnum, Clone)]
-#[clap(rename_all = "lowercase")]
 pub enum JuliaupChannel {
+    #[clap(name = "release")]
     Release,
+    #[clap(name = "releasepreview")]
     ReleasePreview,
+    #[clap(name = "dev")]
     Dev,
 }
 

--- a/src/command_selfchannel.rs
+++ b/src/command_selfchannel.rs
@@ -3,20 +3,16 @@ use anyhow::Result;
 
 #[cfg(feature = "selfupdate")]
 pub fn run_command_selfchannel(
-    channel: String,
+    channel: crate::cli::JuliaupChannel,
     paths: &crate::global_paths::GlobalPaths,
 ) -> Result<()> {
     use crate::config_file::{load_mut_config_db, save_config_db};
-    use anyhow::{bail, Context};
+    use anyhow::Context;
 
     let mut config_file = load_mut_config_db(paths)
         .with_context(|| "`self update` command failed to load configuration data.")?;
 
-    if channel != "dev" && channel != "releasepreview" && channel != "release" {
-        bail!("'{}' is not a valid juliaup channel, you can only specify 'release', 'releasepreview' or 'dev'.", channel);
-    }
-
-    config_file.self_data.juliaup_channel = Some(channel.clone());
+    config_file.self_data.juliaup_channel = Some(channel.to_lowercase().to_string());
 
     save_config_db(&mut config_file)
         .with_context(|| "`selfchannel` command failed to save configuration db.")?;


### PR DESCRIPTION
fixes #819 

```bash
$ juliaup self channel
Configure the channel to use for juliaup updates

Usage: juliaup self channel <CHANNEL>

Arguments:
  <CHANNEL>  [possible values: release, releasepreview, dev]

Options:
  -h, --help  Print help
```


```bash
$ juliaup self channel nightly
error: invalid value 'nightly' for '<CHANNEL>'
  [possible values: release, releasepreview, dev]

For more information, try '--help'.
```