### PR TITLE
Don't show `julia` update messages when not interactive

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -305,7 +305,7 @@ fn check_channel_uptodate(
         })?
         .version;
 
-    if latest_version != current_version {
+    if latest_version != current_version && is_interactive() {
         eprintln!("The latest version of Julia in the `{}` channel is {}. You currently have `{}` installed. Run:", channel, latest_version, current_version);
         eprintln!();
         eprintln!("  juliaup update");
@@ -486,7 +486,7 @@ fn get_julia_path_from_installed_channel(
             server_etag,
             version: _,
         } => {
-            if local_etag != server_etag {
+            if local_etag != server_etag && is_interactive() {
                 if channel.starts_with("nightly") {
                     // Nightly is updateable several times per day so this message will show
                     // more often than not unless folks update a couple of times a day.

--- a/tests/channel_selection.rs
+++ b/tests/channel_selection.rs
@@ -1,4 +1,5 @@
 use predicates::str::contains;
+use predicates::boolean::PredicateBooleanExt;
 
 mod utils;
 use utils::TestEnv;
@@ -183,4 +184,45 @@ fn auto_install_valid_channel() {
         .stderr(contains(
             "Info: Installing Julia 1.10.10 automatically per juliaup settings...",
         ));
+}
+
+#[test]
+fn no_update_messages_in_non_interactive_mode() {
+    let env = TestEnv::new();
+
+    // Set up julia installation
+    env.juliaup()
+        .arg("add")
+        .arg("1.11")
+        .assert()
+        .success();
+
+    env.juliaup()
+        .arg("default")
+        .arg("1.11")
+        .assert()
+        .success();
+
+    // Test that update messages are not shown when using -e flag (non-interactive)
+    env.julia()
+        .arg("-e")
+        .arg("println(\"test\")")
+        .assert()
+        .success()
+        .stderr(
+            contains("new version").not()
+                .and(contains("juliaup update").not())
+                .and(contains("available").not())
+        );
+
+    // Test that update messages are not shown when using --version flag (non-interactive)
+    env.julia()
+        .arg("--version")
+        .assert()
+        .success()
+        .stderr(
+            contains("new version").not()
+                .and(contains("juliaup update").not())
+                .and(contains("available").not())
+        );
 }


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/juliaup/issues/1256

@KristofferC 