### PR TITLE
Fix `install_version` skipping download when files are missing from disk

### DIFF
--- a/src/operations.rs
+++ b/src/operations.rs
@@ -735,9 +735,14 @@ pub fn install_version(
     version_db: &JuliaupVersionDB,
     paths: &GlobalPaths,
 ) -> Result<()> {
-    // Return immediately if the version is already installed.
-    if config_data.installed_versions.contains_key(fullversion) {
-        return Ok(());
+    // Return immediately if the version is already installed and the directory exists on disk.
+    if let Some(existing) = config_data.installed_versions.get(fullversion) {
+        let existing_path = paths.juliauphome.join(&existing.path);
+        if existing_path.exists() {
+            return Ok(());
+        }
+        // Directory is missing on disk, remove stale entry and re-install.
+        config_data.installed_versions.remove(fullversion);
     }
 
     // TODO At some point we could put this behind a conditional compile, we know


### PR DESCRIPTION
This felt annoying:

```
❯ juliaup rm 1.12.6      
    Deleting symlink julia-1.12.6.
      Tidyup No unused Julia installations to clean up.
      Remove Julia channel '1.12.6' successfully removed.

❯ juliaup add 1.12.6
    Checking for new Julia versions
         Add Installed Julia channel '1.12.6'

❯ julia +1.12.6                         
Error: The Julia launcher failed to determine the command for the `1.12.6` channel.

Caused by:
    0: Failed to normalize path for Julia binary, starting from `/Users/kc/.julia/juliaup/juliaup.json`.
    1: No such file or directory (os error 2)
```

I think `add` should check that the folder exist and otherwise redownload. That is what this PR does. 