### PR TITLE
Release config lock before spawning post-update hook

### DIFF
--- a/src/command_selfupdate.rs
+++ b/src/command_selfupdate.rs
@@ -90,6 +90,12 @@ pub fn run_command_selfupdate(paths: &GlobalPaths) -> Result<()> {
 
         download_extract_sans_parent(new_juliaup_url.as_ref(), my_own_folder, 0)?;
 
+        // Release the configuration lock before invoking the post-update hook:
+        // the hook runs in a child process that needs to read the config (e.g.
+        // to restore channel symlinks), and would otherwise deadlock waiting on
+        // the lock this process still holds.
+        drop(config_file);
+
         let new_juliaup = my_own_folder.join(format!("juliaup{}", std::env::consts::EXE_SUFFIX));
         if let Err(e) = std::process::Command::new(&new_juliaup)
             .arg("_post-update")


### PR DESCRIPTION
`self update` holds the exclusive configuration lock from `load_mut_config_db` for the whole command. The `_post-update` hook runs in a child process that reads the config (to restore channel symlinks) via a shared lock, which blocked forever on the parent's exclusive lock.

Drop the lock after extraction completes, just before spawning the hook, so the child can acquire its read lock. The lock is intentionally held across the extraction to serialize concurrent self-updates.

Fixes the deadlock reported after #1514 on the releasepreview channel.