### PR TITLE
Replace unmaintained `human_sort` with `numeric_sort` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,12 +797,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "human-sort"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140a09c9305e6d5e557e2ed7cbc68e05765a7d4213975b87cb04920689cc6219"
-
-[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,7 +1173,6 @@ dependencies = [
  "flate2",
  "fs_extra",
  "human-panic",
- "human-sort",
  "indicatif",
  "indoc",
  "is-terminal",
@@ -1187,6 +1180,7 @@ dependencies = [
  "log",
  "nix",
  "normpath",
+ "numeric-sort",
  "path-absolutize",
  "predicates",
  "regex",
@@ -1328,6 +1322,12 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "numeric-sort"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dcb6053ab98da45585315f79932c5c9821fab8efa4301c0d7b637c91630eb7"
 
 [[package]]
 name = "object"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ bstr = "1.10"
 indoc = "2.0.3"
 is-terminal = "0.4"
 path-absolutize = "3.1.0"
-human-sort = "0.2.2"
+numeric-sort = "0.1.5"
 regex = "1.10"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/command_list.rs
+++ b/src/command_list.rs
@@ -5,7 +5,7 @@ use cli_table::{
     format::{Border, HorizontalLine, Separator},
     print_stdout, ColorChoice, Table, WithTitle,
 };
-use human_sort::compare;
+use numeric_sort::cmp;
 use itertools::Itertools;
 
 #[derive(Table)]
@@ -45,7 +45,7 @@ pub fn run_command_list(paths: &GlobalPaths) -> Result<()> {
                 version: i.1.version.clone(),
             }
         })
-        .sorted_by(|a, b| compare(&a.name, &b.name))
+        .sorted_by(|a, b| cmp(&a.name, &b.name))
         .chain(non_db_rows)
         .collect();
 

--- a/src/command_status.rs
+++ b/src/command_status.rs
@@ -10,7 +10,7 @@ use cli_table::{
     format::{Border, Justify},
     print_stdout, Table, WithTitle,
 };
-use human_sort::compare;
+use numeric_sort::cmp;
 use itertools::Itertools;
 
 #[derive(Table)]
@@ -36,7 +36,7 @@ pub fn run_command_status(paths: &GlobalPaths) -> Result<()> {
         .data
         .installed_channels
         .iter()
-        .sorted_by(|a, b| compare(&a.0.to_string(), &b.0.to_string()))
+        .sorted_by(|a, b| cmp(&a.0.to_string(), &b.0.to_string()))
         .map(|i| -> ChannelRow {
             ChannelRow {
                 default: match config_file.data.default {


### PR DESCRIPTION
Seems like the unmaintained `human-sort` package has started erroring so I replaced it with `numeric-sort`.

Refs:
https://github.com/lycheeverse/lychee/issues/1758
https://github.com/paradakh/human-sort/issues/5