### PR TITLE
Pin cross-rs i686-unknown-linux-gnu image to fix GLIBC_2.28 build failure

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,6 @@
+# The cross-rs 0.2.5 image for i686-unknown-linux-gnu (from ~2022) ships
+# glibc 2.27, too old for modern Rust build scripts (need >= 2.28).
+# Pin to a newer image by digest until cross-rs releases 0.2.6.
+# See: https://github.com/cross-rs/cross/issues/724
+[target.i686-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/i686-unknown-linux-gnu@sha256:dbaac6e686550f3704402c126c60b82ca9a9c7329e89ea115289ecc7ba0bdbce"


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/juliaup/actions/runs/21790460682/job/62870562271

```
warning: file `/project/src/bin/julialauncher.rs` found to be present in multiple build targets:
  * `bin` target `julia`
  * `bin` target `julialauncher`
   Compiling memchr v2.7.6
   Compiling libc v0.2.180
   Compiling cfg-if v1.0.4
   Compiling once_cell v1.21.3
error: failed to run custom build command for `libc v0.2.180`

Caused by:
  process didn't exit successfully: `/target/release/build/libc-9d40498c81809ea2/build-script-build` (exit status: 1)
  --- stderr
  /target/release/build/libc-9d40498c81809ea2/build-script-build: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /target/release/build/libc-9d40498c81809ea2/build-script-build)
  /target/release/build/libc-9d40498c81809ea2/build-script-build: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found (required by /target/release/build/libc-9d40498c81809ea2/build-script-build)
  /target/release/build/libc-9d40498c81809ea2/build-script-build: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.30' not found (required by /target/release/build/libc-9d40498c81809ea2/build-script-build)
warning: build failed, waiting for other jobs to finish...
```

The cross-rs 0.2.5 Docker image for i686-unknown-linux-gnu ships glibc 2.27, which is too old for modern Rust build scripts. This causes CI to fail with:
  /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.28' not found

Pin the image by SHA256 digest to a newer build until cross-rs releases 0.2.6. See: https://github.com/cross-rs/cross/issues/724