### PR TITLE
Don't overwrite body when turning prerelease into release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1213,6 +1213,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         prerelease: false
         allowUpdates: true
+        omitBody: true
 
   deploy-release-channel-crates:
     needs: [create-github-release,package-unix,package-windows-msix,package-windows-msi]


### PR DESCRIPTION
Currently the release process overwrites release notes when converting a GitHub prerelease to a full release, causing manually written or auto-generated notes to be lost.

That just happened to me with some nice release notes I wrote for v1.18.0 when it was prerelease (and github doesn't show you edit history on release notes!)

Solution:
Add `omitBody: true` to the final release step in the workflow. This preserves existing release notes when updating the release instead of overwriting them.