### PR TITLE
docs: Include scoop method of installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ winget install julia -s msstore
 
 on a command line.
 
-If the Windows Store is blocked on a system, we have an alternative [MSIX App Installer](https://learn.microsoft.com/en-us/windows/msix/app-installer/app-installer-file-overview) based setup. Note that this is currently experimental, please report back successes and failures [here](https://github.com/JuliaLang/juliaup/issues/343). To use the App Installer version, download [this](https://install.julialang.org/Julia.appinstaller) file and open it by double clicking on it.
+Alternatively if the Windows Store is blocked on a system, or you don´t have Admin Rights on the system, you can install it through [scoop](https://scoop.sh) by execution in a PowerShell:
+
+```powershell
+scoop install main/juliaup
+```
+
+Other alternatives include installing directly with [MSIX App Installer](https://learn.microsoft.com/en-us/windows/msix/app-installer/app-installer-file-overview) based setup. Note that this is currently experimental, please report back successes and failures [here](https://github.com/JuliaLang/juliaup/issues/343). To use the App Installer version, download [this](https://install.julialang.org/Julia.appinstaller) file and open it by double clicking on it.
 
 If neither the Windows Store nor the App Installer version work on your Windows system, you can also use a MSI based installer. Note that this installation methods comes with serious limitations and is generally not recommended unless no other method works. For example, there is no automatic update mechanism for Juliaup with this installation method. The 64 bit version of the MSI installer can be downloaded from [here](https://install.julialang.org/Julia-x64.msi) and the 32 bit version from [here](https://install.julialang.org/Julia-x86.msi). By default the install will be a per-user install that does not require elevation. You can also do a system install by running the following command from a shell:
 


### PR DESCRIPTION
Hi, 
A few days ago in juliaup can be installed using [scoop](https://scoop.sh). It was enabled with https://github.com/ScoopInstaller/Main/pull/6210

Personally I been using scoop for a few years already on my personal and my work Windows machines and never had any issue. I prefer scoop over winget for cli tools as it eases the way to manage it and find issues.

Hopefully this helps with #343 