### PR TITLE
Include FreeBSD when generating versiondb

### DIFF
--- a/scripts/versiondb/updateversiondb.jl
+++ b/scripts/versiondb/updateversiondb.jl
@@ -29,6 +29,8 @@ function triplet2channel(triplet)
         "x86"
     elseif triplet=="aarch64-linux-gnu"
         "aarch64"
+    elseif triplet=="x86_64-unknown-freebsd11.1"
+        "x64"
     else
         error("Unknown platform.")
     end
@@ -64,6 +66,8 @@ function get_available_versions(data, platform)
         ["i686-linux-gnu"]
     elseif platform=="aarch64-unknown-linux-musl"
         ["aarch64-linux-gnu"]
+    elseif platform=="x86_64-unknown-freebsd"
+        ["x86_64-unknown-freebsd11.1"]
     else
         error("Unknown platform.")
     end
@@ -283,6 +287,7 @@ function main_impl(temp_path)
         "aarch64-unknown-linux-gnu",
         "aarch64-unknown-linux-musl",
         "aarch64-apple-darwin",
+        "x86_64-unknown-freebsd",
     ]
 
     new_version_dbs = platforms |>


### PR DESCRIPTION
This splits out the versiondb part of #872. This ensures that any updates to versiondb that happen while #872 is in development don't require re-syncing, and it will mean that tests will pass locally. (Though the test that failed locally that was related to this mysteriously passed on CI in #872.)

For some reason, versions.json lists the FreeBSD triplet with the suffix 11.1, which does not reflect the version of FreeBSD used for building and has not been supported for a long time, by us or upstream. In fact, the current FreeBSD binaries won't work on anything before 13.2. But in order to use versions.json without some special-casing and/or refactoring, we can just retain the weird suffix.