### PR TITLE
Use `rustls-tls-native-roots` on FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,10 @@ regex = "1.10"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58.0", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Console", "Win32_System_Threading", "Services_Store", "Foundation", "Foundation_Collections", "Web_Http", "Web_Http_Headers", "Storage_Streams", "Management_Deployment"] }
 
-[target.'cfg(any(target_os = "macos",target_os = "freebsd"))'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "native-tls", "socks"] }
 
-[target.'cfg(all(not(target_os = "macos"),not(target_os = "freebsd"),not(windows)))'.dependencies]
+[target.'cfg(all(not(target_os = "macos"),not(windows)))'.dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls-native-roots", "socks"] }
 
 [target.'cfg(not(windows))'.dependencies]


### PR DESCRIPTION
Currently we're using `native-tls`, but the resulting binary links to and may not be able to find libssl. So instead let's try using `rustls-tls-native-roots`, which we also use on Linux.