### PR TITLE
Centralize where paths are discovered

### DIFF
--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -379,9 +379,9 @@ pub fn main() -> Result<()> {
         }
     }
 
-    let juliaupselfbin = install_choices.install_location.join("bin");
+    let juliaupselfexecfolder = install_choices.install_location.join("bin");
 
-    trace!("Set juliaupselfbin to `{:?}`", juliaupselfbin);
+    trace!("Set juliaupselfexecfolder to `{:?}`", juliaupselfexecfolder);
 
     println!("Now installing Juliaup");
 
@@ -389,7 +389,7 @@ pub fn main() -> Result<()> {
         std::fs::remove_file(&paths.juliaupconfig).unwrap();
     }
 
-    std::fs::create_dir_all(&juliaupselfbin)
+    std::fs::create_dir_all(&juliaupselfexecfolder)
         .with_context(|| "Failed to create install folder for Juliaup.")?;
 
     let juliaup_target = get_juliaup_target();
@@ -411,7 +411,7 @@ pub fn main() -> Result<()> {
             )
         })?;
 
-    download_extract_sans_parent(&new_juliaup_url.to_string(), &juliaupselfbin, 0)?;
+    download_extract_sans_parent(&new_juliaup_url.to_string(), &juliaupselfexecfolder, 0)?;
 
     {
         let new_selfconfig_data = JuliaupSelfConfig {
@@ -445,7 +445,7 @@ pub fn main() -> Result<()> {
             .sync_all()
             .with_context(|| "Failed to write config data to disc.")?;
 
-        paths.juliaupselfbin = juliaupselfbin.clone();
+        paths.juliaupselfexecfolder = juliaupselfexecfolder.clone();
         paths.juliaupselfconfig = self_config_path.clone();
     }
 
@@ -467,9 +467,9 @@ pub fn main() -> Result<()> {
     run_command_default(&args.default_channel, &paths)
         .with_context(|| "Failed to run `run_command_default`.")?;
 
-    let symlink_path = juliaupselfbin.join("julia");
+    let symlink_path = juliaupselfexecfolder.join("julia");
 
-    std::os::unix::fs::symlink(juliaupselfbin.join("julialauncher"), &symlink_path).with_context(
+    std::os::unix::fs::symlink(juliaupselfexecfolder.join("julialauncher"), &symlink_path).with_context(
         || {
             format!(
                 "failed to create symlink `{}`.",

--- a/src/command_config_modifypath.rs
+++ b/src/command_config_modifypath.rs
@@ -24,7 +24,7 @@ pub fn run_command_config_modifypath(
             }
 
             if value {
-                add_binfolder_to_path_in_shell_scripts(&paths.juliaupselfbin)?;
+                add_binfolder_to_path_in_shell_scripts(&paths.juliaupselfexecfolder)?;
             } else {
                 remove_binfolder_from_path_in_shell_scripts()?;
             }

--- a/src/command_selfupdate.rs
+++ b/src/command_selfupdate.rs
@@ -71,19 +71,12 @@ pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
                 )
             })?;
 
-        let my_own_path = std::env::current_exe()
-            .with_context(|| "Could not determine the path of the running exe.")?;
-
-        let my_own_folder = my_own_path
-            .parent()
-            .ok_or_else(|| anyhow!("Could not determine parent."))?;
-
         eprintln!(
             "Found new version {} on channel {}.",
             version, juliaup_channel
         );
 
-        download_extract_sans_parent(&new_juliaup_url.to_string(), &my_own_folder, 0)?;
+        download_extract_sans_parent(&new_juliaup_url.to_string(), &path.juliaupselfexecfolder, 0)?;
         eprintln!("Updated Juliaup to version {}.", version);
     }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -292,10 +292,8 @@ pub fn install_version(
     // TODO At some point we could put this behind a conditional compile, we know
     // that we don't ship a bundled version for some platforms.
     let full_version_string_of_bundled_version = get_bundled_julia_version();
-    let my_own_path = std::env::current_exe()?;
-    let path_of_bundled_version = my_own_path
-        .parent()
-        .unwrap() // unwrap OK because we can't get a path that does not have a parent
+    let path_of_bundled_version = &paths
+        .juliaupselfexecfolder
         .join("BundledJulia");
 
     let child_target_foldername = format!("julia-{}", fullversion);
@@ -575,8 +573,8 @@ fn _remove_symlink(symlink_path: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn remove_symlink(symlink_name: &String) -> Result<()> {
-    let symlink_path = get_bin_dir()
+pub fn remove_symlink(symlink_name: &String, paths: &GlobalPaths) -> Result<()> {
+    let symlink_path = get_bin_dir(paths)
         .with_context(|| "Failed to retrieve binary directory while trying to remove a symlink.")?
         .join(symlink_name);
 
@@ -707,14 +705,9 @@ pub fn create_symlink(_: &JuliaupConfigChannel, _: &String, _paths: &GlobalPaths
 }
 
 #[cfg(feature = "selfupdate")]
-pub fn install_background_selfupdate(interval: i64) -> Result<()> {
+pub fn install_background_selfupdate(interval: i64, paths: &GlobalPaths) -> Result<()> {
     use itertools::Itertools;
     use std::process::Stdio;
-
-    let own_exe_path = std::env::current_exe()
-        .with_context(|| "Could not determine the path of the running exe.")?;
-
-    let my_own_path = own_exe_path.to_str().unwrap();
 
     match std::env::var("WSL_DISTRO_NAME") {
         // This is the WSL case, where we schedule a Windows task to do the update
@@ -731,7 +724,7 @@ pub fn install_background_selfupdate(interval: i64) -> Result<()> {
                     "/f",
                     "/it",
                     "/tr",
-                    &format!("wsl --distribution {} {} self update", val, my_own_path),
+                    &format!("wsl --distribution {} {} self update", val, &paths.juliaupselfexec),
                 ])
                 .output()
                 .with_context(|| "Failed to create new Windows task for juliaup.")?;
@@ -748,7 +741,7 @@ pub fn install_background_selfupdate(interval: i64) -> Result<()> {
                 .chain([
                     &format!(
                         "*/{} * * * * {} 4c79c12db1d34bbbab1f6c6f838f423f",
-                        interval, my_own_path
+                        interval, &paths.juliaupselfexec
                     ),
                     "",
                 ])

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,9 @@
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use semver::{BuildMetadata, Version};
 use std::path::PathBuf;
 use url::Url;
+
+use crate::global_paths::GlobalPaths;
 
 pub fn get_juliaserver_base_url() -> Result<Url> {
     let base_url = if let Ok(val) = std::env::var("JULIAUP_SERVER") {
@@ -45,7 +47,7 @@ pub fn get_julianightlies_base_url() -> Result<Url> {
     Ok(parsed_url)
 }
 
-pub fn get_bin_dir() -> Result<PathBuf> {
+pub fn get_bin_dir(paths: &GlobalPaths) -> Result<PathBuf> {
     let entry_sep = if std::env::consts::OS == "windows" {
         ';'
     } else {
@@ -63,11 +65,7 @@ pub fn get_bin_dir() -> Result<PathBuf> {
             path
         }
         Err(_) => {
-            let mut path = std::env::current_exe()
-                .with_context(|| "Could not determine the path of the running exe.")?
-                .parent()
-                .ok_or_else(|| anyhow!("Could not determine parent."))?
-                .to_path_buf();
+            let mut path = paths.juliaupselfexecfolder.clone();
 
             if let Some(home_dir) = dirs::home_dir() {
                 if !path.starts_with(&home_dir) {


### PR DESCRIPTION
Alternative to #886.

@ghyatzo I started to look into it, and then got carried away ;) I _think_ this should be correct, but I'm also a bit nervous as any error in any of this would really be bad... If you could take a careful look if this all looks right to you that would be amazing.

The general idea now is that `juliaupselfexecfolder` is the folder where the `juliaup` binary is located and `juliaupselfexec` is the path to the `juliaup` binary itself. And all paths should be canonical.

There is one thing I don't fully understand, I'll leave a comment at that location.