### PR TITLE
add a pre commit file for running formatting and linting checks that would otherwise fail build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+        name: cargo fmt
+        description: Format Rust code with rustfmt
+        entry: cargo fmt --all --
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-check
+        name: cargo check
+        description: Check Rust code with cargo check
+        entry: cargo check
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: clippy
+        name: cargo clippy
+        description: Lint Rust code with clippy
+        entry: bash -c 'cargo clippy --workspace -- -D warnings'
+        language: system
+        types: [rust]
+        pass_filenames: false


### PR DESCRIPTION
https://pre-commit.com/

I keep forgetting to manually run e.g. `cargo fmt`