### PR TITLE
fix: incorrect data for symlink

### DIFF
--- a/src/command_update.rs
+++ b/src/command_update.rs
@@ -97,21 +97,11 @@ fn update_channel(
 
                 config_db
                     .installed_channels
-                    .insert(channel.clone(), channel_data);
+                    .insert(channel.clone(), channel_data.clone());
 
                 #[cfg(not(windows))]
                 if config_db.settings.create_channel_symlinks {
-                    create_symlink(
-                        &JuliaupConfigChannel::DirectDownloadChannel {
-                            path: path.clone(),
-                            url: url.clone(),
-                            local_etag: local_etag.clone(),
-                            server_etag: server_etag.clone(),
-                            version: version.clone(),
-                        },
-                        channel,
-                        paths,
-                    )?;
+                    create_symlink(&channel_data, channel, paths)?;
                 }
             }
         }


### PR DESCRIPTION
While messing around in #1242 I noticed this. I'm pretty sure `create_symlink` should be getting the updated `channel_data`, rather than simply propagating the previous info. I think this means that a symlink would have its version info forever frozen.