### PR TITLE
README: Give explicit example of the `--path` argument for installing Juliaup into a custom location

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Here `<ARGS>` should be replaced with one or more of the following arguments:
 - `--yes` (or `-y`): Run the installer in a non-interactive mode. All configuration values use their default.
 - `--default-channel <NAME>`: Configure the default channel. For example `--default-channel lts` would install the `lts` channel and configure it as the default.
 - `--path` (or `-p`): Install `juliaup` in a custom location.
-- For example, if you want to install `juliaup` into `~/my/desired/juliaup/path`, you would run the following command: `curl -fsSL https://install.julialang.org | sh -s -- --path ~/my/desired/juliaup/path`
+    - For example, if you want to install `juliaup` into `~/my/desired/juliaup/path`, you would run the following command: `curl -fsSL https://install.julialang.org | sh -s -- --path ~/my/desired/juliaup/path`
 
 ### Software Repositories
 


### PR DESCRIPTION
IMO, the README currently doesn't make it super clear how to accomplish this task (installing Juliaup into a custom location).

People ask for this specific task every now and then, so I think that it's worth having a clear example.