### PR TITLE
Make completions subcommand more user-friendly

### DIFF
--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -110,6 +110,6 @@ fn main() -> Result<()> {
             #[cfg(not(feature = "selfupdate"))]
             SelfSubCmd::Uninstall {} => run_command_selfuninstall_unavailable(),
         },
-        Juliaup::Completions { shell } => run_command_completions(&shell),
+        Juliaup::Completions { shell } => run_command_completions(shell),
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,7 +48,7 @@ pub enum Juliaup {
     #[clap(subcommand, name = "self")]
     SelfSubCmd(SelfSubCmd),
     /// Generate tab-completion scripts for your shell
-    Completions { shell: String },
+    Completions { shell: clap_complete::Shell },
     // This is used for the cron jobs that we create. By using this UUID for the command
     // We can identify the cron jobs that were created by juliaup for uninstall purposes
     #[cfg(feature = "selfupdate")]

--- a/src/command_completions.rs
+++ b/src/command_completions.rs
@@ -1,22 +1,16 @@
 use crate::cli;
-use anyhow::bail;
 use anyhow::Result;
 use clap::CommandFactory;
 use clap_complete::Shell;
 use cli::Juliaup;
 use std::io;
-use std::str::FromStr;
 
-pub fn run_command_completions(shell: &str) -> Result<()> {
-    if let Ok(shell) = Shell::from_str(shell) {
-        clap_complete::generate(
-            shell,
-            &mut Juliaup::command(),
-            "juliaup",
-            &mut io::stdout().lock(),
-        );
-    } else {
-        bail!("'{}' is not a supported shell.", shell)
-    }
+pub fn run_command_completions(shell: Shell) -> Result<()> {
+    clap_complete::generate(
+        shell,
+        &mut Juliaup::command(),
+        "juliaup",
+        &mut io::stdout().lock(),
+    );
     Ok(())
 }


### PR DESCRIPTION
This small change makes the completions subcommand slightly more user-friendly by using strongly typed `Shell` for the completions subcommand argument.


## completions with invalid shell
```console
$ juliaup completions fishy  # before
Error: 'fishy' is not a supported shell.

$ ./target/release/juliaup completions fishy  # after
error: invalid value 'fishy' for '<SHELL>'
  [possible values: bash, elvish, fish, powershell, zsh]

  tip: a similar value exists: 'fish'

For more information, try '--help'.
```

## completions --help:
```console
$ juliaup completions --help  # before
Generate tab-completion scripts for your shell

Usage: juliaup completions <SHELL>

Arguments:
  <SHELL>  

Options:
  -h, --help  Print help

$ ./target/release/juliaup completions --help  # after
Generate tab-completion scripts for your shell

Usage: juliaup completions <SHELL>

Arguments:
  <SHELL>  [possible values: bash, elvish, fish, powershell, zsh]

Options:
  -h, --help  Print help
```