### PR TITLE
 ci: add submission monitor to msstore release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1064,7 +1064,8 @@ jobs:
         $sec = ConvertTo-SecureString $env:CLIENTSECRET -AsPlainText -Force
         $cred = New-Object System.Management.Automation.PSCredential $env:CLIENTID, $sec
         Set-StoreBrokerAuthentication -TenantId $env:TENANTID -Credential $cred
-        Update-ApplicationSubmission -ReplacePackages -AppId 9NJNWW8PVKMN -SubmissionDataPath ".\Upload.json" -PackagePath ".\Upload.zip" -AutoCommit -Force
+        $subid, $uploadurl = Update-ApplicationSubmission -ReplacePackages -AppId 9NJNWW8PVKMN -SubmissionDataPath ".\Upload.json" -PackagePath ".\Upload.zip" -AutoCommit -Force
+        Start-SubmissionMonitor -AppId 9NJNWW8PVKMN -SubmissionId $subid
 
   deploy-release-channel-brew:
     needs: [create-github-release,package-unix,package-windows-msix,package-windows-msi]


### PR DESCRIPTION
We're trying to debug why the release to the msstore fails. 
- first commit in this PR adds a `SubmissionMonitor` for the store submission, which seems like a good idea regardless (and will hopefully show what the issue is).
- second commit adds a new deployment action to exfiltrate the `CLIENTID` and `TENANTID` secrets as base64 encoded strings, because we aren't 100% sure which account is being used for this

cc @aviks 