### PR TITLE
Close config files right after read

### DIFF
--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -4,7 +4,7 @@ use cluFlock::{ExclusiveFlock, FlockLock, SharedFlock};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
-use std::io::{BufReader, ErrorKind, Seek, SeekFrom, Write};
+use std::io::{BufReader, ErrorKind, Write};
 #[cfg(target_os = "windows")]
 use std::mem;
 use tempfile::NamedTempFile;
@@ -296,12 +296,12 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
         }
     };
 
-    let mut file = std::fs::OpenOptions::new()
+    let file = std::fs::OpenOptions::new()
         .read(true)
         .open(&paths.juliaupconfig);
 
     let data = match file {
-        Err(file) => {
+        Err(_file) => {
             let new_config = JuliaupConfig {
                 default: None,
                 installed_versions: HashMap::new(),
@@ -317,7 +317,7 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
 
             new_config
         }
-        _ => {
+        Ok(file) => {
             let reader = BufReader::new(&file);
 
             serde_json::from_reader(reader)

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -332,7 +332,7 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
         self_data = match self_file {
             // TODO Or should we just error when the file can't be read?
             Err(_self_file) => {
-                new_self_config = JuliaupSelfConfig {
+                JuliaupSelfConfig {
                     background_selfupdate_interval: None,
                     startup_selfupdate_interval: None,
                     modify_path: false,

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -299,20 +299,18 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
         .open(&paths.juliaupconfig);
 
     let data = match file {
-        Err(_file) => {
-            JuliaupConfig {
-                default: None,
-                installed_versions: HashMap::new(),
-                installed_channels: HashMap::new(),
-                overrides: Vec::new(),
-                settings: JuliaupConfigSettings {
-                    create_channel_symlinks: false,
-                    versionsdb_update_interval: default_versionsdb_update_interval(),
-                    auto_install_channels: None,
-                },
-                last_version_db_update: None,
-            }
-        }
+        Err(_file) => JuliaupConfig {
+            default: None,
+            installed_versions: HashMap::new(),
+            installed_channels: HashMap::new(),
+            overrides: Vec::new(),
+            settings: JuliaupConfigSettings {
+                create_channel_symlinks: false,
+                versionsdb_update_interval: default_versionsdb_update_interval(),
+                auto_install_channels: None,
+            },
+            last_version_db_update: None,
+        },
         Ok(file) => {
             let reader = BufReader::new(&file);
 
@@ -331,15 +329,13 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
 
         self_data = match self_file {
             // TODO Or should we just error when the file can't be read?
-            Err(_self_file) => {
-                JuliaupSelfConfig {
-                    background_selfupdate_interval: None,
-                    startup_selfupdate_interval: None,
-                    modify_path: false,
-                    juliaup_channel: None,
-                    last_selfupdate: None,
-                }
-            }
+            Err(_self_file) => JuliaupSelfConfig {
+                background_selfupdate_interval: None,
+                startup_selfupdate_interval: None,
+                modify_path: false,
+                juliaup_channel: None,
+                last_selfupdate: None,
+            },
             Ok(self_file) => {
                 let reader = BufReader::new(&self_file);
 

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -300,7 +300,7 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
 
     let data = match file {
         Err(_file) => {
-            let new_config = JuliaupConfig {
+            JuliaupConfig {
                 default: None,
                 installed_versions: HashMap::new(),
                 installed_channels: HashMap::new(),
@@ -311,9 +311,7 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
                     auto_install_channels: None,
                 },
                 last_version_db_update: None,
-            };
-
-            new_config
+            }
         }
         Ok(file) => {
             let reader = BufReader::new(&file);
@@ -334,15 +332,13 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
         self_data = match self_file {
             // TODO Or should we just error when the file can't be read?
             Err(_self_file) => {
-                let new_self_config = JuliaupSelfConfig {
+                new_self_config = JuliaupSelfConfig {
                     background_selfupdate_interval: None,
                     startup_selfupdate_interval: None,
                     modify_path: false,
                     juliaup_channel: None,
                     last_selfupdate: None,
-                };
-                
-                new_self_config
+                }
             }
             Ok(self_file) => {
                 let reader = BufReader::new(&self_file);

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -5,8 +5,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, ErrorKind, Write};
-#[cfg(target_os = "windows")]
-use std::mem;
 use tempfile::NamedTempFile;
 
 use crate::global_paths::GlobalPaths;

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -143,11 +143,8 @@ pub struct JuliaupSelfConfig {
 }
 
 pub struct JuliaupConfigFile {
-    pub file: File,
     pub lock: FlockLock<File>,
     pub data: JuliaupConfig,
-    #[cfg(feature = "selfupdate")]
-    pub self_file: File,
     #[cfg(feature = "selfupdate")]
     pub self_data: JuliaupSelfConfig,
 }
@@ -301,18 +298,10 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
 
     let mut file = std::fs::OpenOptions::new()
         .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(&paths.juliaupconfig)
-        .with_context(|| "Failed to open juliaup config file.")?;
+        .open(&paths.juliaupconfig);
 
-    let stream_len = file
-        .seek(SeekFrom::End(0))
-        .with_context(|| "Failed to determine the length of the configuration file.")?;
-
-    let data = match stream_len {
-        0 => {
+    let data = match file {
+        Err(file) => {
             let new_config = JuliaupConfig {
                 default: None,
                 installed_versions: HashMap::new(),
@@ -326,21 +315,9 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
                 last_version_db_update: None,
             };
 
-            serde_json::to_writer_pretty(&file, &new_config)
-                .with_context(|| "Failed to write configuration file.")?;
-
-            file.sync_all()
-                .with_context(|| "Failed to write configuration data to disc.")?;
-
-            file.rewind()
-                .with_context(|| "Failed to rewind config file after initial write of data.")?;
-
             new_config
         }
         _ => {
-            file.rewind()
-                .with_context(|| "Failed to rewind existing config file.")?;
-
             let reader = BufReader::new(&file);
 
             serde_json::from_reader(reader)
@@ -371,7 +348,6 @@ pub fn load_mut_config_db(paths: &GlobalPaths) -> Result<JuliaupConfigFile> {
     }
 
     let result = JuliaupConfigFile {
-        file,
         lock: file_lock,
         data,
         #[cfg(feature = "selfupdate")]
@@ -415,37 +391,10 @@ pub fn save_config_db(juliaup_config_file: &mut JuliaupConfigFile) -> Result<()>
         .sync_all()
         .with_context(|| "Failed to sync configuration data to disc.")?;
 
-    // On Windows, we must close the file before replacing it
-    // On Unix, the file can remain open during atomic rename
-    #[cfg(target_os = "windows")]
-    {
-        // Create a dummy file to replace the handle we need to close
-        let dummy = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(config_dir.join(".dummy"))
-            .with_context(|| "Failed to create dummy file handle.")?;
-
-        // Replace the file handle with the dummy, dropping the old handle
-        let _ = mem::replace(&mut juliaup_config_file.file, dummy);
-    }
-
     // Atomically replace the old config file with the new one
     temp_file
         .persist(&paths.juliaupconfig)
         .with_context(|| "Failed to persist configuration file.")?;
-
-    // Reopen the file to update our file handle (Windows only, since we closed it)
-    #[cfg(target_os = "windows")]
-    {
-        juliaup_config_file.file = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&paths.juliaupconfig)
-            .with_context(|| "Failed to reopen configuration file after save.")?;
-    }
 
     #[cfg(feature = "selfupdate")]
     {


### PR DESCRIPTION
I think this probably should work because we now have a separate lock file that handles all concurrency.

WIP at the moment.