### PR TITLE
fix: incorrect TLS and cipher warnings with curl v8.10.0

### DIFF
--- a/deploy/shellscript/juliaup-init.sh
+++ b/deploy/shellscript/juliaup-init.sh
@@ -574,7 +574,7 @@ check_help_for() {
     shift
 
     local _category
-    if "$_cmd" --help | grep -q 'For all options use the manual or "--help all".'; then
+    if "$_cmd" --help | grep -q '"--help all"'; then
       _category="all"
     else
       _category=""


### PR DESCRIPTION
Fixed the TLS and cipher warnings that occur with curl v8.10.0+ as described in #1219.