### PR TITLE
check nightlies/pr features with etag avalibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ the `JULIAUP_DEPOT_PATH` environment variable. Caution: Previous versions of Jul
 Juliaup by default downloads julia binary tarballs from the official server "https://julialang-s3.julialang.org".
 If requested, the environment variable `JULIAUP_SERVER` can be used to tell Juliaup to use a third-party mirror server.
 
+**Note:** Nightly and PR channels (e.g., `nightly`, `pr123`) require the server to provide `etag` headers in HTTP responses for version tracking.
+If your custom mirror server does not support `etag` headers, these channels will not be available. Regular versioned Julia releases will still work normally.
+
 ## Development guides
 
 For juliaup developers, information on how to build juliaup locally, update julia versions, and release updates

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -10,6 +10,7 @@ use crate::get_bundled_julia_version;
 use crate::get_juliaup_target;
 use crate::global_paths::GlobalPaths;
 use crate::jsonstructs_versionsdb::JuliaupVersionDB;
+use crate::utils::check_server_supports_nightlies;
 use crate::utils::get_bin_dir;
 use crate::utils::get_julianightlies_base_url;
 use crate::utils::get_juliaserver_base_url;
@@ -168,13 +169,13 @@ pub fn download_extract_sans_parent(
     pb.set_prefix(DOWNLOADING_PREFIX);
     pb.set_style(bar_style());
 
-    let last_modified = match response
+    // Extract etag if present, otherwise return empty string
+    // Empty etag is valid for regular version installs from servers without etag support
+    let last_modified = response
         .headers()
-        .get("etag") {
-            Some(etag) => Ok(etag.to_str().unwrap().to_string()),
-            None => Err(anyhow!(format!("Failed to get etag from `{}`.\n\
-                This is likely due to requesting a pull request that does not have a cached build available. You may have to build locally.", url))),
-        }?;
+        .get("etag")
+        .map(|etag| etag.to_str().unwrap_or("").to_string())
+        .unwrap_or_default();
 
     let response_with_pb = pb.wrap_read(response);
 
@@ -226,15 +227,16 @@ pub fn download_extract_sans_parent(
 
     http_response
         .EnsureSuccessStatusCode()
-        .with_context(|| format!("Failed to get etag from `{}`.\n\
-            This is likely due to requesting a pull request that does not have a cached build available. You may have to build locally.", url))?;
+        .with_context(|| format!("Failed to download from `{}`.", url))?;
 
+    // Extract etag if present, otherwise return empty string
+    // Empty etag is valid for regular version installs from servers without etag support
     let last_modified = http_response
         .Headers()
-        .unwrap()
-        .Lookup(&HSTRING::from("etag"))
-        .unwrap()
-        .to_string();
+        .ok()
+        .and_then(|headers| headers.Lookup(&HSTRING::from("etag")).ok())
+        .map(|etag| etag.to_string())
+        .unwrap_or_default();
 
     let http_response_content = http_response
         .Content()
@@ -653,6 +655,17 @@ pub fn install_from_url(
         }
     };
 
+    // Nightly and PR channels require etag for version tracking
+    // If etag is empty, the server doesn't support this functionality
+    if server_etag.is_empty() {
+        std::fs::remove_dir_all(temp_dir.path())?;
+        bail!(
+            "The server did not provide an etag header, which is required for nightly and PR channels.\n\
+            This is likely due to requesting a pull request that does not have a cached build available, \
+            or using a server that does not support etag headers. You may have to build locally."
+        );
+    }
+
     // Query the actual version
     let julia_path = temp_dir
         .path()
@@ -692,6 +705,14 @@ pub fn install_non_db_version(
     name: &String,
     paths: &GlobalPaths,
 ) -> Result<crate::config_file::JuliaupConfigChannel> {
+    // Check if the nightly server supports etag headers (required for nightly/PR channels)
+    if !check_server_supports_nightlies()? {
+        bail!(
+            "The configured nightly server does not support etag headers, which are required for nightly and PR channels.\n\
+            Nightly and PR channels cannot be installed from this server."
+        );
+    }
+
     // Determine the download URL
     let download_url_base = get_julianightlies_base_url()?;
 
@@ -1639,6 +1660,9 @@ fn download_direct_download_etags(
     use windows::Web::Http::HttpMethod;
     use windows::Web::Http::HttpRequestMessage;
 
+    // Check if the server supports etag headers (required for nightly/PR updates)
+    let server_supports_etag = check_server_supports_nightlies().unwrap_or(false);
+
     let http_client = HttpClient::new().with_context(|| "Failed to create HttpClient.")?;
 
     let mut requests = Vec::new();
@@ -1652,6 +1676,13 @@ fn download_direct_download_etags(
         }
 
         if let JuliaupConfigChannel::DirectDownloadChannel { url, .. } = installed_channel {
+            // If server doesn't support etag, we can't check for updates on nightly/PR channels
+            // Return None gracefully so the update process can continue with other channels
+            if !server_supports_etag {
+                requests.push((channel_name.clone(), None));
+                continue;
+            }
+
             let http_client = http_client.clone();
             let url_clone = url.clone();
             let channel_name_clone = channel_name.clone();
@@ -1678,16 +1709,14 @@ fn download_direct_download_etags(
                         .map_err(|e| anyhow!("Failed to get response: {:?}", e))?;
 
                     if response.IsSuccessStatusCode()? {
-                        let headers = response
+                        // Gracefully handle missing etag - return None instead of error
+                        let etag = response
                             .Headers()
-                            .map_err(|e| anyhow!("Failed to get headers: {:?}", e))?;
+                            .ok()
+                            .and_then(|headers| headers.Lookup(&HSTRING::from("ETag")).ok())
+                            .map(|s| s.to_string());
 
-                        let etag = headers
-                            .Lookup(&HSTRING::from("ETag"))
-                            .map_err(|e| anyhow!("ETag header not found: {:?}", e))?
-                            .to_string();
-
-                        Ok::<Option<String>, anyhow::Error>(Some(etag))
+                        Ok::<Option<String>, anyhow::Error>(etag)
                     } else {
                         Ok::<Option<String>, anyhow::Error>(None)
                     }
@@ -1710,6 +1739,9 @@ fn download_direct_download_etags(
 ) -> Result<Vec<(String, Option<String>)>> {
     use std::sync::Arc;
 
+    // Check if the server supports etag headers (required for nightly/PR updates)
+    let server_supports_etag = check_server_supports_nightlies().unwrap_or(false);
+
     let client = Arc::new(reqwest::blocking::Client::new());
 
     let mut requests = Vec::new();
@@ -1723,6 +1755,13 @@ fn download_direct_download_etags(
         }
 
         if let JuliaupConfigChannel::DirectDownloadChannel { url, .. } = installed_channel {
+            // If server doesn't support etag, we can't check for updates on nightly/PR channels
+            // Return None gracefully so the update process can continue with other channels
+            if !server_supports_etag {
+                requests.push((channel_name.clone(), None));
+                continue;
+            }
+
             let client = Arc::clone(&client);
             let url_clone = url.clone();
             let channel_name_clone = channel_name.clone();
@@ -1740,17 +1779,14 @@ fn download_direct_download_etags(
                     })?;
 
                     if response.status().is_success() {
+                        // Gracefully handle missing etag - return None instead of error
                         let etag = response
                             .headers()
                             .get("etag")
-                            .ok_or_else(|| {
-                                anyhow!("ETag header not found in response from {}", &url_clone)
-                            })?
-                            .to_str()
-                            .map_err(|e| anyhow!("Failed to parse ETag header: {}", e))?
-                            .to_string();
+                            .and_then(|h| h.to_str().ok())
+                            .map(|s| s.to_string());
 
-                        Ok::<Option<String>, anyhow::Error>(Some(etag))
+                        Ok::<Option<String>, anyhow::Error>(etag)
                     } else {
                         Ok::<Option<String>, anyhow::Error>(None)
                     }


### PR DESCRIPTION
Users in China often don't have a stable connection to AWS S3, so mirror sites like https://mirrors.tuna.tsinghua.edu.cn exist; they are typically simple static-file HTTP servers and don't have advanced S3-like features such as etags.

Previously, we have provided the JULIAUP_SERVER feature to change the download baseurl, but at that time, I didn't realize that the server mirror should support ETag.

This commit introduces a server feature check operation for custom JULIAUP_SERVER:

* if JULIAUP_SERVER equals the default official ones, it works as usual. No extra overhead.
* Otherwise, send a HEAD check request and set the NIGHTLY_SERVER_SUPPORTS_ETAG feature flag

If this feature flag is false, then the PR/nightlies download will be disabled. This doesn't affect the mirror sites because they don't support mirroring Julia nightlies deliberately; too few people use it, and it consumes too much unnecessary sync bandwidth.

Known JuliaUp mirror sites in China that can be used to test:

https://mirrors.ustc.edu.cn/juliaup-releases
https://mirrors.tuna.tsinghua.edu.cn/juliaup-releases https://mirrors.bfsu.edu.cn/juliaup-releases

This commit makes it work for the above mirror sites and thus fixes #917.

Disclaimer: This commit is primarily generated by AI (cursor + claude 4.5 opus). I've tested it locally on Windows and Linux, and it works as expected. MacOS is not tested.

Example: PR/nightlies features are disabled with a proper error message:

```
❯ target/debug/juliaup add nightly
Error: The configured nightly server does not support etag headers, which are required for nightly and PR channels.
Nightly and PR channels cannot be installed from this server.

❯ target/debug/julia +nightly
Question: The Juliaup channel 'nightly' is not installed. Would you like to install it?: Yes (install this time only)
Installing Julia nightly as requested
Error: The configured nightly server does not support etag headers, which are required for nightly and PR channels.
Nightly and PR channels cannot be installed from this server.
Error: The Julia launcher failed to determine the command for the `nightly` channel.

Caused by:
Failed to install channel 'nightly'. juliaup add command failed with exit code: Some(1)
```

Example: normal release download just works

```
❯ target/debug/juliaup add 1.10
Checking for new Julia versions
Installing Julia 1.10.10+0.x64.linux.gnu
DEBUG: Starting download from URL: https://mirrors.ustc.edu.cn/julia-releases/bin/linux/x64/1.10/julia-1.10.10-linux-x86_64.tar.gz
Downloading ━━━━━━━━━━━━━━━━━━━━━━━━╸ 165.61 MiB/165.79 MiB eta: 0s
Add Installed Julia channel '1.10'
```

closes #917