### PR TITLE
Prevent compiler warning without panicking

### DIFF
--- a/src/command_update.rs
+++ b/src/command_update.rs
@@ -82,10 +82,11 @@ fn update_channel(
             server_etag,
             version,
         } => {
-            // We only do this so that we use `version` on both Windows and Linux to prevent a compiler warning/error
-            assert!(!version.is_empty());
-
             if local_etag != server_etag {
+                // We only do this so that we use `version` on both Windows and Linux to prevent a compiler warning/error
+                if version.is_empty() {
+                    eprintln!("Channel {} version is empty, something may be wrong.", channel);
+                }
                 eprintln!("{} channel {}", style("Updating").green().bold(), channel);
 
                 let channel_data =

--- a/src/command_update.rs
+++ b/src/command_update.rs
@@ -85,7 +85,10 @@ fn update_channel(
             if local_etag != server_etag {
                 // We only do this so that we use `version` on both Windows and Linux to prevent a compiler warning/error
                 if version.is_empty() {
-                    eprintln!("Channel {} version is empty, something may be wrong.", channel);
+                    eprintln!(
+                        "Channel {} version is empty, something may be wrong.",
+                        channel
+                    );
                 }
                 eprintln!("{} channel {}", style("Updating").green().bold(), channel);
 

--- a/src/command_update.rs
+++ b/src/command_update.rs
@@ -86,7 +86,7 @@ fn update_channel(
                 // We only do this so that we use `version` on both Windows and Linux to prevent a compiler warning/error
                 if version.is_empty() {
                     eprintln!(
-                        "Channel {} version is empty, something may be wrong.",
+                        "Channel {} version is empty, you may need to manually codesign this channel if you trust the contents of this pull request.",
                         channel
                     );
                 }


### PR DESCRIPTION
My attempt at resolving #1068.

The source of the panic seems to be an assertion that was added purely to remove a compiler warning, so I turned it into a warning because I don't think an empty version field should prevent updating to a latest PR.

TODO: If people decide this is an acceptable solution, I'll improve the warning message with potential causes.

One cause is when an installed channel has an empty version field due to not being able to get the version number from a non-codesigned executable on macOS https://github.com/JuliaLang/juliaup/issues/1068#issuecomment-2409141076. It could also be that a particular PR was merged https://github.com/JuliaLang/juliaup/issues/1068#issuecomment-2435179919.