### PR TITLE
Don't orphan old julia versions when failing to delete them.

### DIFF
--- a/src/operations.rs
+++ b/src/operations.rs
@@ -770,10 +770,15 @@ pub fn garbage_collect_versions(
             let path_to_delete = paths.juliauphome.join(&detail.path);
             let display = path_to_delete.display();
 
-            if std::fs::remove_dir_all(&path_to_delete).is_err() {
-                eprintln!("WARNING: Failed to delete {}. You can try to delete at a later point by running `juliaup gc`.", display)
+            if std::fs::remove_dir_all(&path_to_delete) {
+                versions_to_uninstall.push(installed_version.clone());
+            } else {
+                eprintln!(
+                    "WARNING: Failed to delete {}. Make sure to close any running old version. \
+                    You can try to delete at a later point by running `juliaup gc`.",
+                    display
+                )
             }
-            versions_to_uninstall.push(installed_version.clone());
         }
     }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -770,19 +770,21 @@ pub fn garbage_collect_versions(
             let path_to_delete = paths.juliauphome.join(&detail.path);
             let display = path_to_delete.display();
 
-            if std::fs::remove_dir_all(&path_to_delete) {
-                versions_to_uninstall.push(installed_version.clone());
-            } else {
-                eprintln!(
-                    "WARNING: Failed to delete {}. Make sure to close any running old version. \
+            match std::fs::remove_dir_all(&path_to_delete) {
+                Ok(_) => versions_to_uninstall.push(installed_version.clone()),
+                Err(_) => eprintln!(
+                    "{}: Failed to delete {}. \
+                    Make sure to close any old julia version still running.\n\
                     You can try to delete at a later point by running `juliaup gc`.",
+                    style("WARNING").yellow().bold(),
                     display
-                )
+                ),
             }
         }
     }
 
     for i in versions_to_uninstall {
+        eprintln!("{} Julia {}", style("Removed").green().bold(), &i);
         config_data.installed_versions.remove(&i);
     }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -767,7 +767,7 @@ pub fn garbage_collect_versions(
                 version: _,
             } => true,
         }) {
-            let path_to_delete = paths.juliauphome.join(&detail.path);
+            let path_to_delete = paths.juliauphome.join(&detail.path).canonicalize()?;
             let display = path_to_delete.display();
 
             match std::fs::remove_dir_all(&path_to_delete) {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -783,9 +783,13 @@ pub fn garbage_collect_versions(
         }
     }
 
-    for i in versions_to_uninstall {
-        eprintln!("{} Julia {}", style("Removed").green().bold(), &i);
-        config_data.installed_versions.remove(&i);
+    if versions_to_uninstall.is_empty() {
+        eprintln!("Nothing to remove.");
+    } else {
+        for i in versions_to_uninstall {
+            eprintln!("{} Julia {}", style("Removed").green().bold(), &i);
+            config_data.installed_versions.remove(&i);
+        }
     }
 
     if prune_linked {


### PR DESCRIPTION
Alternative to #1146 fixes #1153 

only remove a version from the installed version database if we successfully deleted them.
When failing to remove a version, at least on windows, it is most likely that that version is still running somewhere.
Added a bit of text to hint at that possibility.

With this change `juliaup gc` works as intended after that message.

regarding #1146: it might still be useful to have orphan pruning capabilities as a fallback, but i've opted to keep the two PRs separate for easier review and merging