### PR TITLE
Auto install versions via channel selection

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -178,41 +178,41 @@ fn get_julia_path_from_channel(
     paths: &juliaup::global_paths::GlobalPaths,
 ) -> Result<(PathBuf, Vec<String>)> {
     let channel_valid = is_valid_channel(versions_db, &channel.to_string())?;
-    
+
     // First check if the channel is already installed
     if let Some(channel_info) = config_data.installed_channels.get(channel) {
         return get_julia_path_from_installed_channel(
-            versions_db, 
-            config_data, 
-            channel, 
-            juliaupconfig_path, 
+            versions_db,
+            config_data,
+            channel,
+            juliaupconfig_path,
             channel_info
         );
     }
-    
+
     // Handle auto-installation for command line channel selection
     if let JuliaupChannelSource::CmdLine = juliaup_channel_source {
         if channel_valid || is_pr_channel(&channel.to_string()) {
             eprintln!(
-                "{} Installing Julia {} as it was requested but not installed.", 
+                "{} Installing Julia {} as it was requested but not installed.",
                 style("Info:").cyan().bold(),
                 channel
             );
-            
+
             // Install the channel
             run_command_add(channel, paths)
                 .with_context(|| format!("Failed to automatically install channel '{}'", channel))?;
-            
+
             // Reload the config to get the newly installed channel
             let updated_config_file = load_config_db(paths, None)
                 .with_context(|| "Failed to reload configuration after installing channel.")?;
-            
+
             if let Some(channel_info) = updated_config_file.data.installed_channels.get(channel) {
                 return get_julia_path_from_installed_channel(
-                    versions_db, 
-                    &updated_config_file.data, 
-                    channel, 
-                    juliaupconfig_path, 
+                    versions_db,
+                    &updated_config_file.data,
+                    channel,
+                    juliaupconfig_path,
                     channel_info
                 );
             } else {
@@ -223,7 +223,7 @@ fn get_julia_path_from_channel(
             }
         }
     }
-    
+
     // Original error handling for non-command-line sources or invalid channels
     let error = match juliaup_channel_source {
         JuliaupChannelSource::CmdLine => {
@@ -255,7 +255,7 @@ fn get_julia_path_from_channel(
         },
         JuliaupChannelSource::Default => UserError {msg: format!("The Juliaup configuration is in an inconsistent state, the currently configured default channel `{}` is not installed.", channel) }
     };
-    
+
     Err(error.into())
 }
 

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -186,7 +186,7 @@ fn get_julia_path_from_channel(
             config_data,
             channel,
             juliaupconfig_path,
-            channel_info
+            channel_info,
         );
     }
 
@@ -200,8 +200,9 @@ fn get_julia_path_from_channel(
             );
 
             // Install the channel
-            run_command_add(channel, paths)
-                .with_context(|| format!("Failed to automatically install channel '{}'", channel))?;
+            run_command_add(channel, paths).with_context(|| {
+                format!("Failed to automatically install channel '{}'", channel)
+            })?;
 
             // Reload the config to get the newly installed channel
             let updated_config_file = load_config_db(paths, None)
@@ -213,13 +214,14 @@ fn get_julia_path_from_channel(
                     &updated_config_file.data,
                     channel,
                     juliaupconfig_path,
-                    channel_info
+                    channel_info,
                 );
             } else {
                 return Err(anyhow!(
                     "Channel '{}' was installed but could not be found in configuration.",
                     channel
-                ).into());
+                )
+                .into());
             }
         }
     }

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use juliaup::cli::{ConfigSubCmd, Juliaup, OverrideSubCmd, SelfSubCmd};
 use juliaup::command_api::run_command_api;
 use juliaup::command_completions::run_command_completions;
+use juliaup::command_config_autoinstall::run_command_config_autoinstall;
 #[cfg(not(windows))]
 use juliaup::command_config_symlinks::run_command_config_symlinks;
 use juliaup::command_config_versionsdbupdate::run_command_config_versionsdbupdate;
@@ -122,6 +123,9 @@ fn main() -> Result<()> {
             }
             ConfigSubCmd::VersionsDbUpdateInterval { value } => {
                 run_command_config_versionsdbupdate(value, false, &paths)
+            }
+            ConfigSubCmd::AutoInstallChannels { value } => {
+                run_command_config_autoinstall(value, false, &paths)
             }
         },
         Juliaup::Api { command } => run_command_api(&command, &paths),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -157,4 +157,13 @@ pub enum ConfigSubCmd {
         /// New value
         value: Option<i64>,
     },
+    /// Whether to automatically install Julia channels requested from the command line.
+    /// When set to true, 'julia +channel' will automatically install missing channels.
+    /// When false, users will not be prompted and shown an error.
+    /// When default (unset), users will be prompted interactively or shown an error in non-interactive mode.
+    #[clap(name = "autoinstallchannels")]
+    AutoInstallChannels {
+        /// New value: true, false, or default
+        value: Option<String>,
+    },
 }

--- a/src/command_config_autoinstall.rs
+++ b/src/command_config_autoinstall.rs
@@ -1,0 +1,66 @@
+use anyhow::{anyhow, Result};
+
+pub fn run_command_config_autoinstall(
+    value: Option<String>,
+    quiet: bool,
+    paths: &crate::global_paths::GlobalPaths,
+) -> Result<()> {
+    use crate::config_file::{load_config_db, load_mut_config_db, save_config_db};
+    use anyhow::Context;
+
+    match value {
+        Some(value_str) => {
+            let mut config_file = load_mut_config_db(paths)
+                .with_context(|| "`config` command failed to load configuration data.")?;
+
+            let mut value_changed = false;
+            let new_value = match value_str.to_lowercase().as_str() {
+                "true" => Some(true),
+                "false" => Some(false),
+                "default" => None,
+                _ => return Err(anyhow!("Invalid value '{}'. Valid values are: true, false, default", value_str)),
+            };
+
+            if new_value != config_file.data.settings.auto_install_channels {
+                config_file.data.settings.auto_install_channels = new_value;
+                value_changed = true;
+            }
+
+            save_config_db(&mut config_file)
+                .with_context(|| "Failed to save configuration file from `config` command.")?;
+
+            if !quiet {
+                let display_value = new_value
+                    .map(|b| b.to_string())
+                    .unwrap_or_else(|| "default (not set)".to_string());
+                
+                if value_changed {
+                    eprintln!(
+                        "Property 'autoinstallchannels' set to '{}'",
+                        display_value
+                    );
+                } else {
+                    eprintln!(
+                        "Property 'autoinstallchannels' is already set to '{}'",
+                        display_value
+                    );
+                }
+            }
+        }
+        None => {
+            let config_file = load_config_db(paths, None)
+                .with_context(|| "`config` command failed to load configuration data.")?;
+
+            if !quiet {
+                eprintln!(
+                    "Property 'autoinstallchannels' set to '{}'",
+                    config_file.data.settings.auto_install_channels
+                        .map(|b| b.to_string())
+                        .unwrap_or_else(|| "default (not set)".to_string())
+                );
+            }
+        }
+    };
+
+    Ok(())
+}

--- a/src/command_list.rs
+++ b/src/command_list.rs
@@ -36,7 +36,7 @@ pub fn run_command_list(paths: &GlobalPaths) -> Result<()> {
         })
         .collect();
 
-    let rows_in_table: Vec<_> = versiondb_data
+    let mut all_rows: Vec<ChannelRow> = versiondb_data
         .available_channels
         .iter()
         .map(|i| -> ChannelRow {
@@ -45,12 +45,13 @@ pub fn run_command_list(paths: &GlobalPaths) -> Result<()> {
                 version: i.1.version.clone(),
             }
         })
-        .sorted_by(|a, b| compare(&a.name, &b.name))
-        .chain(non_db_rows)
         .collect();
+    
+    all_rows.extend(non_db_rows);
+    all_rows.sort_by(|a, b| compare(&a.name, &b.name));
 
     print_stdout(
-        rows_in_table
+        all_rows
             .with_title()
             .color_choice(ColorChoice::Never)
             .border(Border::builder().build())

--- a/src/command_list.rs
+++ b/src/command_list.rs
@@ -6,7 +6,6 @@ use cli_table::{
     print_stdout, ColorChoice, Table, WithTitle,
 };
 use human_sort::compare;
-use itertools::Itertools;
 
 #[derive(Table)]
 struct ChannelRow {

--- a/src/command_list.rs
+++ b/src/command_list.rs
@@ -46,7 +46,7 @@ pub fn run_command_list(paths: &GlobalPaths) -> Result<()> {
             }
         })
         .collect();
-    
+
     all_rows.extend(non_db_rows);
     all_rows.sort_by(|a, b| compare(&a.name, &b.name));
 

--- a/src/command_list.rs
+++ b/src/command_list.rs
@@ -5,7 +5,6 @@ use cli_table::{
     format::{Border, HorizontalLine, Separator},
     print_stdout, ColorChoice, Table, WithTitle,
 };
-use human_sort::compare;
 
 #[derive(Table)]
 struct ChannelRow {
@@ -47,7 +46,7 @@ pub fn run_command_list(paths: &GlobalPaths) -> Result<()> {
         .collect();
 
     all_rows.extend(non_db_rows);
-    all_rows.sort_by(|a, b| compare(&a.name, &b.name));
+    all_rows.sort_by(|a, b| a.name.cmp(&b.name));
 
     print_stdout(
         all_rows

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -67,6 +67,12 @@ pub struct JuliaupConfigSettings {
         skip_serializing_if = "is_default_versionsdb_update_interval"
     )]
     pub versionsdb_update_interval: i64,
+    #[serde(
+        rename = "AutoInstallChannels",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub auto_install_channels: Option<bool>,
 }
 
 impl Default for JuliaupConfigSettings {
@@ -74,6 +80,7 @@ impl Default for JuliaupConfigSettings {
         JuliaupConfigSettings {
             create_channel_symlinks: false,
             versionsdb_update_interval: default_versionsdb_update_interval(),
+            auto_install_channels: None,
         }
     }
 }
@@ -203,6 +210,7 @@ pub fn load_config_db(
                 settings: JuliaupConfigSettings {
                     create_channel_symlinks: false,
                     versionsdb_update_interval: default_versionsdb_update_interval(),
+                    auto_install_channels: None,
                 },
                 last_version_db_update: None,
             },
@@ -301,6 +309,7 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
                 settings: JuliaupConfigSettings {
                     create_channel_symlinks: false,
                     versionsdb_update_interval: default_versionsdb_update_interval(),
+                    auto_install_channels: None,
                 },
                 last_version_db_update: None,
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod command_add;
 pub mod command_api;
 pub mod command_completions;
+pub mod command_config_autoinstall;
 pub mod command_config_backgroundselfupdate;
 pub mod command_config_modifypath;
 pub mod command_config_startupselfupdate;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -710,6 +710,7 @@ pub fn install_non_db_version(
                 Ok("bin/macos/aarch64/julia-".to_owned() + &id + "-macos-aarch64.tar.gz")
             }
             "win64" => Ok("bin/windows/x86_64/julia-".to_owned() + &id + "-windows-x86_64.tar.gz"),
+            "win32" => Ok("bin/windows/x86/julia-".to_owned() + &id + "-windows-x86.tar.gz"),
             "linux-x86_64" => {
                 Ok("bin/linux/x86_64/julia-".to_owned() + &id + "-linux-x86_64.tar.gz")
             }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -175,7 +175,8 @@ pub fn download_extract_sans_parent(
 
     http_response
         .EnsureSuccessStatusCode()
-        .with_context(|| "HTTP download reported error status code.")?;
+        .with_context(|| format!("Failed to get etag from `{}`.\n\
+            This is likely due to requesting a pull request that does not have a cached build available. You may have to build locally.", url))?;
 
     let last_modified = http_response
         .Headers()

--- a/tests/channel_selection.rs
+++ b/tests/channel_selection.rs
@@ -1,5 +1,5 @@
 use assert_cmd::Command;
-use predicates::str;
+use predicates::str::contains;
 
 #[test]
 fn channel_selection() {
@@ -140,7 +140,7 @@ fn channel_selection() {
         .assert()
         .success()
         .stdout("1.8.2")
-        .stderr(predicates::str::contains(
+        .stderr(contains(
             "Info: Installing Julia 1.8.2 as it was requested but not installed.",
         ));
 
@@ -157,7 +157,7 @@ fn channel_selection() {
         .assert()
         .success()
         .stdout("SUCCESS")
-        .stderr(predicates::str::contains(
+        .stderr(contains(
             "Info: Installing Julia nightly as it was requested but not installed.",
         ));
 
@@ -173,8 +173,8 @@ fn channel_selection() {
         .env("JULIAUP_CHANNEL", "1.7.4")
         .assert()
         .failure()
-        .stderr(predicates::str::contains("Failed to automatically install channel 'pr1'"))
-        .stderr(predicates::str::contains("This is likely due to requesting a pull request that does not have a cached build available"));
+        .stderr(contains("Failed to automatically install channel 'pr1'"))
+        .stderr(contains("This is likely due to requesting a pull request that does not have a cached build available"));
 }
 
 #[test]
@@ -203,7 +203,7 @@ fn auto_install_valid_channel() {
         .assert()
         .success()
         .stdout("1.10.10")
-        .stderr(predicates::str::contains(
+        .stderr(contains(
             "Info: Installing Julia 1.10.10 as it was requested but not installed.",
         ));
 }

--- a/tests/channel_selection.rs
+++ b/tests/channel_selection.rs
@@ -140,7 +140,9 @@ fn channel_selection() {
         .assert()
         .success()
         .stdout("1.8.2")
-        .stderr(predicates::str::contains("Info: Installing Julia 1.8.2 as it was requested but not installed."));
+        .stderr(predicates::str::contains(
+            "Info: Installing Julia 1.8.2 as it was requested but not installed.",
+        ));
 
     // https://github.com/JuliaLang/juliaup/issues/820
     // Command line channel selector should auto-install valid channels including nightly
@@ -148,14 +150,16 @@ fn channel_selection() {
         .unwrap()
         .arg("+nightly")
         .arg("-e")
-        .arg("print(\"SUCCESS\")")  // Use SUCCESS instead of VERSION since nightly version can vary
+        .arg("print(\"SUCCESS\")") // Use SUCCESS instead of VERSION since nightly version can vary
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .env("JULIAUP_DEPOT_PATH", depot_dir.path())
         .env("JULIAUP_CHANNEL", "1.7.4")
         .assert()
         .success()
         .stdout("SUCCESS")
-        .stderr(predicates::str::contains("Info: Installing Julia nightly as it was requested but not installed."));
+        .stderr(predicates::str::contains(
+            "Info: Installing Julia nightly as it was requested but not installed.",
+        ));
 
     // https://github.com/JuliaLang/juliaup/issues/995
     // PR channels that don't exist should attempt auto-install but fail with a descriptive error
@@ -199,5 +203,7 @@ fn auto_install_valid_channel() {
         .assert()
         .success()
         .stdout("1.10.10")
-        .stderr(predicates::str::contains("Info: Installing Julia 1.10.10 as it was requested but not installed."));
+        .stderr(predicates::str::contains(
+            "Info: Installing Julia 1.10.10 as it was requested but not installed.",
+        ));
 }

--- a/tests/channel_selection.rs
+++ b/tests/channel_selection.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use predicates::str;
 
 #[test]
 fn channel_selection() {
@@ -127,6 +128,7 @@ fn channel_selection() {
         .stderr("ERROR: Invalid Juliaup channel `1.8.6`. Please run `juliaup list` to get a list of valid channels and versions.\n");
 
     // https://github.com/JuliaLang/juliaup/issues/766
+    // Command line channel selector should auto-install valid channels
     Command::cargo_bin("julia")
         .unwrap()
         .arg("+1.8.2")
@@ -136,23 +138,27 @@ fn channel_selection() {
         .env("JULIAUP_DEPOT_PATH", depot_dir.path())
         .env("JULIAUP_CHANNEL", "1.7.4")
         .assert()
-        .failure()
-        .stderr("ERROR: `1.8.2` is not installed. Please run `juliaup add 1.8.2` to install channel or version.\n");
+        .success()
+        .stdout("1.8.2")
+        .stderr(predicates::str::contains("Info: Installing Julia 1.8.2 as it was requested but not installed."));
 
     // https://github.com/JuliaLang/juliaup/issues/820
+    // Command line channel selector should auto-install valid channels including nightly
     Command::cargo_bin("julia")
         .unwrap()
         .arg("+nightly")
         .arg("-e")
-        .arg("print(VERSION)")
+        .arg("print(\"SUCCESS\")")  // Use SUCCESS instead of VERSION since nightly version can vary
         .env("JULIA_DEPOT_PATH", depot_dir.path())
         .env("JULIAUP_DEPOT_PATH", depot_dir.path())
         .env("JULIAUP_CHANNEL", "1.7.4")
         .assert()
-        .failure()
-        .stderr("ERROR: `nightly` is not installed. Please run `juliaup add nightly` to install channel or version.\n");
+        .success()
+        .stdout("SUCCESS")
+        .stderr(predicates::str::contains("Info: Installing Julia nightly as it was requested but not installed."));
 
     // https://github.com/JuliaLang/juliaup/issues/995
+    // PR channels that don't exist should attempt auto-install but fail with a descriptive error
     Command::cargo_bin("julia")
         .unwrap()
         .arg("+pr1")
@@ -163,5 +169,35 @@ fn channel_selection() {
         .env("JULIAUP_CHANNEL", "1.7.4")
         .assert()
         .failure()
-        .stderr("ERROR: `pr1` is not installed. Please run `juliaup add pr1` to install pull request channel if available.\n");
+        .stderr(predicates::str::contains("Failed to automatically install channel 'pr1'"))
+        .stderr(predicates::str::contains("This is likely due to requesting a pull request that does not have a cached build available"));
+}
+
+#[test]
+fn auto_install_valid_channel() {
+    let depot_dir = assert_fs::TempDir::new().unwrap();
+
+    // First set up a basic julia installation so juliaup is properly initialized
+    Command::cargo_bin("juliaup")
+        .unwrap()
+        .arg("add")
+        .arg("1.11")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("");
+
+    // Now test auto-installing a valid but not installed channel via command line
+    Command::cargo_bin("julia")
+        .unwrap()
+        .arg("+1.10.10")
+        .arg("-e")
+        .arg("print(VERSION)")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_DEPOT_PATH", depot_dir.path())
+        .assert()
+        .success()
+        .stdout("1.10.10")
+        .stderr(predicates::str::contains("Info: Installing Julia 1.10.10 as it was requested but not installed."));
 }


### PR DESCRIPTION
Makes it such that if you specify a channel which you don't have installed but is valid, it installs and launches it, with a message.
```
% julia +nightly
Info: Installing Julia nightly as it was requested but not installed.
Installing Julia latest-macos-aarch64
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.13.0-DEV.860 (2025-07-12)
 _/ |\__'_|_|_|\__'_|  |  Commit 6ddb3d64106 (1 day old master)
|__/                   |

julia>
```

Works for all valid channel descriptors (including PRs).

```
% julia +badchannel
ERROR: Invalid Juliaup channel `badchannel`. Please run `juliaup list` to get a list of valid channels and versions.
```

Developed with Claude.


----


Note unrelated bugfixes that are included:
- [`7f7e956` (#1218)](https://github.com/JuliaLang/juliaup/pull/1218/commits/7f7e95663edbe35462dfc563facfbda0477a8732) - fix: add missing win32 handling in install_non_db_version
- [`c6eafe3` (#1218)](https://github.com/JuliaLang/juliaup/pull/1218/commits/c6eafe3d7fb76c2e1dfb2134fe094d7d5beab90e) - fix win32 sorting panic

If this PR isn't a simple merge it might be worth separating those out as a bugfix.