### PR TITLE
Restore julia symlinks after self-update

### DIFF
--- a/src/command_post_update.rs
+++ b/src/command_post_update.rs
@@ -18,6 +18,43 @@ pub fn run_command_post_update(paths: &GlobalPaths) -> Result<()> {
     if let Err(e) = refresh_existing_shell_init_blocks(&bin_path, &paths.juliauphome) {
         eprintln!("Warning: failed to refresh shell init blocks: {e}");
     }
+    #[cfg(not(windows))]
+    if let Err(e) = restore_symlinks(&bin_path, paths) {
+        eprintln!("Warning: failed to restore Julia symlinks: {e}");
+    }
+
+    Ok(())
+}
+
+// Self-update replaces the entire bin directory, which removes the `julia`
+// symlink (and any channel symlinks) that are not part of the juliaup tarball.
+// Recreate them here so `julia` keeps working after an update.
+#[cfg(not(windows))]
+fn restore_symlinks(bin_path: &std::path::Path, paths: &GlobalPaths) -> Result<()> {
+    use crate::config_file::load_config_db;
+    use crate::operations::create_symlink;
+    use anyhow::Context;
+
+    let launcher_path = bin_path.join("julialauncher");
+    if launcher_path.exists() {
+        let julia_symlink = bin_path.join("julia");
+        // Remove any stale or dangling link before recreating it.
+        let _ = std::fs::remove_file(&julia_symlink);
+        std::os::unix::fs::symlink(&launcher_path, &julia_symlink).with_context(|| {
+            format!(
+                "failed to create symlink `{}`.",
+                julia_symlink.to_string_lossy()
+            )
+        })?;
+    }
+
+    let config_file = load_config_db(paths, None)
+        .with_context(|| "Failed to load configuration db while restoring symlinks.")?;
+    if config_file.data.settings.create_channel_symlinks {
+        for (channel_name, channel) in &config_file.data.installed_channels {
+            create_symlink(channel, &format!("julia-{}", channel_name), paths)?;
+        }
+    }
 
     Ok(())
 }

--- a/tests/command_post_update_test.rs
+++ b/tests/command_post_update_test.rs
@@ -1,0 +1,79 @@
+#![cfg(not(windows))]
+
+mod utils;
+use utils::TestEnv;
+
+use assert_cmd::cargo::cargo_bin;
+use assert_cmd::Command;
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+
+fn juliaup(exe: &Path, env: &TestEnv) -> Command {
+    let mut cmd = Command::new(exe);
+    cmd.env("JULIA_DEPOT_PATH", env.depot_path());
+    cmd.env("JULIAUP_DEPOT_PATH", env.depot_path());
+    cmd
+}
+
+/// Regression test for #1513: a self-update swaps the entire bin directory,
+/// which removes the `julia` -> `julialauncher` symlink (not part of the
+/// juliaup tarball) and left users with "command not found: julia". The
+/// `_post-update` hook must restore the symlink so `julia` keeps working.
+#[test]
+fn post_update_restores_julia_symlink() {
+    let env = TestEnv::new();
+    let bin = assert_fs::TempDir::new().unwrap();
+
+    // Place real juliaup + julialauncher binaries in an isolated bin directory.
+    // The post-update hook keys off the running exe's parent, so running this
+    // copy makes it operate here rather than in the cargo target dir.
+    // The `julialauncher` bin requires a build feature and isn't compiled by
+    // default; in the dev build the launcher binary is named `julia`, so copy
+    // that to act as the `julialauncher` the installed product would have.
+    let juliaup_exe = bin.path().join("juliaup");
+    let julialauncher_exe = bin.path().join("julialauncher");
+    fs::copy(cargo_bin("juliaup"), &juliaup_exe).unwrap();
+    fs::copy(cargo_bin("julia"), &julialauncher_exe).unwrap();
+
+    // Install and default a real Julia so the launcher has something to run.
+    juliaup(&juliaup_exe, &env)
+        .args(["add", "1.12.0"])
+        .assert()
+        .success();
+    juliaup(&juliaup_exe, &env)
+        .args(["default", "1.12.0"])
+        .assert()
+        .success();
+
+    // Create the `julia` -> `julialauncher` symlink as the installer does, then
+    // delete it to reproduce the directory swap that wipes it during self-update.
+    let julia = bin.path().join("julia");
+    symlink(&julialauncher_exe, &julia).unwrap();
+    fs::remove_file(&julia).unwrap();
+    assert!(
+        julia.symlink_metadata().is_err(),
+        "precondition: julia symlink should be absent before post-update"
+    );
+
+    // The post-update hook should restore the symlink.
+    juliaup(&juliaup_exe, &env)
+        .arg("_post-update")
+        .assert()
+        .success();
+
+    assert!(
+        julia.symlink_metadata().is_ok(),
+        "julia symlink should be restored by post-update"
+    );
+    assert_eq!(fs::read_link(&julia).unwrap(), julialauncher_exe);
+
+    // And julia must actually run via the restored symlink.
+    Command::new(&julia)
+        .env("JULIA_DEPOT_PATH", env.depot_path())
+        .env("JULIAUP_DEPOT_PATH", env.depot_path())
+        .args(["-e", "print(VERSION)"])
+        .assert()
+        .success()
+        .stdout("1.12.0");
+}


### PR DESCRIPTION
Self-update replaces the entire bin directory via an atomic rename, which removes the `julia` -> `julialauncher` symlink (and any per-channel `julia-<channel>` symlinks) that are not part of the juliaup tarball. This left users with "command not found: julia" after an automatic update.

Recreate these symlinks in the `_post-update` hook so `julia` keeps working after an update. Best-effort and guarded for non-Windows targets.

Fixes #1513