### PR TITLE
Fix Homebrew bump action with explicit tag and revision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1014,6 +1014,8 @@ jobs:
         token: ${{secrets.TOKEN_FOR_HOMEBREW}}
         formula: juliaup
         force: true
+        tag: ${{ github.ref }}
+        revision: ${{ github.sha }}
 
   deploy-release-channel-aur:
     needs: [create-github-release,package-unix,package-windows-msix,package-windows-msi]


### PR DESCRIPTION
Trying to fix this weird failure to publish to brew, https://github.com/JuliaLang/juliaup/actions/runs/18808297234/job/53673368218#step:2:122

Though it mentions 1.18.8 in many places it's failing because 1.18.5 is somehow resolved here..?:
```
Error: You need to bump this formula manually since the new URL
and old URL are both:
  https://github.com/JuliaLang/juliaup/archive/refs/tags/v1.18.5.tar.gz
```

Full log
```
==> Fetching /opt/homebrew...
From https://github.com/Homebrew/brew
 - [deleted]               (none)              -> origin/formula-versions-tap-path
 - [deleted]               (none)              -> origin/pypi-packages-dsl
 - [deleted]               (none)              -> origin/rubocop-md-ignore-copilot-instructions-file
 * [new branch]            audit_revision_and_compatibility_version_relationships -> origin/audit_revision_and_compatibility_version_relationships
 * [new branch]            autobump-audit-skip -> origin/autobump-audit-skip
   14304c59de..0d9b9b42bb  main                -> origin/main
   14304c59de..0d9b9b42bb  master              -> origin/master
 * [new branch]            patches-corrector   -> origin/patches-corrector
 * [new branch]            rm-docker-hub       -> origin/rm-docker-hub
==> Resetting /opt/homebrew...
Switched to and reset branch 'main'
branch 'main' set up to track 'origin/main'.
Your branch is up to date with 'origin/main'.
==> Fetching /opt/homebrew/Library/Taps/aws/homebrew-tap...
==> Resetting /opt/homebrew/Library/Taps/aws/homebrew-tap...
Reset branch 'master'
branch 'master' set up to track 'origin/master'.
Your branch is up to date with 'origin/master'.
==> Fetching /opt/homebrew/Library/Taps/azure/homebrew-bicep...
==> Resetting /opt/homebrew/Library/Taps/azure/homebrew-bicep...
Reset branch 'main'
branch 'main' set up to track 'origin/main'.
Your branch is up to date with 'origin/main'.
==> Fetching /opt/homebrew/Library/Taps/hashicorp/homebrew-tap...
From https://github.com/hashicorp/homebrew-tap
   e677ada..3e099d5  master     -> origin/master
==> Resetting /opt/homebrew/Library/Taps/hashicorp/homebrew-tap...
Reset branch 'master'
branch 'master' set up to track 'origin/master'.
Your branch is up to date with 'origin/master'.
==> Fetching /opt/homebrew/Library/Taps/homebrew/homebrew-cask...
From https://github.com/Homebrew/homebrew-cask
   e1ec6c6c292..152133e8c69  main       -> origin/main
 * [new tag]                 0.1        -> 0.1
 * [new tag]                 0.2        -> 0.2
 * [new tag]                 0.3        -> 0.3
 * [new tag]                 0.4        -> 0.4
 * [new tag]                 0.5        -> 0.5
 * [new tag]                 0.6        -> 0.6
 * [new tag]                 0.7        -> 0.7
 * [new tag]                 0.7.1      -> 0.7.1
 * [new tag]                 0.8        -> 0.8
 * [new tag]                 0.8.1      -> 0.8.1
 * [new tag]                 0.9        -> 0.9
 * [new tag]                 0.9.1      -> 0.9.1
 * [new tag]                 0.9.2      -> 0.9.2
 * [new tag]                 0.9.3      -> 0.9.3
 * [new tag]                 0.9.4      -> 0.9.4
 * [new tag]                 0.9.5      -> 0.9.5
 * [new tag]                 v0.15.0    -> v0.15.0
 * [new tag]                 v0.39.0    -> v0.39.0
 * [new tag]                 v0.45.0    -> v0.45.0
 * [new tag]                 v0.53.2    -> v0.53.2
==> Resetting /opt/homebrew/Library/Taps/homebrew/homebrew-cask...
Reset branch 'main'
branch 'main' set up to track 'origin/main'.
Your branch is up to date with 'origin/main'.
==> Fetching /opt/homebrew/Library/Taps/homebrew/homebrew-core...
From https://github.com/Homebrew/homebrew-core
   d542b51f7e6..c72546383ad  main       -> origin/main
==> Resetting /opt/homebrew/Library/Taps/homebrew/homebrew-core...
Reset branch 'main'
branch 'main' set up to track 'origin/main'.
Your branch is up to date with 'origin/main'.
Run brew ruby $GITHUB_ACTION_PATH/main.rb
  
✔︎ JSON API formula_tap_migrations.jws.json
✔︎ JSON API cask_tap_migrations.jws.json
git config --global user.name David Anthoff
git config --global user.email anthoff@berkeley.edu
/opt/homebrew/bin/brew tap homebrew/core --force
/opt/homebrew/bin/brew --repository
git -C /opt/homebrew apply /Users/runner/work/_actions/dawidd6/action-homebrew-bump-formula/v4/bump-formula-pr.rb.patch
/opt/homebrew/bin/brew bump-formula-pr --no-audit --no-browse --message=[`action-homebrew-bump-formula`](https://github.com/dawidd6/action-homebrew-bump-formula) --version=1.18.8 --force juliaup
Error: You need to bump this formula manually since the new URL
and old URL are both:
  https://github.com/JuliaLang/juliaup/archive/refs/tags/v1.18.5.tar.gz

/opt/homebrew/Library/Homebrew/extend/kernel.rb:67:in 'Kernel#safe_system': Failure while executing; `/opt/homebrew/bin/brew bump-formula-pr --no-audit --no-browse --message=\[\`action-homebrew-bump-formula\`\]\([https://github.com/dawidd6/action-homebrew-bump-formula\](https://github.com/dawidd6/action-homebrew-bump-formula/)) --version=1.18.8 --force juliaup` exited with 1. (ErrorDuringExecution)
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12656/lib/types/private/methods/call_validation.rb:179:in 'UnboundMethod#bind_call'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12656/lib/types/private/methods/call_validation.rb:179:in 'T::Private::Methods::CallValidation.validate_call_skip_block_type'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12656/lib/types/private/methods/call_validation.rb:121:in 'block in Kernel#create_validator_slow_skip_block_type'
	from /Users/runner/work/_actions/dawidd6/action-homebrew-bump-formula/v4/main.rb:26:in 'Homebrew.brew'
	from /Users/runner/work/_actions/dawidd6/action-homebrew-bump-formula/v4/main.rb:114:in '<module:Homebrew>'
	from /Users/runner/work/_actions/dawidd6/action-homebrew-bump-formula/v4/main.rb:17:in '<main>'
Error: Process completed with exit code 1.
```