### PR TITLE
Add end-to-end self-update integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,3 +285,33 @@ jobs:
           df -h
           export CARGO_INCREMENTAL=0
           cargo test --verbose --target ${{matrix.target}} --features ${{matrix.features}}
+
+  test-selfupdate:
+    # Exercises the real `juliaup self update` code path end-to-end against a
+    # local mock server (see tests/command_selfupdate_test.rs, issue #805).
+    # Runs in its own job because it needs the `selfupdate` feature, which
+    # changes config loading in a way that is incompatible with the other
+    # integration tests.
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu
+            runner: ubuntu-latest
+          - os: macos
+            runner: macos-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Resolve toolchain from rust-toolchain.toml
+      id: toolchain
+      shell: bash
+      run: |
+        ver=$(grep '^channel = ' rust-toolchain.toml | sed 's/channel = "\(.*\)"/\1/')
+        echo "name=${ver}" >> "$GITHUB_OUTPUT"
+    - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+      with:
+        toolchain: ${{ steps.toolchain.outputs.name }}
+    - name: Test self update
+      run: cargo test --features selfupdate,binjulialauncher --test command_selfupdate_test
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +268,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
@@ -905,6 +917,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "human-panic"
 version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1357,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "tiny_http",
  "toml 1.1.2+spec-1.1.0",
  "url",
  "windows",
@@ -2364,6 +2383,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,9 @@ assert_cmd = "2"
 assert_fs = "1"
 indoc = "2"
 predicates = "3"
+tiny_http = "0.12"
+tar = "0.4"
+flate2 = "1"
 
 [features]
 selfupdate = []

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -231,6 +231,18 @@ pub fn check_server_supports_nightlies() -> Result<bool> {
     }))
 }
 
+/// Returns `true` if the URL points at a loopback host (localhost / 127.0.0.1 /
+/// ::1). Plain HTTP is permitted for these because the traffic never leaves the
+/// machine; this is used by the integration tests that spin up a local mock
+/// server, and by anyone pointing juliaup at a loopback mirror.
+fn is_loopback_http(url: &Url) -> bool {
+    url.scheme() == "http"
+        && matches!(
+            url.host_str(),
+            Some("localhost" | "127.0.0.1" | "::1" | "[::1]")
+        )
+}
+
 pub fn get_juliaserver_base_url() -> Result<Url> {
     let (base_url, is_custom) = if let Ok(val) = std::env::var("JULIAUP_SERVER") {
         let url = if val.ends_with('/') {
@@ -250,7 +262,7 @@ pub fn get_juliaserver_base_url() -> Result<Url> {
         )
     })?;
 
-    if parsed_url.scheme() != "https" {
+    if parsed_url.scheme() != "https" && !is_loopback_http(&parsed_url) {
         bail!("The value of JULIAUP_SERVER '{}' must use HTTPS.", base_url);
     }
 
@@ -289,7 +301,7 @@ pub fn get_julianightlies_base_url() -> Result<Url> {
         )
     })?;
 
-    if parsed_url.scheme() != "https" {
+    if parsed_url.scheme() != "https" && !is_loopback_http(&parsed_url) {
         bail!(
             "The value of JULIAUP_NIGHTLY_SERVER '{}' must use HTTPS.",
             base_url

--- a/tests/command_selfupdate_test.rs
+++ b/tests/command_selfupdate_test.rs
@@ -228,13 +228,6 @@ fn self_update_end_to_end() {
                 .or(predicate::str::contains("Found new version 999.0.0")),
         );
 
-    // The updated juliaup binary should report the mocked target version.
-    juliaup(None)
-        .arg("--version")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("999.0.0"));
-
     // --- 6. Verify the installation still works ---
     // The launcher symlink must have been restored by the post-update hook.
     assert!(
@@ -342,14 +335,6 @@ fn self_update_auto_triggered_by_launcher() {
         );
         thread::sleep(Duration::from_millis(250));
     }
-
-    // The launcher-triggered self-update should have swapped in the new
-    // juliaup binary version.
-    juliaup()
-        .arg("--version")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("999.0.0"));
 
     // Julia still runs via the restored launcher symlink after the auto-update.
     Command::new(&install.julia_symlink)

--- a/tests/command_selfupdate_test.rs
+++ b/tests/command_selfupdate_test.rs
@@ -228,6 +228,13 @@ fn self_update_end_to_end() {
                 .or(predicate::str::contains("Found new version 999.0.0")),
         );
 
+    // The updated juliaup binary should report the mocked target version.
+    juliaup(None)
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("999.0.0"));
+
     // --- 6. Verify the installation still works ---
     // The launcher symlink must have been restored by the post-update hook.
     assert!(
@@ -335,6 +342,14 @@ fn self_update_auto_triggered_by_launcher() {
         );
         thread::sleep(Duration::from_millis(250));
     }
+
+    // The launcher-triggered self-update should have swapped in the new
+    // juliaup binary version.
+    juliaup()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("999.0.0"));
 
     // Julia still runs via the restored launcher symlink after the auto-update.
     Command::new(&install.julia_symlink)

--- a/tests/command_selfupdate_test.rs
+++ b/tests/command_selfupdate_test.rs
@@ -1,12 +1,8 @@
-//! End-to-end self-update integration test (see issue #805).
+//! End-to-end self-update integration tests (see issue #805).
 //!
-//! This exercises a full upgrade scenario against a local mock server:
-//!   1. install an isolated copy of the current juliaup,
-//!   2. disable automatic self-update,
-//!   3. set up some state (a real channel, a linked channel, an alias),
-//!   4. mock a newer juliaup version as available on a loopback server,
-//!   5. run `juliaup self update`,
-//!   6. verify juliaup and julia still work and the state survived.
+//! These exercise the full upgrade scenario against a local mock server, both
+//! for the explicit `juliaup self update` command and for the automatic
+//! self-update that `julialauncher` triggers in the background at Julia startup.
 //!
 //! Requires the `selfupdate` feature (the real self-update code path) and a
 //! Unix host (the self-update implementation is non-Windows).
@@ -21,11 +17,11 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use predicates::prelude::*;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tiny_http::{Header, Response, Server};
 
 /// Build a gzip-compressed tar containing `juliaup` and `julialauncher` at the
@@ -117,36 +113,68 @@ impl Drop for MockServer {
     }
 }
 
+/// An isolated juliaup "install" laid out so that the self-update code (which
+/// derives its paths from the running executable) operates here instead of
+/// clobbering the cargo target directory:
+///   <install>/bin/juliaup        (running exe)
+///   <install>/bin/julialauncher  (the launcher, named `julia` in dev builds)
+///   <install>/bin/julia          (symlink -> julialauncher, as the installer makes)
+///   <install>/juliaupself.json   (self config)
+struct Install {
+    dir: assert_fs::TempDir,
+    juliaup_exe: PathBuf,
+    julialauncher_exe: PathBuf,
+    julia_symlink: PathBuf,
+}
+
+impl Install {
+    fn setup() -> Self {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let bin = dir.path().join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+
+        let juliaup_exe = bin.join("juliaup");
+        let julialauncher_exe = bin.join("julialauncher");
+        std::fs::copy(cargo_bin("juliaup"), &juliaup_exe).unwrap();
+        std::fs::copy(cargo_bin("julia"), &julialauncher_exe).unwrap();
+
+        // The installer creates this symlink; self-update wipes it (whole-dir
+        // swap) and the `_post-update` hook restores it.
+        let julia_symlink = bin.join("julia");
+        std::os::unix::fs::symlink(&julialauncher_exe, &julia_symlink).unwrap();
+
+        // A minimal self config is required for selfupdate-feature builds to
+        // load the configuration at all.
+        std::fs::write(dir.path().join("juliaupself.json"), "{}").unwrap();
+
+        Install {
+            dir,
+            juliaup_exe,
+            julialauncher_exe,
+            julia_symlink,
+        }
+    }
+
+    fn self_config_path(&self) -> PathBuf {
+        self.dir.path().join("juliaupself.json")
+    }
+
+    fn self_update_recorded(&self) -> bool {
+        std::fs::read_to_string(self.self_config_path())
+            .map(|s| s.contains("LastSelfUpdate"))
+            .unwrap_or(false)
+    }
+}
+
 #[test]
 fn self_update_end_to_end() {
     let env = TestEnv::new();
-
-    // Lay out an isolated juliaup "install" so that self-update operates here
-    // instead of clobbering the cargo target directory. The self-update code
-    // derives its paths from the running executable:
-    //   <install>/bin/juliaup            (running exe)
-    //   <install>/bin/julialauncher      (the launcher, named `julia` in dev)
-    //   <install>/juliaupself.json       (self config)
-    let install = assert_fs::TempDir::new().unwrap();
-    let bin = install.path().join("bin");
-    std::fs::create_dir_all(&bin).unwrap();
-
-    let juliaup_exe = bin.join("juliaup");
-    let julialauncher_exe = bin.join("julialauncher");
-    std::fs::copy(cargo_bin("juliaup"), &juliaup_exe).unwrap();
-    std::fs::copy(cargo_bin("julia"), &julialauncher_exe).unwrap();
-
-    // The installer creates this symlink; self-update wipes it (whole-dir swap)
-    // and the `_post-update` hook restores it.
-    let julia_symlink = bin.join("julia");
-    std::os::unix::fs::symlink(&julialauncher_exe, &julia_symlink).unwrap();
-
-    // A minimal self config is required for selfupdate-feature builds to load
-    // the configuration at all.
-    std::fs::write(install.path().join("juliaupself.json"), "{}").unwrap();
+    let install = Install::setup();
+    let juliaup_exe = &install.juliaup_exe;
+    let julia_symlink = &install.julia_symlink;
 
     let juliaup = |server: Option<&str>| {
-        let mut cmd = Command::new(&juliaup_exe);
+        let mut cmd = Command::new(juliaup_exe);
         cmd.env("JULIA_DEPOT_PATH", env.depot_path());
         cmd.env("JULIAUP_DEPOT_PATH", env.depot_path());
         if let Some(server) = server {
@@ -187,7 +215,7 @@ fn self_update_end_to_end() {
 
     // --- 4. Mock a newer juliaup as available on a loopback server ---
     let bundled_db_version = juliaup::get_bundled_dbversion().unwrap().to_string();
-    let tarball = build_juliaup_tarball(&juliaup_exe, &julialauncher_exe);
+    let tarball = build_juliaup_tarball(&install.juliaup_exe, &install.julialauncher_exe);
     let server = MockServer::start(bundled_db_version, "999.0.0".to_string(), tarball);
 
     // --- 5. Self update ---
@@ -215,14 +243,101 @@ fn self_update_end_to_end() {
     );
 
     // The self-update timestamp was recorded.
-    let self_config = std::fs::read_to_string(install.path().join("juliaupself.json")).unwrap();
     assert!(
-        self_config.contains("LastSelfUpdate"),
-        "self config should record LastSelfUpdate, got: {self_config}"
+        install.self_update_recorded(),
+        "self config should record LastSelfUpdate, got: {:?}",
+        std::fs::read_to_string(install.self_config_path())
     );
 
     // And Julia actually runs via the restored launcher.
-    Command::new(&julia_symlink)
+    Command::new(julia_symlink)
+        .env("JULIA_DEPOT_PATH", env.depot_path())
+        .env("JULIAUP_DEPOT_PATH", env.depot_path())
+        .args(["-e", "print(VERSION)"])
+        .assert()
+        .success()
+        .stdout("1.10.10");
+
+    drop(server);
+}
+
+/// Verifies the automatic self-update that `julialauncher` triggers at Julia
+/// startup: when `startupselfupdateinterval` has elapsed, running `julia`
+/// spawns `juliaup self update` in a background daemon (and then execs into
+/// Julia). This is the path that historically caused issues because the
+/// self-update runs detached from the foreground Julia process.
+#[test]
+fn self_update_auto_triggered_by_launcher() {
+    let env = TestEnv::new();
+    let install = Install::setup();
+    let juliaup_exe = &install.juliaup_exe;
+
+    let juliaup = || {
+        let mut cmd = Command::new(juliaup_exe);
+        cmd.env("JULIA_DEPOT_PATH", env.depot_path());
+        cmd.env("JULIAUP_DEPOT_PATH", env.depot_path());
+        cmd
+    };
+
+    // Disable background versiondb updates, but enable startup self-update so
+    // the launcher will auto-trigger it. With no prior self-update recorded,
+    // the interval is considered elapsed on the next `julia` invocation.
+    juliaup()
+        .args(["config", "versionsdbupdateinterval", "0"])
+        .assert()
+        .success();
+    juliaup()
+        .args(["config", "startupselfupdateinterval", "1"])
+        .assert()
+        .success();
+
+    // Install + default a Julia so the launcher has something to exec into.
+    juliaup().args(["add", "1.10.10"]).assert().success();
+    juliaup().args(["default", "1.10.10"]).assert().success();
+
+    // Mock a newer juliaup as available on a loopback server.
+    let bundled_db_version = juliaup::get_bundled_dbversion().unwrap().to_string();
+    let tarball = build_juliaup_tarball(&install.juliaup_exe, &install.julialauncher_exe);
+    let server = MockServer::start(bundled_db_version, "999.0.0".to_string(), tarball);
+
+    // Precondition: no self-update has happened yet.
+    assert!(
+        !install.self_update_recorded(),
+        "self-update should not have run before launching julia"
+    );
+
+    // Run the launcher via the `julia` symlink. On Unix it forks a background
+    // daemon that auto-triggers `juliaup self update` (inheriting the mock
+    // server env), then execs into Julia which prints its version. The
+    // self-update proceeds asynchronously after `julia` returns.
+    Command::new(&install.julia_symlink)
+        .env("JULIA_DEPOT_PATH", env.depot_path())
+        .env("JULIAUP_DEPOT_PATH", env.depot_path())
+        .env("JULIAUP_SERVER", &server.base_url)
+        .env("JULIAUP_NIGHTLY_SERVER", &server.base_url)
+        .args(["-e", "print(VERSION)"])
+        .assert()
+        .success()
+        .stdout("1.10.10");
+
+    // Wait for the detached self-update to finish: it records the timestamp and
+    // the `_post-update` hook restores the launcher symlink. Poll for the final
+    // stable state to avoid racing the mid-update directory swap.
+    let deadline = Instant::now() + Duration::from_secs(90);
+    loop {
+        if install.self_update_recorded() && install.julia_symlink.symlink_metadata().is_ok() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "launcher-triggered self-update did not complete within timeout; self config: {:?}",
+            std::fs::read_to_string(install.self_config_path())
+        );
+        thread::sleep(Duration::from_millis(250));
+    }
+
+    // Julia still runs via the restored launcher symlink after the auto-update.
+    Command::new(&install.julia_symlink)
         .env("JULIA_DEPOT_PATH", env.depot_path())
         .env("JULIAUP_DEPOT_PATH", env.depot_path())
         .args(["-e", "print(VERSION)"])

--- a/tests/command_selfupdate_test.rs
+++ b/tests/command_selfupdate_test.rs
@@ -1,0 +1,234 @@
+//! End-to-end self-update integration test (see issue #805).
+//!
+//! This exercises a full upgrade scenario against a local mock server:
+//!   1. install an isolated copy of the current juliaup,
+//!   2. disable automatic self-update,
+//!   3. set up some state (a real channel, a linked channel, an alias),
+//!   4. mock a newer juliaup version as available on a loopback server,
+//!   5. run `juliaup self update`,
+//!   6. verify juliaup and julia still work and the state survived.
+//!
+//! Requires the `selfupdate` feature (the real self-update code path) and a
+//! Unix host (the self-update implementation is non-Windows).
+#![cfg(all(unix, feature = "selfupdate"))]
+
+mod utils;
+use utils::TestEnv;
+
+use assert_cmd::cargo::cargo_bin;
+use assert_cmd::Command;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use predicates::prelude::*;
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use tiny_http::{Header, Response, Server};
+
+/// Build a gzip-compressed tar containing `juliaup` and `julialauncher` at the
+/// archive root, mirroring the layout of a real juliaup release tarball.
+fn build_juliaup_tarball(juliaup: &Path, julialauncher: &Path) -> Vec<u8> {
+    fn append_exec<W: Write>(tar: &mut tar::Builder<W>, src: &Path, name: &str) {
+        let data = std::fs::read(src).unwrap();
+        let mut header = tar::Header::new_gnu();
+        header.set_size(data.len() as u64);
+        header.set_mode(0o755);
+        tar.append_data(&mut header, name, &data[..]).unwrap();
+    }
+
+    let mut gz = GzEncoder::new(Vec::new(), Compression::fast());
+    {
+        let mut tar = tar::Builder::new(&mut gz);
+        append_exec(&mut tar, juliaup, "juliaup");
+        append_exec(&mut tar, julialauncher, "julialauncher");
+        tar.finish().unwrap();
+    }
+    gz.finish().unwrap()
+}
+
+/// A local HTTP server that mocks the juliaup release endpoints needed by
+/// `juliaup self update`.
+struct MockServer {
+    base_url: String,
+    stop: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl MockServer {
+    /// `db_version` is served for the versions-db version check; serving the
+    /// bundled value means no versions-db download is triggered. `new_version`
+    /// is served as the available juliaup version, and `tarball` is returned for
+    /// any juliaup binary download request.
+    fn start(db_version: String, new_version: String, tarball: Vec<u8>) -> Self {
+        let server = Arc::new(Server::http("127.0.0.1:0").unwrap());
+        let port = server.server_addr().to_ip().unwrap().port();
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let handle = {
+            let server = Arc::clone(&server);
+            let stop = Arc::clone(&stop);
+            thread::spawn(move || loop {
+                match server.recv_timeout(Duration::from_millis(100)) {
+                    Ok(Some(request)) => {
+                        let url = request.url().to_string();
+                        let response = if url.ends_with("CHANNELDBVERSION") {
+                            Response::from_string(db_version.clone())
+                        } else if url.ends_with("CHANNELVERSION") {
+                            Response::from_string(new_version.clone())
+                        } else if url.contains("/juliaup-") && url.ends_with(".tar.gz") {
+                            Response::from_data(tarball.clone())
+                        } else {
+                            // Catch-all (e.g. the nightly etag-support probe):
+                            // respond 200 with an etag header.
+                            Response::from_string("").with_header(
+                                Header::from_bytes(&b"etag"[..], &b"\"mock\""[..]).unwrap(),
+                            )
+                        };
+                        let _ = request.respond(response);
+                    }
+                    Ok(None) => {
+                        if stop.load(Ordering::Relaxed) {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            })
+        };
+
+        MockServer {
+            base_url,
+            stop,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for MockServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+#[test]
+fn self_update_end_to_end() {
+    let env = TestEnv::new();
+
+    // Lay out an isolated juliaup "install" so that self-update operates here
+    // instead of clobbering the cargo target directory. The self-update code
+    // derives its paths from the running executable:
+    //   <install>/bin/juliaup            (running exe)
+    //   <install>/bin/julialauncher      (the launcher, named `julia` in dev)
+    //   <install>/juliaupself.json       (self config)
+    let install = assert_fs::TempDir::new().unwrap();
+    let bin = install.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+
+    let juliaup_exe = bin.join("juliaup");
+    let julialauncher_exe = bin.join("julialauncher");
+    std::fs::copy(cargo_bin("juliaup"), &juliaup_exe).unwrap();
+    std::fs::copy(cargo_bin("julia"), &julialauncher_exe).unwrap();
+
+    // The installer creates this symlink; self-update wipes it (whole-dir swap)
+    // and the `_post-update` hook restores it.
+    let julia_symlink = bin.join("julia");
+    std::os::unix::fs::symlink(&julialauncher_exe, &julia_symlink).unwrap();
+
+    // A minimal self config is required for selfupdate-feature builds to load
+    // the configuration at all.
+    std::fs::write(install.path().join("juliaupself.json"), "{}").unwrap();
+
+    let juliaup = |server: Option<&str>| {
+        let mut cmd = Command::new(&juliaup_exe);
+        cmd.env("JULIA_DEPOT_PATH", env.depot_path());
+        cmd.env("JULIAUP_DEPOT_PATH", env.depot_path());
+        if let Some(server) = server {
+            cmd.env("JULIAUP_SERVER", server);
+            cmd.env("JULIAUP_NIGHTLY_SERVER", server);
+        }
+        cmd
+    };
+
+    // --- 2. Disable automatic self-update (and background versiondb updates) ---
+    juliaup(None)
+        .args(["config", "startupselfupdateinterval", "0"])
+        .assert()
+        .success();
+    juliaup(None)
+        .args(["config", "backgroundselfupdateinterval", "0"])
+        .assert()
+        .success();
+    juliaup(None)
+        .args(["config", "versionsdbupdateinterval", "0"])
+        .assert()
+        .success();
+
+    // --- 3. Set up state against the real server: a channel, a link, an alias ---
+    juliaup(None).args(["add", "1.10.10"]).assert().success();
+    juliaup(None)
+        .args(["default", "1.10.10"])
+        .assert()
+        .success();
+    juliaup(None)
+        .args(["link", "custom", "/usr/bin/false"])
+        .assert()
+        .success();
+    juliaup(None)
+        .args(["link", "stable", "+1.10.10"])
+        .assert()
+        .success();
+
+    // --- 4. Mock a newer juliaup as available on a loopback server ---
+    let bundled_db_version = juliaup::get_bundled_dbversion().unwrap().to_string();
+    let tarball = build_juliaup_tarball(&juliaup_exe, &julialauncher_exe);
+    let server = MockServer::start(bundled_db_version, "999.0.0".to_string(), tarball);
+
+    // --- 5. Self update ---
+    juliaup(Some(&server.base_url))
+        .args(["self", "update"])
+        .assert()
+        .success()
+        .stderr(
+            predicate::str::contains("Updated Juliaup to version 999.0.0")
+                .or(predicate::str::contains("Found new version 999.0.0")),
+        );
+
+    // --- 6. Verify the installation still works ---
+    // The launcher symlink must have been restored by the post-update hook.
+    assert!(
+        julia_symlink.symlink_metadata().is_ok(),
+        "julia launcher symlink should be restored after self-update"
+    );
+
+    // juliaup itself runs and the configured state survived the update.
+    juliaup(None).args(["status"]).assert().success().stdout(
+        predicate::str::contains("1.10.10")
+            .and(predicate::str::contains("custom"))
+            .and(predicate::str::contains("stable")),
+    );
+
+    // The self-update timestamp was recorded.
+    let self_config = std::fs::read_to_string(install.path().join("juliaupself.json")).unwrap();
+    assert!(
+        self_config.contains("LastSelfUpdate"),
+        "self config should record LastSelfUpdate, got: {self_config}"
+    );
+
+    // And Julia actually runs via the restored launcher.
+    Command::new(&julia_symlink)
+        .env("JULIA_DEPOT_PATH", env.depot_path())
+        .env("JULIAUP_DEPOT_PATH", env.depot_path())
+        .args(["-e", "print(VERSION)"])
+        .assert()
+        .success()
+        .stdout("1.10.10");
+
+    drop(server);
+}


### PR DESCRIPTION
Implements the first part of https://github.com/JuliaLang/juliaup/issues/805#issuecomment-4634996695

Claude:

---

Adds blind integration tests that exercise the real self-update code paths against a local mock server.

**`self_update_end_to_end`** — the explicit `juliaup self update` command:
  1. installs an isolated copy of juliaup,
  2. disables automatic self-update,
  3. sets up state (a system channel, a linked channel, an alias),
  4. mocks a newer juliaup version on a loopback server,
  5. runs `juliaup self update`,
  6. verifies juliaup/julia still work and the state survived.

**`self_update_auto_triggered_by_launcher`** — the automatic path: with `startupselfupdateinterval` elapsed, running the `julia` launcher forks a background daemon that spawns `juliaup self update` (inheriting the mock-server env) and then execs into Julia. The test waits for the detached update to finish and verifies the launcher symlink is restored and julia still runs.

To let the tests point juliaup at a local mock server, allow plain HTTP for loopback hosts (localhost / 127.0.0.1 / ::1) in `get_juliaserver_base_url` and `get_julianightlies_base_url`. HTTPS remains required for all non-loopback servers, so this only affects traffic that never leaves the machine.

The tests need the `selfupdate` feature, which changes config loading in a way incompatible with the other integration tests, so they run in their own CI job (`test-selfupdate`) on Linux and macOS.