### PR TITLE
macOS: codesign all Mach-O binaries in PR builds & check notarization

### DIFF
--- a/src/command_add.rs
+++ b/src/command_add.rs
@@ -1,11 +1,7 @@
 use crate::config_file::{load_mut_config_db, save_config_db, JuliaupConfigChannel};
 use crate::global_paths::GlobalPaths;
-#[cfg(target_os = "macos")]
-use crate::operations::codesign_pr_build_if_needed;
 #[cfg(not(windows))]
 use crate::operations::create_symlink;
-#[cfg(target_os = "macos")]
-use crate::operations::is_pr_channel;
 use crate::operations::{
     channel_to_name, install_non_db_version, install_version, update_version_db,
 };
@@ -106,7 +102,7 @@ fn add_non_db(channel: &str, paths: &GlobalPaths) -> Result<()> {
             "\nWARNING: Note that unmerged PRs may not have been reviewed for security issues etc."
         );
         eprintln!(
-            "Review code at https://github.com/JuliaLang/julia/pull/{}\n",
+            "         Review code at https://github.com/JuliaLang/julia/pull/{}\n",
             pr_number
         );
     }
@@ -132,15 +128,6 @@ fn add_non_db(channel: &str, paths: &GlobalPaths) -> Result<()> {
     #[cfg(not(windows))]
     if config_file.data.settings.create_channel_symlinks {
         create_symlink(&config_channel, &format!("julia-{}", channel), paths)?;
-    }
-
-    // Handle codesigning for PR builds on macOS
-    #[cfg(target_os = "macos")]
-    if is_pr_channel(channel) {
-        if let Err(e) = codesign_pr_build_if_needed(channel, paths) {
-            eprintln!("\nWarning: Codesigning failed: {}", e);
-            eprintln!("The Julia binary may not run without manual codesigning.");
-        }
     }
 
     print_juliaup_style(

--- a/src/command_update.rs
+++ b/src/command_update.rs
@@ -2,13 +2,9 @@ use crate::config_file::JuliaupConfig;
 use crate::config_file::{load_mut_config_db, save_config_db, JuliaupConfigChannel};
 use crate::global_paths::GlobalPaths;
 use crate::jsonstructs_versionsdb::JuliaupVersionDB;
-#[cfg(target_os = "macos")]
-use crate::operations::codesign_pr_build_if_needed;
 #[cfg(not(windows))]
 use crate::operations::create_symlink;
-#[cfg(target_os = "macos")]
-use crate::operations::is_pr_channel;
-use crate::operations::{garbage_collect_versions, install_from_url};
+use crate::operations::{garbage_collect_versions, install_from_url, is_pr_channel};
 use crate::operations::{install_version, update_version_db};
 use crate::utils::{print_juliaup_style, JuliaupMessageType};
 use crate::versions_file::load_versions_db;
@@ -54,8 +50,12 @@ fn update_channel(
                     JuliaupMessageType::Progress,
                 );
 
-                let channel_data =
-                    install_from_url(&url::Url::parse(url)?, &PathBuf::from(path), paths)?;
+                let channel_data = install_from_url(
+                    &url::Url::parse(url)?,
+                    &PathBuf::from(path),
+                    is_pr_channel(channel),
+                    paths,
+                )?;
 
                 config_db
                     .installed_channels
@@ -74,15 +74,6 @@ fn update_channel(
                         channel,
                         paths,
                     )?;
-                }
-
-                // Handle codesigning for PR builds on macOS
-                #[cfg(target_os = "macos")]
-                if is_pr_channel(channel) {
-                    if let Err(e) = codesign_pr_build_if_needed(channel, paths) {
-                        eprintln!("\nWarning: Codesigning failed: {}", e);
-                        eprintln!("The Julia binary may not run without manual codesigning.");
-                    }
                 }
             }
         }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -642,9 +642,25 @@ pub fn channel_to_name(channel: &str) -> Result<String> {
     Ok(version.to_string() + "-" + os_arch_suffix)
 }
 
+fn query_julia_version(julia_path: &Path) -> Result<String> {
+    let output = std::process::Command::new(julia_path)
+        .arg("--startup-file=no")
+        .arg("-e")
+        .arg("print(VERSION)")
+        .output()
+        .with_context(|| {
+            format!(
+                "Failed to execute Julia binary at `{}`.",
+                julia_path.display()
+            )
+        })?;
+    Ok(String::from_utf8(output.stdout)?)
+}
+
 pub fn install_from_url(
     url: &Url,
     path: &PathBuf,
+    #[cfg_attr(not(target_os = "macos"), allow(unused))] is_pr: bool,
     paths: &GlobalPaths,
 ) -> Result<crate::config_file::JuliaupConfigChannel> {
     // Check if the nightly server supports etag headers (required for nightly/PR channels)
@@ -674,23 +690,32 @@ pub fn install_from_url(
         }
     };
 
+    // On macOS, PR builds are unsigned. Gatekeeper blocks unsigned binaries,
+    // which would hang the version query below. Prompt the user to codesign.
+    #[cfg(target_os = "macos")]
+    let did_codesign = if is_pr {
+        prompt_and_codesign_pr_build(temp_dir.path())?
+    } else {
+        true // official nightlies are already signed
+    };
+
     // Query the actual version
     let julia_path = temp_dir
         .path()
         .join("bin")
         .join(format!("julia{}", std::env::consts::EXE_SUFFIX));
-    let julia_process = std::process::Command::new(julia_path.clone())
-        .arg("--startup-file=no")
-        .arg("-e")
-        .arg("print(VERSION)")
-        .output()
-        .with_context(|| {
-            format!(
-                "Failed to execute Julia binary at `{}`.",
-                julia_path.display()
-            )
-        })?;
-    let julia_version = String::from_utf8(julia_process.stdout)?;
+
+    #[cfg(target_os = "macos")]
+    let julia_version = if did_codesign {
+        let version = query_julia_version(&julia_path)?;
+        check_stdlib_notarization(&julia_path);
+        version
+    } else {
+        String::new()
+    };
+
+    #[cfg(not(target_os = "macos"))]
+    let julia_version = query_julia_version(&julia_path)?;
 
     // Move into the final location
     let target_path = paths.juliauphome.join(path);
@@ -834,7 +859,7 @@ pub fn install_non_db_version(
         JuliaupMessageType::Progress,
     );
 
-    let res = install_from_url(&download_url, &rel_path, paths)?;
+    let res = install_from_url(&download_url, &rel_path, is_pr_channel(channel), paths)?;
 
     Ok(res)
 }
@@ -1812,11 +1837,11 @@ fn download_direct_download_etags(
 }
 
 #[cfg(target_os = "macos")]
-pub fn codesign_pr_build_if_needed(channel: &str, paths: &GlobalPaths) -> Result<()> {
+fn prompt_and_codesign_pr_build(dir: &Path) -> Result<bool> {
     use std::io::{self, Write};
 
     eprintln!("\nWARNING: PR builds are not code-signed for macOS.");
-    eprintln!("The Julia binary will fail to run unless you codesign it locally.");
+    eprintln!("         The Julia binary will fail to run unless you codesign it locally.");
     eprint!("\nWould you like to automatically codesign this PR build now? [Y/n]: ");
     io::stderr().flush()?;
 
@@ -1825,47 +1850,49 @@ pub fn codesign_pr_build_if_needed(channel: &str, paths: &GlobalPaths) -> Result
     let input = input.trim().to_lowercase();
 
     if input == "n" || input == "no" {
-        let dir_name = format!("julia-{}", channel);
         eprintln!("\nSkipping codesigning. You can manually codesign later with:");
         eprintln!(
-            "  codesign --force --sign - {}/{}/bin/julia",
-            paths.juliauphome.display(),
-            dir_name
+            "  find {} -type f -perm +111 -exec codesign --force --sign - {{}} \\;",
+            dir.display()
         );
-        eprintln!(
-            "  codesign --force --sign - {}/{}/lib/libjulia.*.dylib",
-            paths.juliauphome.display(),
-            dir_name
-        );
-        return Ok(());
+        return Ok(false);
     }
 
-    let julia_dir = paths.juliauphome.join(format!("julia-{}", channel));
-    let julia_bin = julia_dir.join("bin").join("julia");
-
-    eprintln!("\nCodesigning Julia binary...");
-    codesign_file(&julia_bin)?;
-
-    // Find and codesign libjulia dylib
-    eprintln!("Codesigning Julia library...");
-    let lib_dir = julia_dir.join("lib");
-    if lib_dir.exists() {
-        for entry in std::fs::read_dir(&lib_dir)? {
-            let path = entry?.path();
-            if let Some(name) = path.file_name().and_then(|f| f.to_str()) {
-                if name.starts_with("libjulia.") && name.ends_with(".dylib") {
-                    codesign_file(&path)?;
+    eprintln!("\nCodesigning all Mach-O binaries...");
+    let mut signed_count = 0u32;
+    let mut dirs_to_visit = vec![dir.to_path_buf()];
+    while let Some(current) = dirs_to_visit.pop() {
+        let entries = match std::fs::read_dir(&current) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+            if path.is_dir() {
+                // Skip dSYM bundles and precompiled cache
+                if !path.to_string_lossy().ends_with(".dSYM")
+                    && !path.ends_with("share/julia/compiled")
+                {
+                    dirs_to_visit.push(path);
                 }
+                continue;
+            }
+            if !path.is_file() {
+                continue;
+            }
+            let is_executable = entry
+                .metadata()
+                .map(|m| m.permissions().mode() & 0o111 != 0)
+                .unwrap_or(false);
+            let is_dylib = path.extension().map(|e| e == "dylib").unwrap_or(false);
+            if is_executable || is_dylib {
+                codesign_file(&path)?;
+                signed_count += 1;
             }
         }
     }
-
-    eprintln!("✓ Codesigning completed successfully.");
-
-    // Run stdlib notarization check
-    check_stdlib_notarization(&julia_bin);
-
-    Ok(())
+    eprintln!("\u{2713} Codesigning completed successfully ({signed_count} files).");
+    Ok(true)
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
PR builds on macOS were only codesigning bin/julia and lib/libjulia.*.dylib, leaving ~270 other Mach-O files unsigned. On Apple Silicon, unsigned executables are killed by the kernel, causing failures when Julia tries to invoke tools like lld during package precompilation.

Rewrite codesign_pr_build_if_needed to recursively walk the entire Julia installation directory and sign all executable files and .dylib files, except for stdlibs as it breaks the .ji checksums.