### PR TITLE
rustfmt CI fixes

### DIFF
--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -36,4 +36,4 @@ jobs:
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: rustfmt
-          fail_on_error: true
+          fail_level: error


### PR DESCRIPTION
@tecosaur 

The other issue is https://github.com/JuliaLang/juliaup/actions/runs/17244028982/job/48928853337?pr=1232#step:6:263

```
reviewdog: This GitHub Token doesn't have write permission of Review API [1],
so reviewdog will report results via logging command [2] and create annotations similar to
github-pr-check reporter as a fallback.
```

So it was incorrectly green and reviewdog comments didn't get posted.

@DilumAluthge can you help resolve the token issue (I don't have settings access)