### PR TITLE
release mechanics: retry winstore deploys on auth failure, check brew release exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1125,9 +1125,14 @@ jobs:
       run: |
         VERSION="${{ github.ref_name }}"
         VERSION="${VERSION#v}"
+        FORMULA_VERSION=$(curl -sf https://formulae.brew.sh/api/formula/juliaup.json | jq -r '.versions.stable')
+        if [ "$FORMULA_VERSION" = "$VERSION" ]; then
+          echo "Homebrew bump failed but formula is already at $VERSION - already merged"
+          exit 0
+        fi
         PR_COUNT=$(gh pr list --repo homebrew/homebrew-core --search "juliaup $VERSION" --state open --json number --jq 'length')
         if [ "$PR_COUNT" -eq 0 ]; then
-          echo "Homebrew bump failed and no open PR found for juliaup $VERSION on homebrew-core"
+          echo "Homebrew bump failed, formula is at $FORMULA_VERSION (not $VERSION), and no open PR found on homebrew-core"
           exit 1
         fi
         echo "Homebrew bump failed but found $PR_COUNT open PR(s) for juliaup $VERSION on homebrew-core - likely already handled by BrewTestBot"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1118,16 +1118,19 @@ jobs:
         force: true
         tag: ${{ github.ref }}
         revision: ${{ github.sha }}
-    - name: Check release exists on bump failure
+    - name: Check Homebrew PR exists on bump failure
       if: steps.bump.outcome == 'failure'
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{secrets.TOKEN_FOR_HOMEBREW}}
       run: |
-        if ! gh release view "${{ github.ref_name }}" --repo ${{ github.repository }} > /dev/null 2>&1; then
-          echo "Homebrew bump failed and GitHub release does not exist for ${{ github.ref_name }}"
+        VERSION="${{ github.ref_name }}"
+        VERSION="${VERSION#v}"
+        PR_COUNT=$(gh pr list --repo homebrew/homebrew-core --search "juliaup $VERSION" --state open --json number --jq 'length')
+        if [ "$PR_COUNT" -eq 0 ]; then
+          echo "Homebrew bump failed and no open PR found for juliaup $VERSION on homebrew-core"
           exit 1
         fi
-        echo "Homebrew bump failed but GitHub release exists - likely already handled by BrewTestBot"
+        echo "Homebrew bump failed but found $PR_COUNT open PR(s) for juliaup $VERSION on homebrew-core - likely already handled by BrewTestBot"
 
   deploy-release-channel-aur:
     needs: [create-github-release,package-unix,package-windows-msix,package-windows-msi]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -998,13 +998,23 @@ jobs:
         CLIENTID: ${{ secrets.CLIENTID }}
         CLIENTSECRET: ${{ secrets.CLIENTSECRET }}
       run: |
-        $sec = ConvertTo-SecureString $env:CLIENTSECRET -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential $env:CLIENTID, $sec
-        Set-StoreBrokerAuthentication -TenantId $env:TENANTID -Credential $cred
-        $subid, $uploadurl = Update-ApplicationFlightSubmission -ReplacePackages -AppId 9NJNWW8PVKMN -FlightId 2e2f9fe8-3950-4273-b80d-7f752296ca86 -SubmissionDataPath ".\Upload.json" -PackagePath ".\Upload.zip" -AutoCommit -Force
-        Start-SubmissionMonitor -AppId 9NJNWW8PVKMN -FlightId 2e2f9fe8-3950-4273-b80d-7f752296ca86 -SubmissionId $subid
-        $sub = Get-ApplicationFlightSubmission -AppId 9NJNWW8PVKMN -FlightId 2e2f9fe8-3950-4273-b80d-7f752296ca86 -SubmissionId $subid
-        if ($sub.status -eq "CommitFailed") { throw "Store flight submission $subid failed: CommitFailed" }
+        $maxAttempts = 3
+        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+          try {
+            $sec = ConvertTo-SecureString $env:CLIENTSECRET -AsPlainText -Force
+            $cred = New-Object System.Management.Automation.PSCredential $env:CLIENTID, $sec
+            Set-StoreBrokerAuthentication -TenantId $env:TENANTID -Credential $cred
+            $subid, $uploadurl = Update-ApplicationFlightSubmission -ReplacePackages -AppId 9NJNWW8PVKMN -FlightId 2e2f9fe8-3950-4273-b80d-7f752296ca86 -SubmissionDataPath ".\Upload.json" -PackagePath ".\Upload.zip" -AutoCommit -Force
+            Start-SubmissionMonitor -AppId 9NJNWW8PVKMN -FlightId 2e2f9fe8-3950-4273-b80d-7f752296ca86 -SubmissionId $subid
+            $sub = Get-ApplicationFlightSubmission -AppId 9NJNWW8PVKMN -FlightId 2e2f9fe8-3950-4273-b80d-7f752296ca86 -SubmissionId $subid
+            if ($sub.status -eq "CommitFailed") { throw "Store flight submission $subid failed: CommitFailed" }
+            break
+          } catch {
+            if ($attempt -ge $maxAttempts) { throw }
+            Write-Host "Attempt $attempt failed: $_. Retrying in 60 seconds..."
+            Start-Sleep -Seconds 60
+          }
+        }
 
   deploy-releasepreview-channel-winstore:
     needs: [create-github-release,package-unix,package-windows-msix,package-windows-msi]
@@ -1031,13 +1041,23 @@ jobs:
         CLIENTID: ${{ secrets.CLIENTID }}
         CLIENTSECRET: ${{ secrets.CLIENTSECRET }}
       run: |
-        $sec = ConvertTo-SecureString $env:CLIENTSECRET -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential $env:CLIENTID, $sec
-        Set-StoreBrokerAuthentication -TenantId $env:TENANTID -Credential $cred
-        $subid, $uploadurl = Update-ApplicationFlightSubmission -ReplacePackages -AppId 9NJNWW8PVKMN -FlightId 732b234a-7ea9-4b65-8c9f-b9d9eaefb578 -SubmissionDataPath ".\Upload.json" -PackagePath ".\Upload.zip" -AutoCommit -Force
-        Start-SubmissionMonitor -AppId 9NJNWW8PVKMN -FlightId 732b234a-7ea9-4b65-8c9f-b9d9eaefb578 -SubmissionId $subid
-        $sub = Get-ApplicationFlightSubmission -AppId 9NJNWW8PVKMN -FlightId 732b234a-7ea9-4b65-8c9f-b9d9eaefb578 -SubmissionId $subid
-        if ($sub.status -eq "CommitFailed") { throw "Store flight submission $subid failed: CommitFailed" }
+        $maxAttempts = 3
+        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+          try {
+            $sec = ConvertTo-SecureString $env:CLIENTSECRET -AsPlainText -Force
+            $cred = New-Object System.Management.Automation.PSCredential $env:CLIENTID, $sec
+            Set-StoreBrokerAuthentication -TenantId $env:TENANTID -Credential $cred
+            $subid, $uploadurl = Update-ApplicationFlightSubmission -ReplacePackages -AppId 9NJNWW8PVKMN -FlightId 732b234a-7ea9-4b65-8c9f-b9d9eaefb578 -SubmissionDataPath ".\Upload.json" -PackagePath ".\Upload.zip" -AutoCommit -Force
+            Start-SubmissionMonitor -AppId 9NJNWW8PVKMN -FlightId 732b234a-7ea9-4b65-8c9f-b9d9eaefb578 -SubmissionId $subid
+            $sub = Get-ApplicationFlightSubmission -AppId 9NJNWW8PVKMN -FlightId 732b234a-7ea9-4b65-8c9f-b9d9eaefb578 -SubmissionId $subid
+            if ($sub.status -eq "CommitFailed") { throw "Store flight submission $subid failed: CommitFailed" }
+            break
+          } catch {
+            if ($attempt -ge $maxAttempts) { throw }
+            Write-Host "Attempt $attempt failed: $_. Retrying in 60 seconds..."
+            Start-Sleep -Seconds 60
+          }
+        }
 
   deploy-release-channel-winstore:
     needs: [create-github-release,package-unix,package-windows-msix,package-windows-msi]
@@ -1064,13 +1084,23 @@ jobs:
         CLIENTID: ${{ secrets.CLIENTID }}
         CLIENTSECRET: ${{ secrets.CLIENTSECRET }}
       run: |
-        $sec = ConvertTo-SecureString $env:CLIENTSECRET -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential $env:CLIENTID, $sec
-        Set-StoreBrokerAuthentication -TenantId $env:TENANTID -Credential $cred
-        $subid, $uploadurl = Update-ApplicationSubmission -ReplacePackages -AppId 9NJNWW8PVKMN -SubmissionDataPath ".\Upload.json" -PackagePath ".\Upload.zip" -AutoCommit -Force
-        Start-SubmissionMonitor -AppId 9NJNWW8PVKMN -SubmissionId $subid
-        $sub = Get-ApplicationSubmission -AppId 9NJNWW8PVKMN -SubmissionId $subid
-        if ($sub.status -eq "CommitFailed") { throw "Store submission $subid failed: CommitFailed" }
+        $maxAttempts = 3
+        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+          try {
+            $sec = ConvertTo-SecureString $env:CLIENTSECRET -AsPlainText -Force
+            $cred = New-Object System.Management.Automation.PSCredential $env:CLIENTID, $sec
+            Set-StoreBrokerAuthentication -TenantId $env:TENANTID -Credential $cred
+            $subid, $uploadurl = Update-ApplicationSubmission -ReplacePackages -AppId 9NJNWW8PVKMN -SubmissionDataPath ".\Upload.json" -PackagePath ".\Upload.zip" -AutoCommit -Force
+            Start-SubmissionMonitor -AppId 9NJNWW8PVKMN -SubmissionId $subid
+            $sub = Get-ApplicationSubmission -AppId 9NJNWW8PVKMN -SubmissionId $subid
+            if ($sub.status -eq "CommitFailed") { throw "Store submission $subid failed: CommitFailed" }
+            break
+          } catch {
+            if ($attempt -ge $maxAttempts) { throw }
+            Write-Host "Attempt $attempt failed: $_. Retrying in 60 seconds..."
+            Start-Sleep -Seconds 60
+          }
+        }
 
   deploy-release-channel-brew:
     needs: [create-github-release,package-unix,package-windows-msix,package-windows-msi]
@@ -1079,6 +1109,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
     - name: Update Homebrew formula
+      id: bump
+      continue-on-error: true
       uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # v7
       with:
         token: ${{secrets.TOKEN_FOR_HOMEBREW}}
@@ -1086,6 +1118,16 @@ jobs:
         force: true
         tag: ${{ github.ref }}
         revision: ${{ github.sha }}
+    - name: Check release exists on bump failure
+      if: steps.bump.outcome == 'failure'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        if ! gh release view "${{ github.ref_name }}" --repo ${{ github.repository }} > /dev/null 2>&1; then
+          echo "Homebrew bump failed and GitHub release does not exist for ${{ github.ref_name }}"
+          exit 1
+        fi
+        echo "Homebrew bump failed but GitHub release exists - likely already handled by BrewTestBot"
 
   deploy-release-channel-aur:
     needs: [create-github-release,package-unix,package-windows-msix,package-windows-msi]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1007,7 +1007,7 @@ jobs:
             $subid, $uploadurl = Update-ApplicationFlightSubmission -ReplacePackages -AppId 9NJNWW8PVKMN -FlightId 2e2f9fe8-3950-4273-b80d-7f752296ca86 -SubmissionDataPath ".\Upload.json" -PackagePath ".\Upload.zip" -AutoCommit -Force
             Start-SubmissionMonitor -AppId 9NJNWW8PVKMN -FlightId 2e2f9fe8-3950-4273-b80d-7f752296ca86 -SubmissionId $subid
             $sub = Get-ApplicationFlightSubmission -AppId 9NJNWW8PVKMN -FlightId 2e2f9fe8-3950-4273-b80d-7f752296ca86 -SubmissionId $subid
-            if ($sub.status -eq "CommitFailed") { throw "Store flight submission $subid failed: CommitFailed" }
+            if ($sub.status -eq "CommitFailed") { Write-Error "Store flight submission $subid failed: CommitFailed"; exit 1 }
             break
           } catch {
             if ($attempt -ge $maxAttempts) { throw }
@@ -1050,7 +1050,7 @@ jobs:
             $subid, $uploadurl = Update-ApplicationFlightSubmission -ReplacePackages -AppId 9NJNWW8PVKMN -FlightId 732b234a-7ea9-4b65-8c9f-b9d9eaefb578 -SubmissionDataPath ".\Upload.json" -PackagePath ".\Upload.zip" -AutoCommit -Force
             Start-SubmissionMonitor -AppId 9NJNWW8PVKMN -FlightId 732b234a-7ea9-4b65-8c9f-b9d9eaefb578 -SubmissionId $subid
             $sub = Get-ApplicationFlightSubmission -AppId 9NJNWW8PVKMN -FlightId 732b234a-7ea9-4b65-8c9f-b9d9eaefb578 -SubmissionId $subid
-            if ($sub.status -eq "CommitFailed") { throw "Store flight submission $subid failed: CommitFailed" }
+            if ($sub.status -eq "CommitFailed") { Write-Error "Store flight submission $subid failed: CommitFailed"; exit 1 }
             break
           } catch {
             if ($attempt -ge $maxAttempts) { throw }
@@ -1093,7 +1093,7 @@ jobs:
             $subid, $uploadurl = Update-ApplicationSubmission -ReplacePackages -AppId 9NJNWW8PVKMN -SubmissionDataPath ".\Upload.json" -PackagePath ".\Upload.zip" -AutoCommit -Force
             Start-SubmissionMonitor -AppId 9NJNWW8PVKMN -SubmissionId $subid
             $sub = Get-ApplicationSubmission -AppId 9NJNWW8PVKMN -SubmissionId $subid
-            if ($sub.status -eq "CommitFailed") { throw "Store submission $subid failed: CommitFailed" }
+            if ($sub.status -eq "CommitFailed") { Write-Error "Store submission $subid failed: CommitFailed"; exit 1 }
             break
           } catch {
             if ($attempt -ge $maxAttempts) { throw }
@@ -1121,7 +1121,7 @@ jobs:
     - name: Check Homebrew PR exists on bump failure
       if: steps.bump.outcome == 'failure'
       env:
-        GH_TOKEN: ${{secrets.TOKEN_FOR_HOMEBREW}}
+        GH_TOKEN: ${{ github.token }}
       run: |
         VERSION="${{ github.ref_name }}"
         VERSION="${VERSION#v}"
@@ -1130,7 +1130,7 @@ jobs:
           echo "Homebrew bump failed but formula is already at $VERSION - already merged"
           exit 0
         fi
-        PR_COUNT=$(gh pr list --repo homebrew/homebrew-core --search "juliaup $VERSION" --state open --json number --jq 'length')
+        PR_COUNT=$(gh pr list --repo homebrew/homebrew-core --search "juliaup $VERSION in:title" --state open --json number --jq 'length')
         if [ "$PR_COUNT" -eq 0 ]; then
           echo "Homebrew bump failed, formula is at $FORMULA_VERSION (not $VERSION), and no open PR found on homebrew-core"
           exit 1


### PR DESCRIPTION
- Wrap all 3 winstore deploy steps in a 3-attempt retry loop with 60s delay to handle transient auth/API blips
- For the brew deploy, add continue-on-error and a follow-up step that checks the GitHub release exists if the bump fails. If the release is missing it errors; if it exists the failure was likely BrewTestBot already handling the bump