### PR TITLE
Declare "console" subsystem for WindowsApp

### DIFF
--- a/deploy/msix/appxmanifest.xml
+++ b/deploy/msix/appxmanifest.xml
@@ -54,7 +54,7 @@
       </uap:VisualElements>
       <Extensions>
         <uap3:Extension Category="windows.appExecutionAlias" Executable="Julia/julialauncher.exe" EntryPoint="Windows.FullTrustApplication">
-          <uap3:AppExecutionAlias>
+          <uap3:AppExecutionAlias desktop4:Subsystem="console">
             <desktop:ExecutionAlias Alias="julia.exe" />
           </uap3:AppExecutionAlias>
         </uap3:Extension>
@@ -87,7 +87,7 @@
       </uap:VisualElements>
       <Extensions>
         <uap3:Extension Category="windows.appExecutionAlias" Executable="Julia/juliaup.exe" EntryPoint="Windows.FullTrustApplication">
-          <uap3:AppExecutionAlias>
+          <uap3:AppExecutionAlias desktop4:Subsystem="console">
             <desktop:ExecutionAlias Alias="juliaup.exe" />
           </uap3:AppExecutionAlias>
         </uap3:Extension>


### PR DESCRIPTION
With luck, this will resolve https://github.com/JuliaLang/juliaup/issues/1267 and https://github.com/JuliaLang/juliaup/issues/1268 although I have not installed the app locally to verify that yet.

Discovered with help from Claude.