### PR TITLE
Fix CI: pin Rust 1.96 and use :edge cross images for GLIBC 2.28+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,10 +223,20 @@ jobs:
       with:
         platform: x86
         version: 12.2.0
+    - name: Resolve toolchain from rust-toolchain.toml
+      id: toolchain
+      shell: bash
+      run: |
+        ver=$(grep '^channel = ' rust-toolchain.toml | sed 's/channel = "\(.*\)"/\1/')
+        case "${{ matrix.toolchain }}" in
+          stable-gnu) echo "name=${ver}-x86_64-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
+          stable-i686-gnu) echo "name=${ver}-i686-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
+          *) echo "name=${ver}" >> "$GITHUB_OUTPUT" ;;
+        esac
     - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       if: ${{ ! contains(matrix.target, 'freebsd') }}
       with:
-        toolchain: ${{matrix.toolchain}}
+        toolchain: ${{ steps.toolchain.outputs.name }}
         target: ${{matrix.target}}
     - name: Release build
       if: ${{ ! contains(matrix.target, 'freebsd') }}
@@ -239,6 +249,7 @@ jobs:
         CARGO_TARGET_x86_64-unknown-linux-musl: ${{matrix.rustflags}}
         CARGO_TARGET_i686-unknown-linux-musl: ${{matrix.rustflags}}
         CARGO_TARGET_aarch64-unknown-linux-musl: ${{matrix.rustflags}}
+        AWS_LC_SYS_CMAKE_BUILDER: "1"
     - name: Free Disk Space
       if: ${{ contains(matrix.target, 'freebsd') }}
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -358,10 +369,20 @@ jobs:
       with:
         platform: x86
         version: 12.2.0
+    - name: Resolve toolchain from rust-toolchain.toml
+      id: toolchain
+      shell: bash
+      run: |
+        ver=$(grep '^channel = ' rust-toolchain.toml | sed 's/channel = "\(.*\)"/\1/')
+        case "${{ matrix.toolchain }}" in
+          stable-gnu) echo "name=${ver}-x86_64-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
+          stable-i686-gnu) echo "name=${ver}-i686-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
+          *) echo "name=${ver}" >> "$GITHUB_OUTPUT" ;;
+        esac
     - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       if: ${{ ! contains(matrix.target, 'freebsd') }}
       with:
-        toolchain: ${{matrix.toolchain}}
+        toolchain: ${{ steps.toolchain.outputs.name }}
         target: ${{matrix.target}}
     - name: Test
       if: ${{ ! contains(matrix.target, 'freebsd') }}
@@ -374,6 +395,7 @@ jobs:
         CARGO_TARGET_x86_64-unknown-linux-musl: ${{matrix.rustflags}}
         CARGO_TARGET_i686-unknown-linux-musl: ${{matrix.rustflags}}
         CARGO_TARGET_aarch64-unknown-linux-musl: ${{matrix.rustflags}}
+        AWS_LC_SYS_CMAKE_BUILDER: "1"
     - name: Free Disk Space
       if: ${{ contains(matrix.target, 'freebsd') }}
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,6 @@ jobs:
       run: sudo apt-get install musl-tools
     - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       with:
-        toolchain: stable
         target: ${{matrix.target}}
     - if: ${{ matrix.os == 'ubuntu' }}
       uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3
@@ -149,6 +148,7 @@ jobs:
         CARGO_TARGET_x86_64-unknown-linux-musl: ${{matrix.rustflags}}
         CARGO_TARGET_i686-unknown-linux-musl: ${{matrix.rustflags}}
         CARGO_TARGET_aarch64-unknown-linux-musl: ${{matrix.rustflags}}
+        AWS_LC_SYS_CMAKE_BUILDER: "1"
 
   test-juliaup:
     runs-on: ${{ matrix.runner }}
@@ -230,10 +230,20 @@ jobs:
       with:
         platform: x86
         version: 12.2.0
+    - name: Resolve toolchain from rust-toolchain.toml
+      id: toolchain
+      shell: bash
+      run: |
+        ver=$(grep '^channel = ' rust-toolchain.toml | sed 's/channel = "\(.*\)"/\1/')
+        case "${{ matrix.toolchain }}" in
+          stable-gnu) echo "name=${ver}-x86_64-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
+          stable-i686-gnu) echo "name=${ver}-i686-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
+          *) echo "name=${ver}" >> "$GITHUB_OUTPUT" ;;
+        esac
     - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       if: ${{ ! contains(matrix.target, 'freebsd') }}
       with:
-        toolchain: ${{matrix.toolchain}}
+        toolchain: ${{ steps.toolchain.outputs.name }}
         target: ${{matrix.target}}
     - name: Test
       if: ${{ ! contains(matrix.target, 'freebsd') }}

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,6 +1,35 @@
-# The cross-rs 0.2.5 image for i686-unknown-linux-gnu (from ~2022) ships
-# glibc 2.27, too old for modern Rust build scripts (need >= 2.28).
-# Pin to a newer image by digest until cross-rs releases 0.2.6.
+# The cross-rs 0.2.5 images (latest release from 2023) ship with glibc 2.27,
+# which is too old for modern Rust build scripts (need >= 2.28, e.g. libc 0.2.186+).
+# For the affected targets, use :edge tag to get regularly updated base images
+# with glibc 2.28+ until cross-rs releases 0.2.6. This is the officially
+# recommended approach. The *-musl images for x86_64 are already new enough so
+# they are left on the default 0.2.5 image.
 # See: https://github.com/cross-rs/cross/issues/724
+
 [target.i686-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/i686-unknown-linux-gnu@sha256:dbaac6e686550f3704402c126c60b82ca9a9c7329e89ea115289ecc7ba0bdbce"
+
+[target.i686-unknown-linux-musl]
+image = "ghcr.io/cross-rs/i686-unknown-linux-musl:edge"
+
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
+
+[target.aarch64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:edge"
+
+# x86_64-linux-gnu is a native build (HOST == target), so aws-lc-sys runs its cc
+# builder memcmp self-check, which panics with the newer GCC in the :edge image
+# (gcc bug 95189). Force aws-lc-sys to use its CMake builder instead, which skips
+# that check: install cmake and pass AWS_LC_SYS_CMAKE_BUILDER=1 into the container.
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:edge"
+pre-build = ["apt-get update && apt-get install --assume-yes cmake"]
+
+[target.x86_64-unknown-linux-gnu.env]
+passthrough = ["AWS_LC_SYS_CMAKE_BUILDER"]
+
+# FreeBSD is cross-compiled (HOST != target), so aws-lc-sys skips the memcmp
+# self-check; only the newer glibc from :edge is needed here.
+[target.x86_64-unknown-freebsd]
+image = "ghcr.io/cross-rs/x86_64-unknown-freebsd:edge"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.96.0"
 components = ["clippy", "rustfmt"]

--- a/src/bin/julialauncher.rs
+++ b/src/bin/julialauncher.rs
@@ -169,11 +169,13 @@ fn is_interactive() -> bool {
                 return false;
             }
             // Any other non-flag argument that doesn't start with '-' could be a script
-            filename if !filename.starts_with('-') && !filename.is_empty() => {
-                // This could be a script file, check if it exists as a file
-                if std::path::Path::new(filename).exists() {
-                    return false;
-                }
+            // file. Check if it exists as a file.
+            filename
+                if !filename.starts_with('-')
+                    && !filename.is_empty()
+                    && std::path::Path::new(filename).exists() =>
+            {
+                return false;
             }
             _ => {} // Continue checking other arguments
         }

--- a/src/command_api.rs
+++ b/src/command_api.rs
@@ -160,14 +160,10 @@ pub fn run_command_api(command: &str, paths: &GlobalPaths) -> Result<()> {
         };
 
         match config_file.data.default {
-            Some(ref default_value) => {
-                if key == default_value {
-                    ret_value.default = Some(curr.clone());
-                } else {
-                    ret_value.other_versions.push(curr);
-                }
+            Some(ref default_value) if key == default_value => {
+                ret_value.default = Some(curr.clone());
             }
-            None => {
+            _ => {
                 ret_value.other_versions.push(curr);
             }
         }


### PR DESCRIPTION
## Problem

The build/test CI jobs passed `toolchain: stable` to `setup-rust-toolchain`, so they ignored the version pinned in `rust-toolchain.toml` and floated onto whatever stable the runner happened to have. When stable moved to 1.96, its `gnu` std started referencing `GLIBC_2.28`/`2.29`/`2.30`, which the glibc-2.27 cross-rs 0.2.5 images cannot satisfy — breaking the Linux cross builds:

```
error: failed to run custom build command for `libc v0.2.186`
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found
```

(`libc` was just the first build-script crate to hit it; the real trigger was the floating toolchain.)

## Fix

Make `rust-toolchain.toml` the single source of truth and bump it to **1.96.0**:

- Drop `toolchain: stable` from `check-juliaup` so it honors the pin.
- For the jobs whose matrix selects Windows-GNU hosts (`test-juliaup` and the two `release.yml` jobs), add a small step that reads the version from `rust-toolchain.toml` and maps the semantic matrix values (`stable-gnu` / `stable-i686-gnu`) to real toolchains, then feeds that to `setup-rust-toolchain`. Matrix label values are unchanged, so the existing mingw conditions keep working.
- The freebsd job already reads the version from `rust-toolchain.toml`; `clippy.yml`/`rustfmt.yml` and the crates/msix jobs already omit `toolchain:`, so they pick up the bump automatically.

Use `:edge` cross-rs images for the targets whose 0.2.5 image ships an old glibc (i686/aarch64 gnu+musl, x86_64 gnu, freebsd). `x86_64-unknown-linux-gnu` is a native build (`HOST == target`), so `aws-lc-sys` runs its cc-builder `memcmp` self-check, which panics with the newer GCC in the `:edge` image (gcc bug 95189); install `cmake` and pass `AWS_LC_SYS_CMAKE_BUILDER=1` to force its CMake builder, which skips that check.
