### PR TITLE
CI: disable fail fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,14 @@ on:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
 
   check-juliaup:
     runs-on: ${{ matrix.runner }}
     strategy:
-      fail-fast: ${{ github.ref != 'refs/heads/main' }}
+      fail-fast: false
       matrix:
         label: [
           x86_64-pc-windows-msvc-windowsstore,
@@ -153,7 +153,7 @@ jobs:
   test-juliaup:
     runs-on: ${{ matrix.runner }}
     strategy:
-      fail-fast: ${{ github.ref != 'refs/heads/main' }}
+      fail-fast: false
       matrix:
         target: [
           x86_64-pc-windows-msvc,


### PR DESCRIPTION
Our CI is too flaky. It makes getting CI green annoying