### PR TITLE
Ensure Julia terminates when launcher terminates on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ human-sort = "0.2.2"
 regex = "1.10.5"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58.0", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_System_Console", "Services_Store", "Foundation", "Foundation_Collections", "Web_Http", "Web_Http_Headers", "Storage_Streams", "Management_Deployment"] }
+windows = { version = "0.58.0", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Console", "Win32_System_Threading", "Services_Store", "Foundation", "Foundation_Collections", "Web_Http", "Web_Http_Headers", "Storage_Streams", "Management_Deployment"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 reqwest = { version = "0.12.3", default-features = false, features = ["blocking", "native-tls", "socks"] }

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -5,18 +5,18 @@ use juliaup::config_file::{load_config_db, JuliaupConfig, JuliaupConfigChannel};
 use juliaup::global_paths::get_paths;
 use juliaup::jsonstructs_versionsdb::JuliaupVersionDB;
 use juliaup::versions_file::load_versions_db;
-use normpath::PathExt;
-#[cfg(not(windows))]
-use std::os::unix::process::CommandExt;
-use std::path::Path;
-use std::path::PathBuf;
 #[cfg(not(windows))]
 use nix::{
     sys::wait::{waitpid, WaitStatus},
     unistd::{fork, ForkResult},
 };
+use normpath::PathExt;
+#[cfg(not(windows))]
+use std::os::unix::process::CommandExt;
 #[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, RawHandle};
+use std::path::Path;
+use std::path::PathBuf;
 #[cfg(windows)]
 use windows::Win32::System::{
     JobObjects::{AssignProcessToJobObject, SetInformationJobObject},

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -5,16 +5,23 @@ use juliaup::config_file::{load_config_db, JuliaupConfig, JuliaupConfigChannel};
 use juliaup::global_paths::get_paths;
 use juliaup::jsonstructs_versionsdb::JuliaupVersionDB;
 use juliaup::versions_file::load_versions_db;
-#[cfg(not(windows))]
-use nix::{
-    sys::wait::{waitpid, WaitStatus},
-    unistd::{fork, ForkResult},
-};
 use normpath::PathExt;
 #[cfg(not(windows))]
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::path::PathBuf;
+#[cfg(not(windows))]
+use nix::{
+    sys::wait::{waitpid, WaitStatus},
+    unistd::{fork, ForkResult},
+};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, RawHandle};
+#[cfg(windows)]
+use windows::Win32::System::{
+    JobObjects::{AssignProcessToJobObject, SetInformationJobObject},
+    Threading::GetCurrentProcess,
+};
 
 #[derive(thiserror::Error, Debug)]
 #[error("{msg}")]
@@ -430,10 +437,48 @@ fn run_app() -> Result<i32> {
         // process to handle things.
         ctrlc::set_handler(|| ()).with_context(|| "Failed to set the Ctrl-C handler.")?;
 
+        let mut job_attr: windows::Win32::Security::SECURITY_ATTRIBUTES =
+            windows::Win32::Security::SECURITY_ATTRIBUTES::default();
+        let mut job_info: windows::Win32::System::JobObjects::JOBOBJECT_EXTENDED_LIMIT_INFORMATION =
+            windows::Win32::System::JobObjects::JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+
+        job_attr.bInheritHandle = false.into();
+        job_info.BasicLimitInformation.LimitFlags =
+            windows::Win32::System::JobObjects::JOB_OBJECT_LIMIT_BREAKAWAY_OK
+                | windows::Win32::System::JobObjects::JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK
+                | windows::Win32::System::JobObjects::JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
+                | windows::Win32::System::JobObjects::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        let job_handle = unsafe {
+            windows::Win32::System::JobObjects::CreateJobObjectW(
+                Some(&job_attr),
+                windows::core::PCWSTR::null(),
+            )
+        }?;
+        unsafe {
+            SetInformationJobObject(
+                job_handle,
+                windows::Win32::System::JobObjects::JobObjectExtendedLimitInformation,
+                &job_info as *const _ as *const std::os::raw::c_void,
+                std::mem::size_of_val(&job_info) as u32,
+            )
+        }?;
+
+        unsafe { AssignProcessToJobObject(job_handle, GetCurrentProcess()) }?;
+
         let mut child_process = std::process::Command::new(julia_path)
             .args(&new_args)
             .spawn()
             .with_context(|| "The Julia launcher failed to start Julia.")?; // TODO Maybe include the command we actually tried to start?
+
+        unsafe {
+            AssignProcessToJobObject(
+                job_handle,
+                std::mem::transmute::<RawHandle, windows::Win32::Foundation::HANDLE>(
+                    child_process.as_raw_handle(),
+                ),
+            )
+        }?;
 
         run_versiondb_update(&config_file).with_context(|| "Failed to run version db update")?;
 

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -471,14 +471,16 @@ fn run_app() -> Result<i32> {
             .spawn()
             .with_context(|| "The Julia launcher failed to start Julia.")?; // TODO Maybe include the command we actually tried to start?
 
-        unsafe {
+        // We ignore any error here, as that is what libuv also does, see the documentation
+        // at https://github.com/libuv/libuv/blob/5ff1fc724f7f53d921599dbe18e6f96b298233f1/src/win/process.c#L1077
+        let _ = unsafe {
             AssignProcessToJobObject(
                 job_handle,
                 std::mem::transmute::<RawHandle, windows::Win32::Foundation::HANDLE>(
                     child_process.as_raw_handle(),
                 ),
             )
-        }?;
+        };
 
         run_versiondb_update(&config_file).with_context(|| "Failed to run version db update")?;
 

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -446,7 +446,6 @@ fn run_app() -> Result<i32> {
         job_info.BasicLimitInformation.LimitFlags =
             windows::Win32::System::JobObjects::JOB_OBJECT_LIMIT_BREAKAWAY_OK
                 | windows::Win32::System::JobObjects::JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK
-                | windows::Win32::System::JobObjects::JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
                 | windows::Win32::System::JobObjects::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
 
         let job_handle = unsafe {


### PR DESCRIPTION
This essentially follows the logic in libuv https://github.com/libuv/libuv/blob/5ff1fc724f7f53d921599dbe18e6f96b298233f1/src/win/process.c#L69.

The idea is that when the launcher process is killed, we want to make sure the actual Julia process also is terminated.