### PR TITLE
Switch tests from 1.11-nightly to 1.10-nightly

### DIFF
--- a/tests/command_add.rs
+++ b/tests/command_add.rs
@@ -23,7 +23,7 @@ fn command_add() {
 
     env.juliaup()
         .arg("add")
-        .arg("1.11-nightly")
+        .arg("1.10-nightly")
         .assert()
         .success()
         .stdout("");


### PR DESCRIPTION
It seems that there are no more 1.11-nightly builds, causing CI failures for juliaup.
