### PR TITLE
Fix logging variable in the `override` command

### DIFF
--- a/src/command_override.rs
+++ b/src/command_override.rs
@@ -81,7 +81,10 @@ pub fn run_command_override_set(
         .iter()
         .any(|i| i.path == path.to_string_lossy())
     {
-        bail!("'{}' path already has an override configured.", path.to_string_lossy());
+        bail!(
+            "'{}' path already has an override configured.",
+            path.to_string_lossy()
+        );
     }
 
     config_file.data.overrides.push(JuliaupOverride {

--- a/src/command_override.rs
+++ b/src/command_override.rs
@@ -81,7 +81,7 @@ pub fn run_command_override_set(
         .iter()
         .any(|i| i.path == path.to_string_lossy())
     {
-        bail!("'{}' path already has an override configured.", &channel);
+        bail!("'{}' path already has an override configured.", path.to_string_lossy());
     }
 
     config_file.data.overrides.push(JuliaupOverride {


### PR DESCRIPTION
When executing `juliaup override set CHANNEL PATH` in an existing path, previous version of juliaup displayed ambiguous information. This PR attempts to fix the issue.