### PR TITLE
ci: declare contents:write and pull-requests:write on updateversiondb workflow

### DIFF
--- a/.github/workflows/updateversiondb.yml
+++ b/.github/workflows/updateversiondb.yml
@@ -7,6 +7,10 @@ concurrency:
   group: versiondbupdate
   cancel-in-progress: true  
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
 
   update-versiondb:


### PR DESCRIPTION
Declares `permissions: contents: write` and `pull-requests: write` at the workflow level on `.github/workflows/updateversiondb.yml`. The job chain runs a Julia script, uploads the version DB to S3 with separately-stored AWS credentials, then calls `peter-evans/create-pull-request@v8` to open the auto-update PR. That action needs both `contents: write` (to push the branch) and `pull-requests: write` (to open the PR). Everything S3 goes through the AWS secrets and does not touch `GITHUB_TOKEN`.

This is supply-chain hygiene grounded in CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) - a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the blast radius equalled the issued scope. With no `permissions` block today, this workflow inherits the org default, which can be wider than `contents+pull-requests`. Pinning at the actual minimum drops everything else (id-token, packages, pages, etc.) from the runtime token regardless of how the org default evolves, and registers with OpenSSF Scorecard's Token-Permissions check.

YAML validated locally with `yaml.safe_load`.
