### PR TITLE
Fix FreeBSD CI: extract Rust version from rust-toolchain.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,7 +251,8 @@ jobs:
         memory: '12G'
         shell: sh
         run: |
-          fetch https://sh.rustup.rs -o - | sh -s -- -y --default-toolchain ${{matrix.toolchain}}
+          RUST_VERSION=$(grep '^channel = ' rust-toolchain.toml | sed 's/channel = "\(.*\)"/\1/')
+          fetch https://sh.rustup.rs -o - | sh -s -- -y --default-toolchain "$RUST_VERSION" --profile minimal
           . "${HOME}/.cargo/env"
           export RUST_BACKTRACE=full
           cargo test --target ${{matrix.target}} --features ${{matrix.features}}


### PR DESCRIPTION
- Extract Rust version dynamically from rust-toolchain.toml instead of hardcoding or using matrix.toolchain
- Use minimal profile to avoid installing rustfmt/clippy which were causing segfaults during installation in FreeBSD VM
- Prevents double installation (stable then 1.90.0) by using the correct version from the start