### PR TITLE
Prune versions not referenced in `juliaup.json` with `--prune-orphans`

### DIFF
--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -96,7 +96,10 @@ fn main() -> Result<()> {
         Juliaup::Remove { channel } => run_command_remove(&channel, &paths),
         Juliaup::Status {} => run_command_status(&paths),
         Juliaup::Update { channel } => run_command_update(channel, &paths),
-        Juliaup::Gc { prune_linked } => run_command_gc(prune_linked, &paths),
+        Juliaup::Gc {
+            prune_linked,
+            prune_orphans,
+        } => run_command_gc(prune_linked, prune_orphans, &paths),
         Juliaup::Link {
             channel,
             file,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,8 @@ pub enum Juliaup {
     Gc {
         #[clap(long)]
         prune_linked: bool,
+        #[clap(long)]
+        prune_orphans: bool,
     },
     #[clap(subcommand, name = "config")]
     /// Juliaup configuration

--- a/src/command_gc.rs
+++ b/src/command_gc.rs
@@ -3,11 +3,11 @@ use crate::global_paths::GlobalPaths;
 use crate::operations::garbage_collect_versions;
 use anyhow::{Context, Result};
 
-pub fn run_command_gc(prune_linked: bool, paths: &GlobalPaths) -> Result<()> {
+pub fn run_command_gc(prune_linked: bool, prune_orphans: bool, paths: &GlobalPaths) -> Result<()> {
     let mut config_file = load_mut_config_db(paths)
         .with_context(|| "`gc` command failed to load configuration data.")?;
 
-    garbage_collect_versions(prune_linked, &mut config_file.data, paths)?;
+    garbage_collect_versions(prune_linked, prune_orphans, &mut config_file.data, paths)?;
 
     save_config_db(&mut config_file)
         .with_context(|| "`gc` command failed to save configuration db.")?;

--- a/src/command_remove.rs
+++ b/src/command_remove.rs
@@ -67,7 +67,7 @@ pub fn run_command_remove(channel: &str, paths: &GlobalPaths) -> Result<()> {
 
     save_config_db(&mut config_file).with_context(|| {
         format!(
-            "Failed to save configuration file from `remove` command after '{}' was installed.",
+            "Failed to save configuration file from `remove` command after '{}' was removed.",
             channel
         )
     })?;

--- a/src/command_remove.rs
+++ b/src/command_remove.rs
@@ -63,7 +63,7 @@ pub fn run_command_remove(channel: &str, paths: &GlobalPaths) -> Result<()> {
     #[cfg(not(windows))]
     remove_symlink(&format!("julia-{}", channel))?;
 
-    garbage_collect_versions(false, &mut config_file.data, paths)?;
+    garbage_collect_versions(false, false, &mut config_file.data, paths)?;
 
     save_config_db(&mut config_file).with_context(|| {
         format!(

--- a/src/command_update.rs
+++ b/src/command_update.rs
@@ -147,7 +147,7 @@ pub fn run_command_update(channel: Option<String>, paths: &GlobalPaths) -> Resul
         }
     };
 
-    garbage_collect_versions(false, &mut config_file.data, paths)?;
+    garbage_collect_versions(false, false, &mut config_file.data, paths)?;
 
     save_config_db(&mut config_file)
         .with_context(|| "`update` command failed to save configuration db.")?;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -691,20 +691,13 @@ pub fn garbage_collect_versions(
     paths: &GlobalPaths,
 ) -> Result<()> {
     let mut versions_to_uninstall: Vec<String> = Vec::new();
+
+    // GC for SystemChannel channels
     for (installed_version, detail) in &config_data.installed_versions {
+        // Removes installed version if not associated to any installed channel
         if config_data.installed_channels.iter().all(|j| match &j.1 {
             JuliaupConfigChannel::SystemChannel { version } => version != installed_version,
-            JuliaupConfigChannel::LinkedChannel {
-                command: _,
-                args: _,
-            } => true,
-            JuliaupConfigChannel::DirectDownloadChannel {
-                path: _,
-                url: _,
-                local_etag: _,
-                server_etag: _,
-                version: _,
-            } => true,
+            _ => true,
         }) {
             let path_to_delete = paths.juliauphome.join(&detail.path);
             let display = path_to_delete.display();
@@ -715,9 +708,8 @@ pub fn garbage_collect_versions(
             versions_to_uninstall.push(installed_version.clone());
         }
     }
-
-    for i in versions_to_uninstall {
-        config_data.installed_versions.remove(&i);
+    for version_to_delete in versions_to_uninstall {
+        config_data.installed_versions.remove(&version_to_delete);
     }
 
     if prune_linked {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -22,6 +22,7 @@ use console::style;
 use flate2::read::GzDecoder;
 use indicatif::{ProgressBar, ProgressStyle};
 use indoc::formatdoc;
+use itertools::Itertools;
 use regex::Regex;
 use semver::Version;
 #[cfg(not(windows))]
@@ -687,6 +688,7 @@ pub fn install_non_db_version(
 
 pub fn garbage_collect_versions(
     prune_linked: bool,
+    prune_orphans: bool,
     config_data: &mut JuliaupConfig,
     paths: &GlobalPaths,
 ) -> Result<()> {
@@ -712,8 +714,65 @@ pub fn garbage_collect_versions(
         config_data.installed_versions.remove(&version_to_delete);
     }
 
+    // GC for DirectDownloadChannel channels
+    let jl_dirs: Vec<_> = std::fs::read_dir(&paths.juliauphome)?
+        .into_iter()
+        .filter_map_ok(|r| {
+            if r.path().is_dir() {
+                Some(r.path())
+            } else {
+                None
+            }
+        })
+        .filter_map_ok(|r| {
+            let dirname = r.file_name()?.to_str()?;
+            if dirname.starts_with("julia-") {
+                Some(dirname.to_owned())
+            } else {
+                None
+            }
+        })
+        .filter(|r| r.is_ok())
+        .map(|r| r.unwrap()) // This is safe, since we only have the Ok variants
+        .collect();
+
+    if prune_orphans {
+        for jl_dir in jl_dirs {
+            if config_data
+                .installed_channels
+                .iter()
+                .all(|(_, detail)| match &detail {
+                    JuliaupConfigChannel::SystemChannel { version } => {
+                        let channel_path = &config_data.installed_versions[version]
+                            .path
+                            .replace("./", "");
+                        *channel_path != jl_dir
+                    }
+                    JuliaupConfigChannel::DirectDownloadChannel {
+                        path,
+                        url: _,
+                        local_etag: _,
+                        server_etag: _,
+                        version: _,
+                    } => {
+                        let channel_path = path.replace("./", "");
+                        channel_path != jl_dir
+                    }
+                    JuliaupConfigChannel::LinkedChannel {
+                        command: _,
+                        args: _,
+                    } => true,
+                })
+            {
+                if std::fs::remove_dir_all(paths.juliauphome.join(&jl_dir)).is_err() {
+                    eprintln!("WARNING: Failed to delete {}. You can try to delete at a later point by running `juliaup gc`.", &jl_dir)
+                }
+            }
+        }
+    }
+
     if prune_linked {
-        let mut channels_to_uninstall: Vec<String> = Vec::new();
+        let mut linked_channels_to_uninstall: Vec<String> = Vec::new();
         for (installed_channel, detail) in &config_data.installed_channels {
             match &detail {
                 JuliaupConfigChannel::LinkedChannel {
@@ -721,13 +780,13 @@ pub fn garbage_collect_versions(
                     args: _,
                 } => {
                     if !is_valid_julia_path(&PathBuf::from(cmd)) {
-                        channels_to_uninstall.push(installed_channel.clone());
+                        linked_channels_to_uninstall.push(installed_channel.clone());
                     }
                 }
                 _ => (),
             }
         }
-        for channel in channels_to_uninstall {
+        for channel in linked_channels_to_uninstall {
             remove_symlink(&format!("julia-{}", &channel))?;
             config_data.installed_channels.remove(&channel);
         }


### PR DESCRIPTION
I took a look at #1129 and it seems like if a direct download channel was deleted and the .juliaup folder was not, it would forever be ignored by the `gc` command. I attempt to address it by adding a `--prune-orphans` flag similar to the `--prune-linked` flag that will remove any folder that starts with "julia-" that is not referenced by the "juliaup.json" config file.

I also add some clarifying comments to the SystemChannel code to make it easier to understand.