### PR TITLE
Replace file locking with atomic file operations

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -316,7 +316,7 @@ fn run_app() -> Result<i32> {
     do_initial_setup(&paths.juliaupconfig)
         .with_context(|| "The Julia launcher failed to run the initial setup steps.")?;
 
-    let config_file = load_config_db(&paths, None)
+    let config_file = load_config_db(&paths)
         .with_context(|| "The Julia launcher failed to load a configuration file.")?;
 
     let versiondb_data = load_versions_db(&paths)

--- a/src/command_api.rs
+++ b/src/command_api.rs
@@ -39,7 +39,7 @@ pub fn run_command_api(command: &str, paths: &GlobalPaths) -> Result<()> {
         other_versions: Vec::new(),
     };
 
-    let config_file = load_config_db(paths, None).with_context(|| {
+    let config_file = load_config_db(paths).with_context(|| {
         "Failed to load configuration file while running the getconfig1 API command."
     })?;
 

--- a/src/command_config_backgroundselfupdate.rs
+++ b/src/command_config_backgroundselfupdate.rs
@@ -57,7 +57,7 @@ pub fn run_command_config_backgroundselfupdate(
             }
         }
         None => {
-            let config_file = load_config_db(paths, None)
+            let config_file = load_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {

--- a/src/command_config_modifypath.rs
+++ b/src/command_config_modifypath.rs
@@ -41,7 +41,7 @@ pub fn run_command_config_modifypath(
             }
         }
         None => {
-            let config_file = load_config_db(paths, None)
+            let config_file = load_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {

--- a/src/command_config_startupselfupdate.rs
+++ b/src/command_config_startupselfupdate.rs
@@ -47,7 +47,7 @@ pub fn run_command_config_startupselfupdate(
             }
         }
         None => {
-            let config_file = load_config_db(paths, None)
+            let config_file = load_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {

--- a/src/command_config_symlinks.rs
+++ b/src/command_config_symlinks.rs
@@ -43,7 +43,7 @@ pub fn run_command_config_symlinks(
             }
         }
         None => {
-            let config_file = load_config_db(paths, None)
+            let config_file = load_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {

--- a/src/command_config_versionsdbupdate.rs
+++ b/src/command_config_versionsdbupdate.rs
@@ -38,7 +38,7 @@ pub fn run_command_config_versionsdbupdate(
             }
         }
         None => {
-            let config_file = load_config_db(paths, None)
+            let config_file = load_config_db(paths)
                 .with_context(|| "`config` command failed to load configuration data.")?;
 
             if !quiet {

--- a/src/command_info.rs
+++ b/src/command_info.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Context, Result};
 
 pub fn run_command_info(paths: &GlobalPaths) -> Result<()> {
     #[cfg(feature = "selfupdate")]
-    let config_file = load_config_db(paths, None).with_context(|| {
+    let config_file = load_config_db(paths).with_context(|| {
         "`run_command_update_version_db` command failed to load configuration db."
     })?;
 
@@ -21,7 +21,7 @@ pub fn run_command_info(paths: &GlobalPaths) -> Result<()> {
     };
 
     #[cfg(not(feature = "selfupdate"))]
-    let _config_file = load_config_db(paths, None).with_context(|| {
+    let _config_file = load_config_db(paths).with_context(|| {
         "`run_command_update_version_db` command failed to load configuration db."
     })?;
 

--- a/src/command_override.rs
+++ b/src/command_override.rs
@@ -24,7 +24,7 @@ struct OverrideRow {
 }
 
 pub fn run_command_override_status(paths: &GlobalPaths) -> Result<()> {
-    let config_file = load_config_db(paths, None)
+    let config_file = load_config_db(paths)
         .with_context(|| "`override status` command failed to load configuration file.")?;
 
     let rows_in_table: Vec<_> = config_file

--- a/src/command_status.rs
+++ b/src/command_status.rs
@@ -26,7 +26,7 @@ struct ChannelRow {
 }
 
 pub fn run_command_status(paths: &GlobalPaths) -> Result<()> {
-    let config_file = load_config_db(paths, None)
+    let config_file = load_config_db(paths)
         .with_context(|| "`status` command failed to load configuration file.")?;
 
     let versiondb_data =

--- a/src/global_paths.rs
+++ b/src/global_paths.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 pub struct GlobalPaths {
     pub juliauphome: PathBuf,
     pub juliaupconfig: PathBuf,
-    pub lockfile: PathBuf,
     pub versiondb: PathBuf,
     #[cfg(feature = "selfupdate")]
     pub juliaupselfhome: PathBuf,
@@ -70,8 +69,6 @@ pub fn get_paths() -> Result<GlobalPaths> {
 
     let versiondb = juliauphome.join(format!("versiondb-{}.json", get_juliaup_target()));
 
-    let lockfile = juliauphome.join(".juliaup-lock");
-
     #[cfg(feature = "selfupdate")]
     let juliaupselfhome = my_own_path
         .parent()
@@ -86,7 +83,6 @@ pub fn get_paths() -> Result<GlobalPaths> {
     Ok(GlobalPaths {
         juliauphome,
         juliaupconfig,
-        lockfile,
         versiondb,
         #[cfg(feature = "selfupdate")]
         juliaupselfhome,

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,4 +1,3 @@
-use crate::config_file::get_read_lock;
 use crate::config_file::load_config_db;
 use crate::config_file::load_mut_config_db;
 use crate::config_file::save_config_db;
@@ -1320,12 +1319,10 @@ pub fn update_version_db(channel: &Option<String>, paths: &GlobalPaths) -> Resul
         style("Checking").green().bold()
     );
 
-    let file_lock = get_read_lock(paths)?;
-
     let mut temp_versiondb_download_path: Option<TempPath> = None;
     let mut delete_old_version_db: bool = false;
 
-    let old_config_file = load_config_db(paths, Some(&file_lock)).with_context(|| {
+    let old_config_file = load_config_db(paths).with_context(|| {
         "`run_command_update_version_db` command failed to load configuration db."
     })?;
 
@@ -1347,11 +1344,6 @@ pub fn update_version_db(channel: &Option<String>, paths: &GlobalPaths) -> Resul
         Err(_) => None,
     };
 
-    // This scope makes sure the lock file gets closed after we release the lock
-    {
-        let (_, res) = file_lock.data_unlock();
-        res.with_context(|| "Failed to unlock configuration file.")?;
-    }
 
     #[cfg(feature = "selfupdate")]
     let juliaup_channel = match &old_config_file.self_data.juliaup_channel {


### PR DESCRIPTION
As I proposed in https://github.com/JuliaLang/juliaup/issues/561#issuecomment-3238937586. Unless I'm missing something, this should fix https://github.com/JuliaLang/juliaup/issues/561. Written by Claude.

This commit removes the lock file mechanism and replaces it with atomic file operations using temporary files for safer concurrent access.

Changes:
- Remove cluFlock dependency from Cargo.toml
- Remove lock file creation and management code
- Implement atomic save using tempfile's NamedTempFile
- Write to temporary file then atomically rename to target
- Simplify load_config_db by removing lock parameter
- Update all callers to use new API

The new approach writes configuration changes to a temporary file in the same directory, then atomically renames it to replace the original file. This ensures readers always see either the complete old version or complete new version, never partial writes.

🤖 Generated with [Claude Code](https://claude.ai/code)