### PR TITLE
feat: add fmt to status command

### DIFF
--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -94,7 +94,7 @@ fn main() -> Result<()> {
         Juliaup::Default { channel } => run_command_default(&channel, &paths),
         Juliaup::Add { channel } => run_command_add(&channel, &paths),
         Juliaup::Remove { channel } => run_command_remove(&channel, &paths),
-        Juliaup::Status {} => run_command_status(&paths),
+        Juliaup::Status(args) => run_command_status(&paths, args.fmt),
         Juliaup::Update { channel } => run_command_update(channel, &paths),
         Juliaup::Gc { prune_linked } => run_command_gc(prune_linked, &paths),
         Juliaup::Link {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::command_status::StatusArgs;
 use clap::{Parser, ValueEnum};
 
 #[derive(Parser)]
@@ -31,7 +32,7 @@ pub enum Juliaup {
     Remove { channel: String },
     #[clap(alias = "st")]
     /// Show all installed Julia versions
-    Status {},
+    Status(StatusArgs),
     /// Garbage collect uninstalled Julia versions
     Gc {
         #[clap(long)]


### PR DESCRIPTION
This PR adds an optional `fmt` command to `juliaup status` supporting `json`, `ndjson`, `csv`, and `tsv` formats. 

The intent is to allow other processes to consume the output of `juliaup`'s status command. 

In my particular use case the goal is to be able to run a julia script using the closest available version of julia possible. 

For example a `Manifest.toml` may have 

```toml
julia_version = "1.8.3"
```

And `juliaup status` may show 
```
$ juliaup st
 Default  Channel  Version                          Update
-----------------------------------------------------------
          1.8.2    1.8.2+0.aarch64.apple.darwin14
       *  1.11     1.11.2+0.aarch64.apple.darwin14
          1.11.1   1.11.1+0.aarch64.apple.darwin14
```
In this case I want to run version `1.8.2` because it should still be minor version compatible. However using juliaup's julia binary with `julia +1.8` we get an error: 

```
ERROR: Invalid Juliaup channel ``. Please run `juliaup list` to get a list of valid channels and versions.
```

With the `-f json` format I can parse the output using `serde_json` and manually match the versions using `semver` to order on precedence. 

```rs
use serde::{Deserialize, Serialize};
use std::{
    error::Error,
    process::{Command, Stdio},
};

#[derive(Serialize, Deserialize, Debug)]
struct JuliaChannel {
    name: String,
    version: String,
}

fn main() -> Result<(), Box<dyn Error>> {
    let output = Command::new("juliaup")
        .args(["status", "-f", "json"])
        .stdout(Stdio::piped())
        .spawn()?
        .wait_with_output()?;

    let vers = serde_json::from_slice::<Vec<JuliaChannel>>(&output.stdout)?;
    dbg!(&vers);
    Ok(())
}
```
```
[src/main.rs:21:5] &vers = [
    JuliaChannel {
        name: "1.8.2",
        version: "1.8.2+0.aarch64.apple.darwin14",
    },
    JuliaChannel {
        name: "1.11",
        version: "1.11.2+0.aarch64.apple.darwin14",
    },
    JuliaChannel {
        name: "1.11.1",
        version: "1.11.1+0.aarch64.apple.darwin14",
    },
]
```