### PR TITLE
Pin quality checks to the same rust toolchain

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.90.0
           components: clippy
       - name: Run clippy
         run: cargo clippy --workspace --features ${{ matrix.features }} -- -D warnings

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.90.0
           components: rustfmt
       - name: Rustfmt check
         if: ${{ github.event_name != 'pull_request' }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.90.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This makes clippy CI, rustfmt CI and the precommit hook use the same rust toolchain version, which is now written in only one place.

Without this you can easily end up with disagreement between local and CI results.