### PR TITLE
Use the `--verbose` flag for Cargo on FreeBSD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,8 +266,10 @@ jobs:
           rm -rf target
           rm -rf ~/.cargo/registry/cache
           rm -rf ~/.cargo/git/db
+          pkg clean -y
           df -h
-          CARGO_INCREMENTAL=0 cargo build --release ${{matrix.bins}} --target ${{matrix.target}} --features ${{matrix.features}}
+          export CARGO_INCREMENTAL=0
+          cargo build --verbose --release ${{matrix.bins}} --target ${{matrix.target}} --features ${{matrix.features}}
     - uses: actions/upload-artifact@v6
       with:
         name: juliaup-${{matrix.label}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,5 +271,7 @@ jobs:
           rm -rf target
           rm -rf ~/.cargo/registry/cache
           rm -rf ~/.cargo/git/db
+          pkg clean -y
           df -h
-          CARGO_INCREMENTAL=0 cargo test --target ${{matrix.target}} --features ${{matrix.features}}
+          export CARGO_INCREMENTAL=0
+          cargo test --verbose --target ${{matrix.target}} --features ${{matrix.features}}


### PR DESCRIPTION
Also clean the FreeBSD package manager's cache, in case that might help with the disk space thing. (EDIT: It doesn't)

The `--verbose` flag will hopefully show us what's happening when we get a completely unexplained [segfault](https://github.com/JuliaLang/juliaup/actions/runs/21790460682/job/62868862320). FWIW I had never seen that segfault before, which makes me wonder whether there's something about `CARGO_INCREMENTAL=0` that it doesn't like?