### PR TITLE
Notify user when trying to launch nonexistent linked channel

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use juliaup::config_file::{load_config_db, JuliaupConfig, JuliaupConfigChannel};
 use juliaup::global_paths::get_paths;
 use juliaup::jsonstructs_versionsdb::JuliaupVersionDB;
+use juliaup::utils::is_valid_julia_path;
 use juliaup::versions_file::load_versions_db;
 #[cfg(not(windows))]
 use nix::{
@@ -396,9 +397,16 @@ fn run_app() -> Result<i32> {
             }
 
             // replace the current process
-            std::process::Command::new(julia_path)
-                .args(&new_args)
-                .exec();
+            if is_valid_julia_path(&julia_path) {
+                std::process::Command::new(julia_path)
+                    .args(&new_args)
+                    .exec();
+            } else {
+                panic!(
+                    "Could not launch Julia. Verify that there is a valid Julia binary at \"{}\".",
+                    julia_path.to_string_lossy()
+                );
+            }
 
             // this is never reached
             Ok(0)

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use juliaup::config_file::{load_config_db, JuliaupConfig, JuliaupConfigChannel};
 use juliaup::global_paths::get_paths;
 use juliaup::jsonstructs_versionsdb::JuliaupVersionDB;
+#[cfg(not(windows))]
 use juliaup::utils::is_valid_julia_path;
 use juliaup::versions_file::load_versions_db;
 #[cfg(not(windows))]

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -5,8 +5,6 @@ use itertools::Itertools;
 use juliaup::config_file::{load_config_db, JuliaupConfig, JuliaupConfigChannel};
 use juliaup::global_paths::get_paths;
 use juliaup::jsonstructs_versionsdb::JuliaupVersionDB;
-#[cfg(not(windows))]
-use juliaup::utils::is_valid_julia_path;
 use juliaup::versions_file::load_versions_db;
 #[cfg(not(windows))]
 use nix::{
@@ -398,19 +396,15 @@ fn run_app() -> Result<i32> {
             }
 
             // replace the current process
-            if is_valid_julia_path(&julia_path) {
-                std::process::Command::new(julia_path)
-                    .args(&new_args)
-                    .exec();
-            } else {
-                panic!(
-                    "Could not launch Julia. Verify that there is a valid Julia binary at \"{}\".",
-                    julia_path.to_string_lossy()
-                );
-            }
+            std::process::Command::new(&julia_path)
+                .args(&new_args)
+                .exec();
 
-            // this is never reached
-            Ok(0)
+            // this is only ever reached if launching Julia fails
+            panic!(
+                "Could not launch Julia. Verify that there is a valid Julia binary at \"{}\".",
+                julia_path.to_string_lossy()
+            )
         }
         Ok(ForkResult::Child) => {
             // double-fork to prevent zombies

--- a/src/command_link.rs
+++ b/src/command_link.rs
@@ -3,6 +3,7 @@ use crate::config_file::{load_mut_config_db, save_config_db};
 use crate::global_paths::GlobalPaths;
 #[cfg(not(windows))]
 use crate::operations::create_symlink;
+use crate::utils::is_valid_julia_path;
 use crate::versions_file::load_versions_db;
 use anyhow::{bail, Context, Result};
 use path_absolutize::Absolutize;
@@ -31,6 +32,10 @@ pub fn run_command_link(
     let absolute_file_path = Path::new(file)
         .absolutize()
         .with_context(|| format!("Failed to convert path `{}` to absolute path.", file))?;
+
+    if !is_valid_julia_path(&absolute_file_path.to_path_buf()) {
+        eprintln!("WARNING: There is no julia binary at {}. If this was a mistake, run `juliaup remove {}` and try again.", absolute_file_path.to_string_lossy(), channel);
+    }
 
     config_file.data.installed_channels.insert(
         channel.to_string(),


### PR DESCRIPTION
Only warn when adding nonexistent julia install, as I find it useful to be able to add the link before I have the julia binary.

Fixes #979