### PR TITLE
canonicalize the current_exe result when self updating, so that it works with symlinking.

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use juliaup::config_file::{load_config_db, JuliaupConfig, JuliaupConfigChannel};
 use juliaup::global_paths::get_paths;
 use juliaup::jsonstructs_versionsdb::JuliaupVersionDB;
+use juliaup::utils::get_juliaup_path;
 use juliaup::versions_file::load_versions_db;
 #[cfg(not(windows))]
 use nix::{
@@ -20,20 +21,6 @@ use std::path::PathBuf;
 #[error("{msg}")]
 pub struct UserError {
     msg: String,
-}
-
-fn get_juliaup_path() -> Result<PathBuf> {
-    let my_own_path = std::env::current_exe()
-        .with_context(|| "std::env::current_exe() did not find its own path.")?
-        .canonicalize()
-        .with_context(|| "Failed to canonicalize the path to the Julia launcher.")?;
-
-    let juliaup_path = my_own_path
-        .parent()
-        .unwrap() // unwrap OK here because this can't happen
-        .join(format!("juliaup{}", std::env::consts::EXE_SUFFIX));
-
-    Ok(juliaup_path)
 }
 
 fn do_initial_setup(juliaupconfig_path: &Path) -> Result<()> {

--- a/src/command_selfupdate.rs
+++ b/src/command_selfupdate.rs
@@ -71,19 +71,12 @@ pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
                 )
             })?;
 
-        let my_own_path = std::env::current_exe()
-            .with_context(|| "Could not determine the path of the running exe.")?;
-
-        let my_own_folder = my_own_path
-            .parent()
-            .ok_or_else(|| anyhow!("Could not determine parent."))?;
-
         eprintln!(
             "Found new version {} on channel {}.",
             version, juliaup_channel
         );
 
-        download_extract_sans_parent(&new_juliaup_url.to_string(), &my_own_folder, 0)?;
+        download_extract_sans_parent(&new_juliaup_url.to_string(), &paths.juliaupselfbin, 0)?;
         eprintln!("Updated Juliaup to version {}.", version);
     }
 

--- a/src/command_selfupdate.rs
+++ b/src/command_selfupdate.rs
@@ -8,7 +8,7 @@ pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
     use crate::operations::{download_extract_sans_parent, download_juliaup_version};
     use crate::utils::get_juliaserver_base_url;
     use crate::{get_juliaup_target, get_own_version};
-    use anyhow::{anyhow, bail};
+    use anyhow::bail;
 
     update_version_db(paths).with_context(|| "Failed to update versions db.")?;
 

--- a/src/global_paths.rs
+++ b/src/global_paths.rs
@@ -1,6 +1,8 @@
 use crate::get_juliaup_target;
 #[cfg(feature = "selfupdate")]
 use anyhow::Context;
+#[cfg(feature = "selfupdate")]
+use crate::utils::get_juliaup_path;
 use anyhow::{anyhow, bail, Result};
 use std::path::PathBuf;
 pub struct GlobalPaths {
@@ -57,9 +59,7 @@ pub fn get_paths() -> Result<GlobalPaths> {
     let juliauphome = get_juliaup_home_path()?;
 
     #[cfg(feature = "selfupdate")]
-    let my_own_path = std::env::current_exe()
-        .with_context(|| "Could not determine the path of the running exe.")?
-        .canonicalize()?;
+    let my_own_path = get_juliaup_path()?;
 
     #[cfg(feature = "selfupdate")]
     let juliaupselfbin = my_own_path

--- a/src/global_paths.rs
+++ b/src/global_paths.rs
@@ -1,7 +1,5 @@
 use crate::get_juliaup_target;
 #[cfg(feature = "selfupdate")]
-use anyhow::Context;
-#[cfg(feature = "selfupdate")]
 use crate::utils::get_juliaup_path;
 use anyhow::{anyhow, bail, Result};
 use std::path::PathBuf;

--- a/src/global_paths.rs
+++ b/src/global_paths.rs
@@ -58,7 +58,8 @@ pub fn get_paths() -> Result<GlobalPaths> {
 
     #[cfg(feature = "selfupdate")]
     let my_own_path = std::env::current_exe()
-        .with_context(|| "Could not determine the path of the running exe.")?;
+        .with_context(|| "Could not determine the path of the running exe.")?
+        .canonicalize()?;
 
     #[cfg(feature = "selfupdate")]
     let juliaupselfbin = my_own_path

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -11,6 +11,7 @@ use crate::jsonstructs_versionsdb::JuliaupVersionDB;
 use crate::utils::get_bin_dir;
 use crate::utils::get_julianightlies_base_url;
 use crate::utils::get_juliaserver_base_url;
+use crate::utils::get_juliaup_path;
 use anyhow::{anyhow, bail, Context, Result};
 use bstr::ByteSlice;
 use bstr::ByteVec;
@@ -292,7 +293,7 @@ pub fn install_version(
     // TODO At some point we could put this behind a conditional compile, we know
     // that we don't ship a bundled version for some platforms.
     let full_version_string_of_bundled_version = get_bundled_julia_version();
-    let my_own_path = std::env::current_exe()?;
+    let my_own_path = get_juliaup_path()?;
     let path_of_bundled_version = my_own_path
         .parent()
         .unwrap() // unwrap OK because we can't get a path that does not have a parent
@@ -711,8 +712,7 @@ pub fn install_background_selfupdate(interval: i64) -> Result<()> {
     use itertools::Itertools;
     use std::process::Stdio;
 
-    let own_exe_path = std::env::current_exe()
-        .with_context(|| "Could not determine the path of the running exe.")?;
+    let own_exe_path = get_juliaup_path()?;
 
     let my_own_path = own_exe_path.to_str().unwrap();
 


### PR DESCRIPTION
Fixes #885,

It centralises the resolution of the self path into a single function. Consolidated all the locations which queried the self path to call that function for better maintainability and consistency.

this change could also help towards #844, giving better support to symlinks and therefore custom locations
