### PR TITLE
Document more installer self-update options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ Here `<ARGS>` should be replaced with one or more of the following arguments:
 - `--default-channel <NAME>`: Configure the default channel. For example `--default-channel lts` would install the `lts` channel and configure it as the default.
 - `--path` (or `-p`): Install `juliaup` in a custom location.
     - For example, if you want to install `juliaup` into `~/my/desired/juliaup/path`, you would run the following command: `curl -fsSL https://install.julialang.org | sh -s -- --path ~/my/desired/juliaup/path`
+- `--add-to-path <yes|no|0|1>`: Control whether the installer modifies shell startup files to add the Juliaup bin directory to `PATH`. Defaults to `yes`.
+- `--background-selfupdate <MINUTES>`: Configure how often a background task checks for Juliaup self-updates. Use `0` to disable background self-updates. Defaults to `0`.
+- `--startup-selfupdate <MINUTES>`: Configure how often Julia startup checks for Juliaup self-updates. Use `0` to disable startup self-updates. Defaults to `1440`.
+
+For example, a non-interactive install into a custom location that does not modify `PATH` and disables both self-update checks can be run as:
+
+```bash
+curl -fsSL https://install.julialang.org | sh -s -- \
+    --path "$JULIAUP_DEPOT_PATH" \
+    --yes \
+    --add-to-path=no \
+    --background-selfupdate=0 \
+    --startup-selfupdate=0
+```
 
 ### Software Repositories
 

--- a/deploy/shellscript/juliaup-init.sh
+++ b/deploy/shellscript/juliaup-init.sh
@@ -43,13 +43,19 @@ USAGE:
 
 FLAGS:
     -y, --yes                   Disable confirmation prompt.
-        --add-to-path           Add to user PATH environment variable
-        --background-selfupdate Background self-update interval
-        --startup-selfupdate    Startup self-update interval
+        --add-to-path <yes|no|0|1>
+                                Add the Juliaup bin directory to PATH startup
+                                files. Defaults to yes.
+        --background-selfupdate <MINUTES>
+                                Check for Juliaup self-updates in the
+                                background every MINUTES minutes. Defaults to 0.
+        --startup-selfupdate <MINUTES>
+                                Check for Juliaup self-updates when Julia starts
+                                every MINUTES minutes. Defaults to 1440.
     -h, --help                  Prints help information
 
 OPTIONS:
-    -p, --path              Custom install path
+    -p, --path PATH             Custom install path
 
 EOF
 }

--- a/src/bin/juliainstaller.rs
+++ b/src/bin/juliainstaller.rs
@@ -132,15 +132,27 @@ struct Juliainstaller {
     /// Specify alternate path for Juliaup
     #[clap(short = 'p', long = "path")]
     alternate_path: Option<String>,
-    /// Control adding the Juliaup dir to the PATH
-    /// Use Option<bool> and default_value="yes" to force --add-to-path=[yes|no|0|1] instead of flag
-    #[clap(long = "add-to-path", value_parser = BoolishValueParser::new(), default_value = "yes")]
+    /// Add the Juliaup bin directory to PATH startup files
+    #[clap(
+        long = "add-to-path",
+        value_parser = BoolishValueParser::new(),
+        default_value = "yes",
+        value_name = "yes|no|0|1"
+    )]
     add_to_path: Option<bool>,
-    /// Manually specify the background self-update interval
-    #[clap(long = "background-selfupdate", default_value_t = 0)]
+    /// Check for Juliaup self-updates in the background every MINUTES minutes
+    #[clap(
+        long = "background-selfupdate",
+        default_value_t = 0,
+        value_name = "MINUTES"
+    )]
     background_selfupdate_interval: i64,
-    /// Manually specify the statup self-update interval
-    #[clap(long = "startup-selfupdate", default_value_t = 1440)]
+    /// Check for Juliaup self-updates when Julia starts every MINUTES minutes
+    #[clap(
+        long = "startup-selfupdate",
+        default_value_t = 1440,
+        value_name = "MINUTES"
+    )]
     startup_selfupdate_interval: i64,
 }
 

--- a/tests/juliainstaller_help.rs
+++ b/tests/juliainstaller_help.rs
@@ -1,0 +1,30 @@
+#![cfg(all(feature = "binjuliainstaller", feature = "selfupdate"))]
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+
+#[test]
+fn installer_help_documents_noninteractive_options() {
+    cargo_bin_cmd!("juliainstaller")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "--add-to-path <yes|no|0|1>",
+        ))
+        .stdout(predicate::str::contains(
+            "Add the Juliaup bin directory to PATH startup files [default: yes]",
+        ))
+        .stdout(predicate::str::contains(
+            "--background-selfupdate <MINUTES>",
+        ))
+        .stdout(predicate::str::contains(
+            "Check for Juliaup self-updates in the background every MINUTES minutes [default: 0]",
+        ))
+        .stdout(predicate::str::contains(
+            "--startup-selfupdate <MINUTES>",
+        ))
+        .stdout(predicate::str::contains(
+            "Check for Juliaup self-updates when Julia starts every MINUTES minutes [default: 1440]",
+        ));
+}


### PR DESCRIPTION
Document `--add-to-path`, `--background-selfupdate` and `--startup-selfupdate` options in the README; improve their documentation in the usage text printed by the script.

Co-authored-by: Codex <codex@openai.com>

Resolves #1432