### PR TITLE
Update progress bar style to match 1.12 progress bar

### DIFF
--- a/src/operations.rs
+++ b/src/operations.rs
@@ -105,12 +105,12 @@ pub fn download_extract_sans_parent(
         None => ProgressBar::new_spinner(),
     };
 
-    pb.set_prefix("  Downloading:");
+    pb.set_prefix("  Downloading");
     pb.set_style(
         ProgressStyle::default_bar()
-            .template("{prefix:.cyan.bold} [{bar}] {bytes}/{total_bytes} eta: {eta}")
+            .template("{prefix:.cyan.bold}: {bar:.cyan/white} {bytes}/{total_bytes} eta: {eta}")
             .unwrap()
-            .progress_chars("=> "),
+            .progress_chars("━╸━"),
     );
 
     let last_modified = match response
@@ -204,12 +204,12 @@ pub fn download_extract_sans_parent(
         ProgressBar::new_spinner()
     };
 
-    pb.set_prefix("  Downloading:");
+    pb.set_prefix("  Downloading");
     pb.set_style(
         ProgressStyle::default_bar()
-            .template("{prefix:.cyan.bold} [{bar}] {bytes}/{total_bytes} eta: {eta}")
+            .template("{prefix:.cyan.bold}: {bar:.cyan/white} {bytes}/{total_bytes} eta: {eta}")
             .unwrap()
-            .progress_chars("=> "),
+            .progress_chars("━╸━"),
     );
 
     let response_with_pb = pb.wrap_read(DataReaderWrap(reader));


### PR DESCRIPTION
Couldn't get the smoother version without causing some issues with the colour printing.

I moved the ':' out of the prefix as it was too blue for me but I can revert that if people don't like it.