### PR TITLE
Isolate HOME in tests so they don't modify the user's shell rc files

### DIFF
--- a/tests/command_post_update_test.rs
+++ b/tests/command_post_update_test.rs
@@ -11,8 +11,7 @@ use std::path::Path;
 
 fn juliaup(exe: &Path, env: &TestEnv) -> Command {
     let mut cmd = Command::new(exe);
-    cmd.env("JULIA_DEPOT_PATH", env.depot_path());
-    cmd.env("JULIAUP_DEPOT_PATH", env.depot_path());
+    env.apply_env(&mut cmd);
     cmd
 }
 
@@ -69,9 +68,9 @@ fn post_update_restores_julia_symlink() {
     assert_eq!(fs::read_link(&julia).unwrap(), julialauncher_exe);
 
     // And julia must actually run via the restored symlink.
-    Command::new(&julia)
-        .env("JULIA_DEPOT_PATH", env.depot_path())
-        .env("JULIAUP_DEPOT_PATH", env.depot_path())
+    let mut julia_cmd = Command::new(&julia);
+    env.apply_env(&mut julia_cmd);
+    julia_cmd
         .args(["-e", "print(VERSION)"])
         .assert()
         .success()

--- a/tests/command_selfupdate_test.rs
+++ b/tests/command_selfupdate_test.rs
@@ -175,8 +175,7 @@ fn self_update_end_to_end() {
 
     let juliaup = |server: Option<&str>| {
         let mut cmd = Command::new(juliaup_exe);
-        cmd.env("JULIA_DEPOT_PATH", env.depot_path());
-        cmd.env("JULIAUP_DEPOT_PATH", env.depot_path());
+        env.apply_env(&mut cmd);
         if let Some(server) = server {
             cmd.env("JULIAUP_SERVER", server);
             cmd.env("JULIAUP_NIGHTLY_SERVER", server);
@@ -250,9 +249,9 @@ fn self_update_end_to_end() {
     );
 
     // And Julia actually runs via the restored launcher.
-    Command::new(julia_symlink)
-        .env("JULIA_DEPOT_PATH", env.depot_path())
-        .env("JULIAUP_DEPOT_PATH", env.depot_path())
+    let mut julia_cmd = Command::new(julia_symlink);
+    env.apply_env(&mut julia_cmd);
+    julia_cmd
         .args(["-e", "print(VERSION)"])
         .assert()
         .success()
@@ -274,8 +273,7 @@ fn self_update_auto_triggered_by_launcher() {
 
     let juliaup = || {
         let mut cmd = Command::new(juliaup_exe);
-        cmd.env("JULIA_DEPOT_PATH", env.depot_path());
-        cmd.env("JULIAUP_DEPOT_PATH", env.depot_path());
+        env.apply_env(&mut cmd);
         cmd
     };
 
@@ -310,9 +308,9 @@ fn self_update_auto_triggered_by_launcher() {
     // daemon that auto-triggers `juliaup self update` (inheriting the mock
     // server env), then execs into Julia which prints its version. The
     // self-update proceeds asynchronously after `julia` returns.
-    Command::new(&install.julia_symlink)
-        .env("JULIA_DEPOT_PATH", env.depot_path())
-        .env("JULIAUP_DEPOT_PATH", env.depot_path())
+    let mut julia_cmd = Command::new(&install.julia_symlink);
+    env.apply_env(&mut julia_cmd);
+    julia_cmd
         .env("JULIAUP_SERVER", &server.base_url)
         .env("JULIAUP_NIGHTLY_SERVER", &server.base_url)
         .args(["-e", "print(VERSION)"])
@@ -337,9 +335,9 @@ fn self_update_auto_triggered_by_launcher() {
     }
 
     // Julia still runs via the restored launcher symlink after the auto-update.
-    Command::new(&install.julia_symlink)
-        .env("JULIA_DEPOT_PATH", env.depot_path())
-        .env("JULIAUP_DEPOT_PATH", env.depot_path())
+    let mut julia_cmd = Command::new(&install.julia_symlink);
+    env.apply_env(&mut julia_cmd);
+    julia_cmd
         .args(["-e", "print(VERSION)"])
         .assert()
         .success()

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 /// with isolated depot directories.
 pub struct TestEnv {
     depot_dir: TempDir,
+    home_dir: TempDir,
 }
 
 impl Default for TestEnv {
@@ -17,26 +18,40 @@ impl Default for TestEnv {
 #[allow(dead_code)] // May not be used in all test configurations
 impl TestEnv {
     /// Create a new test environment with an isolated temporary depot directory
+    /// and an isolated home directory, so that code paths that modify files in
+    /// the user's home (e.g. shell startup scripts during self-update) never
+    /// touch the real one.
     pub fn new() -> Self {
         Self {
             depot_dir: TempDir::new().unwrap(),
+            home_dir: TempDir::new().unwrap(),
         }
+    }
+
+    /// Apply the isolated depot and home directories to a command.
+    pub fn apply_env(&self, cmd: &mut Command) {
+        cmd.env("JULIA_DEPOT_PATH", self.depot_dir.path());
+        cmd.env("JULIAUP_DEPOT_PATH", self.depot_dir.path());
+        cmd.env("HOME", self.home_dir.path());
     }
 
     /// Get a Command for running juliaup with the test environment's depot paths
     pub fn juliaup(&self) -> Command {
         let mut cmd = cargo_bin_cmd!("juliaup");
-        cmd.env("JULIA_DEPOT_PATH", self.depot_dir.path());
-        cmd.env("JULIAUP_DEPOT_PATH", self.depot_dir.path());
+        self.apply_env(&mut cmd);
         cmd
     }
 
     /// Get a Command for running julia with the test environment's depot paths
     pub fn julia(&self) -> Command {
         let mut cmd = cargo_bin_cmd!("julia");
-        cmd.env("JULIA_DEPOT_PATH", self.depot_dir.path());
-        cmd.env("JULIAUP_DEPOT_PATH", self.depot_dir.path());
+        self.apply_env(&mut cmd);
         cmd
+    }
+
+    /// Get the isolated home directory path
+    pub fn home_path(&self) -> &Path {
+        self.home_dir.path()
     }
 
     /// Get the path to the juliaup config file


### PR DESCRIPTION
Previously running these tests locally messed with/broke my juliaup install because it replaced juliaup with the temp version from the test in my `.zshrc`.


Claude:

---

The self-update and post-update integration tests exercise the `_post-update` hook, which calls refresh_existing_shell_init_blocks. That rewrites the juliaup init block in any shell startup file under the user's home directory — so running these tests locally on a machine with a real juliaup install repointed ~/.zshrc's PATH at the test's temp-dir install, breaking the user's shell.

TestEnv now creates an isolated temporary home directory alongside the isolated depot and sets HOME on every spawned command (dirs::home_dir honors $HOME on Unix). The selfupdate and post-update tests' hand-built commands route through the new TestEnv::apply_env so the launcher's detached self-update daemon inherits the isolation too.