### PR TITLE
Fix locking for version db update

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -314,7 +314,7 @@ fn run_app() -> Result<i32> {
     do_initial_setup(&paths.juliaupconfig)
         .with_context(|| "The Julia launcher failed to run the initial setup steps.")?;
 
-    let config_file = load_config_db(&paths)
+    let config_file = load_config_db(&paths, None)
         .with_context(|| "The Julia launcher failed to load a configuration file.")?;
 
     let versiondb_data = load_versions_db(&paths)

--- a/src/command_api.rs
+++ b/src/command_api.rs
@@ -39,7 +39,7 @@ pub fn run_command_api(command: &str, paths: &GlobalPaths) -> Result<()> {
         other_versions: Vec::new(),
     };
 
-    let config_file = load_config_db(paths).with_context(|| {
+    let config_file = load_config_db(paths, None).with_context(|| {
         "Failed to load configuration file while running the getconfig1 API command."
     })?;
 

--- a/src/command_config_backgroundselfupdate.rs
+++ b/src/command_config_backgroundselfupdate.rs
@@ -63,7 +63,7 @@ pub fn run_command_config_backgroundselfupdate(
             }
         }
         None => {
-            let config_file = load_config_db(paths)
+            let config_file = load_config_db(paths, None)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {

--- a/src/command_config_modifypath.rs
+++ b/src/command_config_modifypath.rs
@@ -41,7 +41,7 @@ pub fn run_command_config_modifypath(
             }
         }
         None => {
-            let config_file = load_config_db(paths)
+            let config_file = load_config_db(paths, None)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {

--- a/src/command_config_startupselfupdate.rs
+++ b/src/command_config_startupselfupdate.rs
@@ -53,7 +53,7 @@ pub fn run_command_config_startupselfupdate(
             }
         }
         None => {
-            let config_file = load_config_db(paths)
+            let config_file = load_config_db(paths, None)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {

--- a/src/command_config_symlinks.rs
+++ b/src/command_config_symlinks.rs
@@ -43,7 +43,7 @@ pub fn run_command_config_symlinks(
             }
         }
         None => {
-            let config_file = load_config_db(paths)
+            let config_file = load_config_db(paths, None)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {

--- a/src/command_config_versionsdbupdate.rs
+++ b/src/command_config_versionsdbupdate.rs
@@ -38,7 +38,7 @@ pub fn run_command_config_versionsdbupdate(
             }
         }
         None => {
-            let config_file = load_config_db(paths)
+            let config_file = load_config_db(paths, None)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {

--- a/src/command_info.rs
+++ b/src/command_info.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Context, Result};
 
 pub fn run_command_info(paths: &GlobalPaths) -> Result<()> {
     #[cfg(feature = "selfupdate")]
-    let config_file = load_config_db(paths).with_context(|| {
+    let config_file = load_config_db(paths, None).with_context(|| {
         "`run_command_update_version_db` command failed to load configuration db."
     })?;
 

--- a/src/command_info.rs
+++ b/src/command_info.rs
@@ -21,7 +21,7 @@ pub fn run_command_info(paths: &GlobalPaths) -> Result<()> {
     };
 
     #[cfg(not(feature = "selfupdate"))]
-    let _config_file = load_config_db(paths).with_context(|| {
+    let _config_file = load_config_db(paths, None).with_context(|| {
         "`run_command_update_version_db` command failed to load configuration db."
     })?;
 

--- a/src/command_override.rs
+++ b/src/command_override.rs
@@ -24,7 +24,7 @@ struct OverrideRow {
 }
 
 pub fn run_command_override_status(paths: &GlobalPaths) -> Result<()> {
-    let config_file = load_config_db(paths)
+    let config_file = load_config_db(paths, None)
         .with_context(|| "`override status` command failed to load configuration file.")?;
 
     let rows_in_table: Vec<_> = config_file

--- a/src/command_status.rs
+++ b/src/command_status.rs
@@ -26,7 +26,7 @@ struct ChannelRow {
 }
 
 pub fn run_command_status(paths: &GlobalPaths) -> Result<()> {
-    let config_file = load_config_db(paths)
+    let config_file = load_config_db(paths, None)
         .with_context(|| "`status` command failed to load configuration file.")?;
 
     let versiondb_data =

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -20,13 +20,13 @@ fn is_default_versionsdb_update_interval(i: &i64) -> bool {
     *i == default_versionsdb_update_interval()
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct JuliaupConfigVersion {
     #[serde(rename = "Path")]
     pub path: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum JuliaupConfigChannel {
     DirectDownloadChannel {
@@ -53,7 +53,7 @@ pub enum JuliaupConfigChannel {
     },
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct JuliaupConfigSettings {
     #[serde(
         rename = "CreateChannelSymlinks",
@@ -78,7 +78,7 @@ impl Default for JuliaupConfigSettings {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct JuliaupOverride {
     #[serde(rename = "Path")]
     pub path: String,
@@ -86,7 +86,7 @@ pub struct JuliaupOverride {
     pub channel: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct JuliaupConfig {
     #[serde(rename = "Default")]
     pub default: Option<String>,
@@ -142,7 +142,7 @@ pub struct JuliaupReadonlyConfigFile {
     pub self_data: JuliaupSelfConfig,
 }
 
-pub fn load_config_db(paths: &GlobalPaths) -> Result<JuliaupReadonlyConfigFile> {
+pub fn get_read_lock(paths: &GlobalPaths) -> Result<FlockLock<File>> {
     std::fs::create_dir_all(&paths.juliauphome)
         .with_context(|| "Could not create juliaup home folder.")?;
 
@@ -156,16 +156,29 @@ pub fn load_config_db(paths: &GlobalPaths) -> Result<JuliaupReadonlyConfigFile> 
         Err(e) => return Err(anyhow!("Could not create lockfile: {}.", e)),
     };
 
-    let file_lock = match SharedFlock::try_lock(&lock_file) {
+    let file_lock = match SharedFlock::try_lock(lock_file) {
         Ok(lock) => lock,
-        Err(_e) => {
+        Err(e) => {
             eprintln!(
                 "Juliaup configuration is locked by another process, waiting for it to unlock."
             );
 
-            SharedFlock::wait_lock(&lock_file).unwrap()
+            SharedFlock::wait_lock(e.into()).unwrap()
         }
     };
+
+    return Ok(file_lock);
+}
+
+pub fn load_config_db(
+    paths: &GlobalPaths,
+    existing_lock: Option<&FlockLock<File>>,
+) -> Result<JuliaupReadonlyConfigFile> {
+    let mut file_lock: Option<FlockLock<File>> = None;
+
+    if existing_lock.is_none() {
+        file_lock = Some(get_read_lock(paths)?);
+    }
 
     let v = match std::fs::OpenOptions::new()
         .read(true)
@@ -229,9 +242,11 @@ pub fn load_config_db(paths: &GlobalPaths) -> Result<JuliaupReadonlyConfigFile> 
         };
     }
 
-    file_lock
-        .unlock()
-        .with_context(|| "Failed to unlock configuration file.")?;
+    if let Some(file_lock) = file_lock {
+        file_lock
+            .unlock()
+            .with_context(|| "Failed to unlock configuration file.")?;
+    }
 
     Ok(JuliaupReadonlyConfigFile {
         data: v,

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1382,7 +1382,7 @@ pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
     }
 
     #[cfg(feature = "selfupdate")]
-    let juliaup_channel = match &config_file.self_data.juliaup_channel {
+    let juliaup_channel = match &old_config_file.self_data.juliaup_channel {
         Some(juliaup_channel) => juliaup_channel.to_string(),
         None => "release".to_string(),
     };

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1347,7 +1347,7 @@ mod tests {
 pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
     let old_last_version_db_update: Option<DateTime<Utc>>;
     let direct_download_etags: Vec<(String, String)>;
-    let temp_versiondb_download_path: Option<TempPath>;
+    let mut temp_versiondb_download_path: Option<TempPath> = None;
     let mut delete_old_version_db: bool = false;
 
     {
@@ -1429,9 +1429,9 @@ pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
                     ))
                     .with_context(|| "Failed to construct URL for version db download.")?;
 
-                let foo = tempfile::NamedTempFile::new_in(&paths.versiondb.parent().unwrap()).unwrap().into_temp_path()
+                let temp_path = tempfile::NamedTempFile::new_in(&paths.versiondb.parent().unwrap()).unwrap().into_temp_path();
 
-                download_versiondb(&onlineversiondburl.to_string(), &foo)
+                download_versiondb(&onlineversiondburl.to_string(), &temp_path)
                     .with_context(|| {
                         format!(
                             "Failed to download new version db from {}.",
@@ -1439,12 +1439,10 @@ pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
                         )
                     })?;
 
-                temp_versiondb_download_path = Some(foo);
+                temp_versiondb_download_path = Some(temp_path);
             }
         } else if local_dbversion.is_some() {
             // If the bundled version is up-to-date we can delete any cached version db json file
-            
-
             delete_old_version_db = true;
         }
     }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1419,7 +1419,7 @@ pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
     let direct_download_etags = download_direct_download_etags(&old_config_file.data)?;
 
     let bundled_dbversion = get_bundled_dbversion()
-        .with_context(|| "Failed to determine the bundled version db version.")?;  
+        .with_context(|| "Failed to determine the bundled version db version.")?;
 
     if online_dbversion > bundled_dbversion {
         if local_dbversion.is_none() || online_dbversion > local_dbversion.unwrap() {
@@ -1460,7 +1460,11 @@ pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
     }
 
     for (channel, etag) in direct_download_etags {
-        let channel_data = new_config_file.data.installed_channels.get(&channel).unwrap();
+        let channel_data = new_config_file
+            .data
+            .installed_channels
+            .get(&channel)
+            .unwrap();
 
         match channel_data {
             JuliaupConfigChannel::DirectDownloadChannel {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,3 +1,4 @@
+use crate::config_file::load_config_db;
 use crate::config_file::load_mut_config_db;
 use crate::config_file::save_config_db;
 use crate::config_file::JuliaupConfig;
@@ -15,12 +16,15 @@ use crate::utils::is_valid_julia_path;
 use anyhow::{anyhow, bail, Context, Result};
 use bstr::ByteSlice;
 use bstr::ByteVec;
+use chrono::DateTime;
+use chrono::Utc;
 use console::style;
 #[cfg(not(target_os = "freebsd"))]
 use flate2::read::GzDecoder;
 use indicatif::{ProgressBar, ProgressStyle};
 use indoc::formatdoc;
 use semver::Version;
+use tempfile::TempPath;
 #[cfg(not(windows))]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(not(target_os = "freebsd"))]
@@ -1341,46 +1345,119 @@ mod tests {
 }
 
 pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
+    let old_last_version_db_update: Option<DateTime<Utc>>;
+    let direct_download_etags: Vec<(String, String)>;
+    let temp_versiondb_download_path: Option<TempPath>;
+    let mut delete_old_version_db: bool = false;
+
+    {
+        let config_file = load_config_db(paths).with_context(|| {
+            "`run_command_update_version_db` command failed to load configuration db."
+        })?;
+
+        old_last_version_db_update = config_file.data.last_version_db_update;
+
+        #[cfg(feature = "selfupdate")]
+        let juliaup_channel = match &config_file.self_data.juliaup_channel {
+            Some(juliaup_channel) => juliaup_channel.to_string(),
+            None => "release".to_string(),
+        };
+
+        // TODO Figure out how we can learn about the correctn Juliaup channel here
+        #[cfg(not(feature = "selfupdate"))]
+        let juliaup_channel = "release".to_string();
+
+        let juliaupserver_base =
+            get_juliaserver_base_url().with_context(|| "Failed to get Juliaup server base URL.")?;
+
+        let dbversion_url_path = match juliaup_channel.as_str() {
+            "release" => "juliaup/RELEASECHANNELDBVERSION",
+            "releasepreview" => "juliaup/RELEASEPREVIEWCHANNELDBVERSION",
+            "dev" => "juliaup/DEVCHANNELDBVERSION",
+            _ => bail!(
+                "Juliaup is configured to a channel named '{}' that does not exist.",
+                &juliaup_channel
+            ),
+        };
+
+        let dbversion_url = juliaupserver_base
+            .join(dbversion_url_path)
+            .with_context(|| {
+                format!(
+                    "Failed to construct a valid url from '{}' and '{}'.",
+                    juliaupserver_base, dbversion_url_path
+                )
+            })?;
+
+        let online_dbversion = download_juliaup_version(&dbversion_url.to_string())
+            .with_context(|| "Failed to download current version db version.")?;
+
+        direct_download_etags = download_direct_download_etags(&config_file.data)?;
+
+        let bundled_dbversion = get_bundled_dbversion()
+            .with_context(|| "Failed to determine the bundled version db version.")?;
+
+        let local_dbversion = match std::fs::OpenOptions::new()
+            .read(true)
+            .open(&paths.versiondb)
+        {
+            Ok(file) => {
+                let reader = BufReader::new(&file);
+
+                if let Ok(versiondb) =
+                    serde_json::from_reader::<BufReader<&std::fs::File>, JuliaupVersionDB>(reader)
+                {
+                    if let Ok(version) = semver::Version::parse(&versiondb.version) {
+                        Some(version)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+            Err(_) => None,
+        };
+
+        if online_dbversion > bundled_dbversion {
+            if local_dbversion.is_none() || online_dbversion > local_dbversion.unwrap() {
+                let onlineversiondburl = juliaupserver_base
+                    .join(&format!(
+                        "juliaup/versiondb/versiondb-{}-{}.json",
+                        online_dbversion,
+                        get_juliaup_target()
+                    ))
+                    .with_context(|| "Failed to construct URL for version db download.")?;
+
+                let foo = tempfile::NamedTempFile::new_in(&paths.versiondb.parent().unwrap()).unwrap().into_temp_path()
+
+                download_versiondb(&onlineversiondburl.to_string(), &foo)
+                    .with_context(|| {
+                        format!(
+                            "Failed to download new version db from {}.",
+                            onlineversiondburl
+                        )
+                    })?;
+
+                temp_versiondb_download_path = Some(foo);
+            }
+        } else if local_dbversion.is_some() {
+            // If the bundled version is up-to-date we can delete any cached version db json file
+            
+
+            delete_old_version_db = true;
+        }
+    }
+
     let mut config_file = load_mut_config_db(paths).with_context(|| {
         "`run_command_update_version_db` command failed to load configuration db."
     })?;
 
-    #[cfg(feature = "selfupdate")]
-    let juliaup_channel = match &config_file.self_data.juliaup_channel {
-        Some(juliaup_channel) => juliaup_channel.to_string(),
-        None => "release".to_string(),
-    };
-
-    // TODO Figure out how we can learn about the correctn Juliaup channel here
-    #[cfg(not(feature = "selfupdate"))]
-    let juliaup_channel = "release".to_string();
-
-    let juliaupserver_base =
-        get_juliaserver_base_url().with_context(|| "Failed to get Juliaup server base URL.")?;
-
-    let dbversion_url_path = match juliaup_channel.as_str() {
-        "release" => "juliaup/RELEASECHANNELDBVERSION",
-        "releasepreview" => "juliaup/RELEASEPREVIEWCHANNELDBVERSION",
-        "dev" => "juliaup/DEVCHANNELDBVERSION",
-        _ => bail!(
-            "Juliaup is configured to a channel named '{}' that does not exist.",
-            &juliaup_channel
-        ),
-    };
-
-    let dbversion_url = juliaupserver_base
-        .join(dbversion_url_path)
-        .with_context(|| {
-            format!(
-                "Failed to construct a valid url from '{}' and '{}'.",
-                juliaupserver_base, dbversion_url_path
-            )
-        })?;
-
-    let online_dbversion = download_juliaup_version(&dbversion_url.to_string())
-        .with_context(|| "Failed to download current version db version.")?;
-
-    let direct_download_etags = download_direct_download_etags(&mut config_file.data)?;
+    // This is our optimistic locking check: if someone changed the last modified
+    // field since we released the read-lock, we just give up
+    if config_file.data.last_version_db_update != old_last_version_db_update {
+        return Ok(());
+    }
 
     for (channel, etag) in direct_download_etags {
         let channel_data = config_file.data.installed_channels.get(&channel).unwrap();
@@ -1410,63 +1487,21 @@ pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
 
     config_file.data.last_version_db_update = Some(chrono::Utc::now());
 
-    save_config_db(&mut config_file).with_context(|| "Failed to save configuration file.")?;
-
-    let bundled_dbversion = get_bundled_dbversion()
-        .with_context(|| "Failed to determine the bundled version db version.")?;
-
-    let local_dbversion = match std::fs::OpenOptions::new()
-        .read(true)
-        .open(&paths.versiondb)
-    {
-        Ok(file) => {
-            let reader = BufReader::new(&file);
-
-            if let Ok(versiondb) =
-                serde_json::from_reader::<BufReader<&std::fs::File>, JuliaupVersionDB>(reader)
-            {
-                if let Ok(version) = semver::Version::parse(&versiondb.version) {
-                    Some(version)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        }
-        Err(_) => None,
-    };
-
-    if online_dbversion > bundled_dbversion {
-        if local_dbversion.is_none() || online_dbversion > local_dbversion.unwrap() {
-            let onlineversiondburl = juliaupserver_base
-                .join(&format!(
-                    "juliaup/versiondb/versiondb-{}-{}.json",
-                    online_dbversion,
-                    get_juliaup_target()
-                ))
-                .with_context(|| "Failed to construct URL for version db download.")?;
-
-            download_versiondb(&onlineversiondburl.to_string(), &paths.versiondb).with_context(
-                || {
-                    format!(
-                        "Failed to download new version db from {}.",
-                        onlineversiondburl
-                    )
-                },
-            )?;
-        }
-    } else if local_dbversion.is_some() {
-        // If the bundled version is up-to-date we can delete any cached version db json file
+    if let Some(foo) = temp_versiondb_download_path {
+        std::fs::rename(&foo, &paths.versiondb)?;
+    }
+    else if delete_old_version_db {
         let _ = std::fs::remove_file(&paths.versiondb);
     }
+
+    save_config_db(&mut config_file).with_context(|| "Failed to save configuration file.")?;
 
     Ok(())
 }
 
 #[cfg(windows)]
 fn download_direct_download_etags(
-    config_data: &mut JuliaupConfig,
+    config_data: &JuliaupConfig,
 ) -> Result<Vec<(String, String)>> {
     use windows::core::HSTRING;
     use windows::Web::Http::HttpMethod;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1456,6 +1456,10 @@ pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
     // This is our optimistic locking check: if someone changed the last modified
     // field since we released the read-lock, we just give up
     if new_config_file.data != old_config_file.data {
+        if let Some(temp_versiondb_download_path) = temp_versiondb_download_path {
+            let _ = std::fs::remove_file(temp_versiondb_download_path);
+        }
+
         return Ok(());
     }
 
@@ -1491,8 +1495,8 @@ pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
 
     new_config_file.data.last_version_db_update = Some(chrono::Utc::now());
 
-    if let Some(foo) = temp_versiondb_download_path {
-        std::fs::rename(&foo, &paths.versiondb)?;
+    if let Some(temp_versiondb_download_path) = temp_versiondb_download_path {
+        std::fs::rename(&temp_versiondb_download_path, &paths.versiondb)?;
     } else if delete_old_version_db {
         let _ = std::fs::remove_file(&paths.versiondb);
     }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1559,7 +1559,7 @@ fn download_direct_download_etags(config_data: &JuliaupConfig) -> Result<Vec<(St
 
 #[cfg(not(windows))]
 fn download_direct_download_etags(
-    config_data: &mut JuliaupConfig,
+    config_data: &JuliaupConfig,
 ) -> Result<Vec<(String, String)>> {
     let client = reqwest::blocking::Client::new();
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -24,7 +24,6 @@ use flate2::read::GzDecoder;
 use indicatif::{ProgressBar, ProgressStyle};
 use indoc::formatdoc;
 use semver::Version;
-use tempfile::TempPath;
 #[cfg(not(windows))]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(not(target_os = "freebsd"))]
@@ -36,6 +35,7 @@ use std::{
 #[cfg(not(target_os = "freebsd"))]
 use tar::Archive;
 use tempfile::Builder;
+use tempfile::TempPath;
 use url::Url;
 
 #[cfg(not(target_os = "freebsd"))]
@@ -1429,15 +1429,18 @@ pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
                     ))
                     .with_context(|| "Failed to construct URL for version db download.")?;
 
-                let temp_path = tempfile::NamedTempFile::new_in(&paths.versiondb.parent().unwrap()).unwrap().into_temp_path();
+                let temp_path = tempfile::NamedTempFile::new_in(&paths.versiondb.parent().unwrap())
+                    .unwrap()
+                    .into_temp_path();
 
-                download_versiondb(&onlineversiondburl.to_string(), &temp_path)
-                    .with_context(|| {
+                download_versiondb(&onlineversiondburl.to_string(), &temp_path).with_context(
+                    || {
                         format!(
                             "Failed to download new version db from {}.",
                             onlineversiondburl
                         )
-                    })?;
+                    },
+                )?;
 
                 temp_versiondb_download_path = Some(temp_path);
             }
@@ -1487,8 +1490,7 @@ pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
 
     if let Some(foo) = temp_versiondb_download_path {
         std::fs::rename(&foo, &paths.versiondb)?;
-    }
-    else if delete_old_version_db {
+    } else if delete_old_version_db {
         let _ = std::fs::remove_file(&paths.versiondb);
     }
 
@@ -1498,9 +1500,7 @@ pub fn update_version_db(paths: &GlobalPaths) -> Result<()> {
 }
 
 #[cfg(windows)]
-fn download_direct_download_etags(
-    config_data: &JuliaupConfig,
-) -> Result<Vec<(String, String)>> {
+fn download_direct_download_etags(config_data: &JuliaupConfig) -> Result<Vec<(String, String)>> {
     use windows::core::HSTRING;
     use windows::Web::Http::HttpMethod;
     use windows::Web::Http::HttpRequestMessage;

--- a/tests/command_initial_setup_from_launcher_test.rs
+++ b/tests/command_initial_setup_from_launcher_test.rs
@@ -20,7 +20,7 @@ fn command_initial_setup() {
         .success()
         .stdout(predicate::str::is_empty())
         .stderr(
-            predicate::str::starts_with("Installing Julia 1.11.0").and(
+            predicate::str::starts_with("Installing Julia 1.11.1").and(
                 predicate::str::contains("apple.darwin14")
                     .not()
                     .or(


### PR DESCRIPTION
This should reduce the length of time the write lock is held during version db updates. Hopefully this will get rid of the majority of cases where users get the dreaded "something is locked" message when they try to launch Julia.

The implementation now is:
1. Take a read-lock on the config file
2. Read the config file and read the version db (if it exists) from disc
3. Release the read-lock
4. Analyse the data acquired in 2) and then if needed download any and all data we need. If that includes a new version db file, save it under a temporary file name.
5. Take a read-write-lock on the config file
6. Read the config file again, compare the values with the values read in 2), and if there is any difference, abort (this is essentially the situation that our optimistic locking strategy didn't work). We could add some retry story here, i.e. if this fails, just retry again for a few times. But for now, it just gives up.
7. Move the temporary downloaded version db to the real version db file name, i.e. replace that
8. Update the config file with new etag info about direct download channels, and update the time when the version db was last updated
9. Save the config file
10. Delete any now unnecessary files
11. Release the read-write-lock
