### PR TITLE
Give each check-juliaup matrix job its own rust-cache key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,11 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
         target: ${{matrix.target}}
+        # Without this, all matrix jobs on one OS share a single job-id-based
+        # cache key. The cross containers differ in glibc version (see
+        # Cross.toml), so a target/ dir saved by a new-glibc job breaks build
+        # scripts when restored into an old-glibc container.
+        cache-key: ${{matrix.label}}
     - if: ${{ matrix.os == 'ubuntu' }}
       uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
       with:


### PR DESCRIPTION
All Linux check-juliaup jobs shared one job-id-based rust-cache key, but they build inside cross-rs containers with different glibc versions (see Cross.toml): some targets use :edge images (Ubuntu 24.04, glibc 2.39) while x86_64-musl is on the 0.2.5 image, i686-gnu is pinned to an older digest, and the freebsd :edge image is still built on an older base.

Cargo build scripts are compiled for the host side of the container, so whichever job wins the cache-save race determines the glibc requirement of the cached build-script binaries. After #1550 bumped Cargo.lock, the aarch64-musl (:edge, glibc 2.39) job saved the shared cache, and the next push to main failed in every old-glibc container with "version `GLIBC_2.39' not found" when re-running the cached libc build script.

Pass the matrix label as an additional cache key so each target caches its own container-built artifacts. This also sidesteps the existing poisoned cache entry without needing to delete it, since every key changes. test-juliaup is unaffected: it always builds on the host, so its shared cache never crosses glibc boundaries.