### PR TITLE
Don't overwrite body when turning prerelease into release Pt. 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -909,6 +909,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: "public/*.*"
         allowUpdates: true
+        omitBodyDuringUpdate: true
         prerelease: true
 
   deploy-dev-channel-winstore:


### PR DESCRIPTION
There's another place that release notes can be overwritten (just happened again to me)

Continuation of https://github.com/JuliaLang/juliaup/pull/1248