### PR TITLE
Fix installer crash on permission errors

### DIFF
--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -498,13 +498,6 @@ pub fn main() -> Result<()> {
 
         paths.juliaupselfbin = juliaupselfbin.clone();
         paths.juliaupselfconfig = self_config_path.clone();
-        // Update the main config paths to point to the installation location
-        paths.juliauphome = install_choices.install_location.clone();
-        paths.juliaupconfig = install_choices.install_location.join("juliaup.json");
-        paths.lockfile = install_choices.install_location.join(".juliaup-lock");
-        paths.versiondb = install_choices
-            .install_location
-            .join(format!("versiondb-{}.json", juliaup_target));
     }
 
     run_command_config_backgroundselfupdate(


### PR DESCRIPTION
Fixes #1393 
Fixes #1395

This PR addresses installer crashes on Linux systems with filesystem restrictions, SELinux, or permission issues.

## Changes

1. **Replace `.unwrap()` calls with proper error handling**: The installer now provides informative error messages instead of panicking when configuration operations fail.

~2. **Fix installer writing to wrong directory**: Update all global paths to point to the installation location (`~/.juliaup`) after creating the install directory. Previously, the installer would attempt to write configuration files to `~/.julia/juliaup` (the default Julia package directory) even when installing to `~/.juliaup`, causing 'Operation not permitted' errors on systems with filesystem restrictions, SELinux policies, or cross-filesystem temp file issues.~

These changes ensure the installer works correctly on systems with stricter security policies and filesystem configurations.

Developed with Claude