### PR TITLE
Fix x86_64 macOS CI to use macos intel runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
             target: x86_64-apple-darwin
             bins: --bin juliaup --bin julialauncher --bin juliainstaller
             os: macos
-            runner: macos-13
+            runner: macos-15-intel
             features: selfupdate,binjuliainstaller,binjulialauncher
             rustflags:
             toolchain: stable
@@ -98,7 +98,7 @@ jobs:
             target: x86_64-apple-darwin
             bins: --bin juliaup --bin julia
             os: macos
-            runner: macos-13
+            runner: macos-15-intel
             features: dummy
             rustflags:
             toolchain: stable
@@ -298,7 +298,7 @@ jobs:
             toolchain: stable-gnu
           - target: x86_64-apple-darwin
             os: macos
-            runner: macos-13
+            runner: macos-15-intel
             features: dummy,binjulialauncher
             rustflags:
             toolchain: stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           - label: x86_64-apple-darwin
             target: x86_64-apple-darwin
             os: macos
-            runner: macos-13
+            runner: macos-15-intel
             features: selfupdate,binjuliainstaller,binjulialauncher
             rustflags:
           - label: x86_64-unknown-linux-gnu
@@ -175,7 +175,7 @@ jobs:
             toolchain: stable-gnu
           - target: x86_64-apple-darwin
             os: macos
-            runner: macos-13
+            runner: macos-15-intel
             features: dummy,binjulialauncher
             rustflags:
             toolchain: stable


### PR DESCRIPTION
Use explicit runner field in matrix instead of ${{ matrix.os }}-latest to ensure x86_64-apple-darwin targets run on macos-13 (x86_64) instead of macos-latest (which is now ARM64). This avoids running x86 binaries under Rosetta emulation.