### PR TITLE
security: Harden deployment workflow

### DIFF
--- a/.github/aur_known_hosts
+++ b/.github/aur_known_hosts
@@ -1,0 +1,20 @@
+# Vendored SSH host keys for aur.archlinux.org
+#
+# Used by the `deploy-release-channel-aur` job in .github/workflows/release.yml to
+# enable strict host key checking when pushing the PKGBUILD update over SSH, so the
+# deploy cannot be silently man-in-the-middled.
+#
+# Source of truth: Arch Linux infrastructure repository
+#   https://gitlab.archlinux.org/archlinux/infrastructure/-/blob/master/docs/ssh-known_hosts.txt
+#
+# Published production fingerprints (roles/aurweb/templates/config.j2):
+#   ED25519  SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4
+#   ECDSA    SHA256:uTa/0PndEgPZTf76e1DFqXKJEXKsn7m9ivhLQtzGOCI
+#   RSA      SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8
+#
+# To verify / refresh these entries:
+#   ssh-keyscan aur.archlinux.org > aur_known_hosts.new
+#   ssh-keygen -lf aur_known_hosts.new   # fingerprints must match the values above
+aur.archlinux.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLMiLrP8pVi5BFX2i3vepSUnpedeiewE5XptnUnau+ZoeUOPkpoCgZZuYfpaIQfhhJJI5qgnjJmr4hyJbe/zxow=
+aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN
+aur.archlinux.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKF9vAFWdgm9Bi8uc+tYRBmXASBb5cB5iZsB7LOWWFeBrLp3r14w0/9S2vozjgqY5sJLDPONWoTTaVTbhe3vwO8CBKZTEt1AcWxuXNlRnk9FliR1/eNB9uz/7y1R0+c1Md+P98AJJSJWKN12nqIDIhjl2S1vOUvm7FNY43fU2knIhEbHybhwWeg+0wxpKwcAd/JeL5i92Uv03MYftOToUijd1pqyVFdJvQFhqD4v3M157jxS5FTOBrccAEjT+zYmFyD8WvKUa9vUclRddNllmBJdy4NyLB8SvVZULUPrP3QOlmzemeKracTlVOUG1wsDbxknF1BwSCU7CmU6UFP90kpWIyz66bP0bl67QAvlIc52Yix7pKJPbw85+zykvnfl2mdROsaT8p8R9nwCdFsBc9IiD0NhPEHcyHRwB8fokXTajk2QnGhL+zP5KnkmXnyQYOCUYo3EKMXIlVOVbPDgRYYT/XqvBuzq5S9rrU70KoI/S5lDnFfx/+lPLdtcnnEPk=

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,10 @@ on:
     tags:
       - 'v*'
 
-permissions: write-all
+# Least-privilege default for all jobs; jobs that publish GitHub Releases
+# elevate to `contents: write` individually.
+permissions:
+  contents: read
 
 jobs:
 
@@ -965,6 +968,8 @@ jobs:
     needs: [test-juliaup]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write  # create the GitHub Release
     steps:
     - name: Release
       uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
@@ -977,6 +982,8 @@ jobs:
     needs: [create-github-release, package-unix-portable, package-windows-portable]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write  # upload assets to the GitHub Release
     steps:
     - uses: actions/download-artifact@v8
       with:
@@ -1347,6 +1354,8 @@ jobs:
     environment: release-channel
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write  # promote the GitHub Release out of prerelease
     steps:
     - name: Release
       uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1172,11 +1172,18 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
+      - name: Checkout juliaup repo (for vendored AUR host key)
+        uses: actions/checkout@v6
+        with:
+          path: juliaup-src
       - name: Checkout PKGBUILD repo
         run: |
+          mkdir -p ~/.ssh
+          cp juliaup-src/.github/aur_known_hosts ~/.ssh/known_hosts
+          rm -rf juliaup-src
           echo "$AUR_SSH_KEY" > ~/aur_ssh_key
           chmod 600 ~/aur_ssh_key
-          git config --global core.sshCommand "ssh -i ~/aur_ssh_key -o 'StrictHostKeyChecking=no'"
+          git config --global core.sshCommand "ssh -i ~/aur_ssh_key -o 'UserKnownHostsFile=~/.ssh/known_hosts' -o 'StrictHostKeyChecking=yes'"
           git clone "aur@aur.archlinux.org:juliaup.git" .
         env:
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}


### PR DESCRIPTION
The GitHub actions AUR deploy workflow disabled SSH host key checking. As a result, an attacker capable of MITM a CI job (which is itself a tough lift, but of course depends on both ISP path between the runner and AUR) could gain arbitrary code execution in the CI job context, which in particular has access to the AUR deploy secret and would thus be capable of corrupting the deployed binary. There is no indication of active compromise, but after merging this PR, the AUR deploy key should be rotated and the existing AUR published releases should be validated out of an abundance of caution.

This issue was assigned ID JLSEC-2026-609

This issue was reported by the Anthropic CVD program under the following IDs:
- ANT-2026-0A39KRBA
- ANT-2026-J4TBAZ7H
- ANT-2026-QNVDP32K
- ANT-2026-TWQFC5FM