### PR TITLE
Use reviewdog to suggest rustfmt diff

### DIFF
--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -25,8 +25,12 @@ jobs:
         with:
           components: rustfmt
       - name: Rustfmt check
-        run: cargo fmt -- -v ${{ github.event_name == 'pull_request' && '' || '--check' }}
-      - name: Suggest changes
+        if: ${{ github.event_name != 'pull_request' }}
+        run: cargo fmt -- --check -v
+      - name: Rustfmt PR
+        if: ${{ github.event_name == 'pull_request' }}
+        run: cargo fmt -- -v
+      - name: Suggest format changes
         if: ${{ github.event_name == 'pull_request' }}
         uses: reviewdog/action-suggester@v1
         with:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+# https://github.com/reviewdog/action-suggester?tab=readme-ov-file#required-permissions
+permissions:
+  contents: read
+  checks: write
+  issues: write
+  pull-requests: write
+
 jobs:
   rustfmt:
     name: Rustfmt Check
@@ -18,4 +25,10 @@ jobs:
         with:
           components: rustfmt
       - name: Rustfmt check
-        run: cargo fmt -- --check -v
+        run: cargo fmt -- -v ${{ github.event_name == 'pull_request' && '' || '--check' }}
+      - name: Suggest changes
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: rustfmt
+          fail_on_error: true


### PR DESCRIPTION
This adds a step after running `cargo fmt` that uses [reviewdog/action-suggester](https://github.com/reviewdog/action-suggester) to comment on the PR with the diff as a suggestion. I've set it to run only on PRs, and formatting producing a nonempty diff should still fail the build either way.

Using this requires the preceding step that creates the diff to not fail, otherwise the step is skipped entirely. The way I've gone about that is to only pass the `--check` flag to `cargo fmt` if it's not running on a PR. I _think_ that should work as intended. Another potential option is to always use `--check` but assign an `id` to the `cargo fmt` step (e.g. `id: fmt`) and use `if: ${{ failure() && steps.fmt.conclusion == 'failure' && github.event_name == 'pull_request' }}` as the condition for the reviewdog step.