### PR TITLE
Add workaround as error hint to tmp-not-executable branch

### DIFF
--- a/deploy/shellscript/juliaup-init.sh
+++ b/deploy/shellscript/juliaup-init.sh
@@ -136,7 +136,10 @@ main() {
     if [ ! -x "$_file" ]; then
         printf '%s\n' "Cannot execute $_file." 1>&2
 
-        printf '%s\n' "Please install the files to a location where you can execute binaries." 1>&2
+        printf '%s\n' "Please use a tmp location where you can execute binaries." 1>&2
+        printf '%s\n' "Hint: you can change the tmp location with" 1>&2
+        printf '%s\n' "`mkdir -p ~/tmp && curl -fsSL https://install.julialang.org | TMPDIR=~/tmp sh`" 1>&2
+        # Workaround adapted from  https://github.com/JuliaLang/juliaup/issues/450#issuecomment-1325439708
         exit 1
     fi
 

--- a/deploy/shellscript/juliaup-init.sh
+++ b/deploy/shellscript/juliaup-init.sh
@@ -138,7 +138,7 @@ main() {
 
         printf '%s\n' "Please use a tmp location where you can execute binaries." 1>&2
         printf '%s\n' "Hint: you can change the tmp location with" 1>&2
-        printf '%s\n' "`mkdir -p ~/tmp && curl -fsSL https://install.julialang.org | TMPDIR=~/tmp sh`" 1>&2
+        printf '%s\n' "    mkdir -p ~/tmp && curl -fsSL https://install.julialang.org | TMPDIR=~/tmp sh" 1>&2
         # Workaround adapted from  https://github.com/JuliaLang/juliaup/issues/450#issuecomment-1325439708
         exit 1
     fi


### PR DESCRIPTION
I changed "Install the files to a location..." to "Use a tmp location..." because "the files" being installed are, according to the user, julia and maybe juliaup.

I used a hint instead of a fallback because the hint is less magical and almost as helpful. And because it's easier to implement. I'd be open to this being an automatic fallback when `tmp` is not executable, but then we'd need to handle cleanup logic as well.

If this PR merges I might make a followup to hint for https://github.com/JuliaLang/juliaup/issues/673, but tbh that feels like a system bug: curl should be able to write to the default tmpdir.

Fixes https://github.com/JuliaLang/juliaup/issues/450
Fixes https://github.com/JuliaLang/juliaup/issues/942