### PR TITLE
Colored + wrapped help menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -2127,6 +2128,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ codegen-units = 1
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "color", "wrap_help"] }
 clap_complete = "4.5"
 clap_complete_nushell = "4.5"
 dirs = "6.0.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,10 +1,11 @@
+use crate::cli_styles;
 use clap::{Parser, ValueEnum};
 
 /// Shell options for completions
 #[derive(Clone, ValueEnum)]
 pub enum CompletionShell {
     Bash,
-    Elvish, 
+    Elvish,
     Fish,
     Nushell,
     PowerShell,
@@ -14,6 +15,7 @@ pub enum CompletionShell {
 #[derive(Parser)]
 #[clap(name = "Juliaup", version)]
 #[command(
+    styles = cli_styles::get_styles(),
     after_help = "To launch a specific Julia version, use `julia +{channel}` e.g. `julia +1.6`.
 Entering just `julia` uses the default channel set via `juliaup default`."
 )]
@@ -62,9 +64,9 @@ pub enum Juliaup {
     #[clap(subcommand, name = "self")]
     SelfSubCmd(SelfSubCmd),
     /// Generate tab-completion scripts for your shell
-    Completions { 
+    Completions {
         #[arg(value_enum, value_name = "SHELL")]
-        shell: CompletionShell 
+        shell: CompletionShell,
     },
     // This is used for the cron jobs that we create. By using this UUID for the command
     // We can identify the cron jobs that were created by juliaup for uninstall purposes
@@ -74,6 +76,7 @@ pub enum Juliaup {
 }
 
 #[derive(Parser)]
+#[command(styles = cli_styles::get_styles())]
 /// Manage directory overrides
 pub enum OverrideSubCmd {
     Status {},
@@ -111,6 +114,7 @@ impl JuliaupChannel {
 }
 
 #[derive(Parser)]
+#[command(styles = cli_styles::get_styles())]
 /// Manage this juliaup installation
 pub enum SelfSubCmd {
     #[cfg(not(feature = "selfupdate"))]
@@ -136,6 +140,7 @@ pub enum SelfSubCmd {
 }
 
 #[derive(Parser)]
+#[command(styles = cli_styles::get_styles())]
 pub enum ConfigSubCmd {
     #[cfg(not(windows))]
     #[clap(name = "channelsymlinks")]

--- a/src/cli_styles.rs
+++ b/src/cli_styles.rs
@@ -1,0 +1,36 @@
+use clap::builder::styling::{AnsiColor, Effects, Style, Styles};
+
+pub fn get_styles() -> Styles {
+    Styles::styled()
+        .header(
+            Style::new()
+                .fg_color(Some(AnsiColor::Green.into()))
+                .effects(Effects::BOLD),
+        )
+        .usage(
+            Style::new()
+                .fg_color(Some(AnsiColor::Green.into()))
+                .effects(Effects::BOLD),
+        )
+        .literal(
+            Style::new()
+                .fg_color(Some(AnsiColor::Cyan.into()))
+                .effects(Effects::BOLD),
+        )
+        .placeholder(Style::new().fg_color(Some(AnsiColor::Cyan.into())))
+        .error(
+            Style::new()
+                .fg_color(Some(AnsiColor::Red.into()))
+                .effects(Effects::BOLD),
+        )
+        .valid(
+            Style::new()
+                .fg_color(Some(AnsiColor::Cyan.into()))
+                .effects(Effects::BOLD),
+        )
+        .invalid(
+            Style::new()
+                .fg_color(Some(AnsiColor::Yellow.into()))
+                .effects(Effects::BOLD),
+        )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 
 pub mod cli;
+pub mod cli_styles;
 pub mod command_add;
 pub mod command_api;
 pub mod command_completions;


### PR DESCRIPTION
This adds standard colors to the help menus. It also enabled "wrap_text" on the binary so it can stay nicely formatted on narrow terminals.

Note that this default clap coloring automatically detects terminal compatibility before adding colors to the menu.

Before:

<img width="395" height="422" alt="image" src="https://github.com/user-attachments/assets/fb38d5fa-6a35-4531-80f2-40c770eeaf55" />

After:

<img width="449" height="430" alt="image" src="https://github.com/user-attachments/assets/00055d7e-3f07-4966-a796-288ee8701fa6" />
