### PR TITLE
Fix `is_interactive` args

### DIFF
--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -154,16 +154,13 @@ fn is_interactive() -> bool {
     for arg in julia_args {
         match arg.as_str() {
             // Expression evaluation is non-interactive
-            "-e" | "--eval" => return false,
+            "-e" | "--eval" | "-E" | "--print" => return false,
             // Reading from stdin pipe is non-interactive
             "-" => return false,
-            // Print options are typically non-interactive
-            "-p" | "--print" => return false,
-            // License/version display is non-interactive
-            "-L" | "--license" => return false,
+            // Version display is non-interactive
             "-v" | "--version" => return false,
             // Help is non-interactive
-            "-h" | "--help" => return false,
+            "-h" | "--help" | "--help-hidden" => return false,
             // Check if this looks like a Julia file (ends with .jl)
             filename if filename.ends_with(".jl") && !filename.starts_with('-') => {
                 return false;

--- a/tests/command_update.rs
+++ b/tests/command_update.rs
@@ -123,6 +123,19 @@ fn command_update_outdated_channel() {
                 .and(contains("You currently have").not()),
         );
 
+    env.julia()
+        .arg("+1.10")
+        .arg("-E")
+        .arg("1+1")
+        .assert()
+        .success()
+        .stderr(
+            contains("latest version")
+                .not()
+                .and(contains("juliaup update").not())
+                .and(contains("You currently have").not()),
+        );
+
     env.juliaup().arg("update").arg("1.10").assert().success();
 
     let updated_config_content =


### PR DESCRIPTION
Noticed testing the `releasepreview` 
```
% julia +nightly -e "1+1"
% julia +nightly -E "1+1"
A new `nightly` version is available. Install with `juliaup update`.
2
```

The 2nd shouldn't warn.