### PR TITLE
Add concise Julia version formatter

### DIFF
--- a/src/command_list.rs
+++ b/src/command_list.rs
@@ -1,4 +1,5 @@
 use crate::operations::{channel_to_name, get_channel_variations};
+use crate::utils::format_version_for_display;
 use crate::{global_paths::GlobalPaths, versions_file::load_versions_db};
 use anyhow::{Context, Result};
 use cli_table::{
@@ -42,7 +43,7 @@ pub fn run_command_list(paths: &GlobalPaths) -> Result<()> {
         .map(|i| -> ChannelRow {
             ChannelRow {
                 name: i.0.to_string(),
-                version: i.1.version.clone(),
+                version: format_version_for_display(&i.1.version),
             }
         })
         .sorted_by(|a, b| cmp(&a.name, &b.name))

--- a/src/command_status.rs
+++ b/src/command_status.rs
@@ -2,6 +2,7 @@ use crate::config_file::load_config_db;
 use crate::config_file::{JuliaupConfigChannel, JuliaupReadonlyConfigFile};
 use crate::global_paths::GlobalPaths;
 use crate::jsonstructs_versionsdb::JuliaupVersionDB;
+use crate::utils::format_version_for_display;
 use crate::versions_file::load_versions_db;
 use anyhow::{Context, Result};
 use cli_table::format::HorizontalLine;
@@ -45,15 +46,16 @@ fn format_linked_command(command: &str, args: &Option<Vec<String>>) -> String {
 fn format_version(channel_name: &str, channel: &JuliaupConfigChannel) -> String {
     match channel {
         JuliaupConfigChannel::DirectDownloadChannel { version, .. } => {
+            let version = format_version_for_display(version);
             match Regex::new(r"^pr(\d+)").unwrap().captures(channel_name) {
                 Some(caps) => format!(
                     "{version} https://github.com/JuliaLang/julia/pull/{}",
                     &caps[1]
                 ),
-                None => version.clone(),
+                None => version,
             }
         }
-        JuliaupConfigChannel::SystemChannel { version } => version.clone(),
+        JuliaupConfigChannel::SystemChannel { version } => format_version_for_display(version),
         JuliaupConfigChannel::LinkedChannel { command, args } => {
             format_linked_command(command, args)
         }
@@ -80,9 +82,10 @@ fn get_update_info(
         } => (local_etag != server_etag).then(|| "Update available".to_string()),
         JuliaupConfigChannel::SystemChannel { version } => {
             match versiondb_data.available_channels.get(channel_name) {
-                Some(channel) if &channel.version != version => {
-                    Some(format!("Update to {} available", channel.version))
-                }
+                Some(channel) if &channel.version != version => Some(format!(
+                    "Update to {} available",
+                    format_version_for_display(&channel.version)
+                )),
                 _ => None,
             }
         }
@@ -97,9 +100,10 @@ fn get_update_info(
                 }) => (local_etag != server_etag).then(|| "Update available".to_string()),
                 Some(JuliaupConfigChannel::SystemChannel { version }) => {
                     match versiondb_data.available_channels.get(target) {
-                        Some(channel) if channel.version != *version => {
-                            Some(format!("Update to {} available", channel.version))
-                        }
+                        Some(channel) if channel.version != *version => Some(format!(
+                            "Update to {} available",
+                            format_version_for_display(&channel.version)
+                        )),
                         _ => None,
                     }
                 }
@@ -204,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn format_version_system_channel_unchanged() {
+    fn format_version_system_channel_drops_build_metadata() {
         assert_eq!(
             format_version(
                 "1.11",
@@ -212,7 +216,7 @@ mod tests {
                     version: "1.11.2+0.x64.apple.darwin14".to_string()
                 }
             ),
-            "1.11.2+0.x64.apple.darwin14"
+            "1.11.2"
         );
     }
 }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -13,6 +13,7 @@ use crate::get_juliaup_target;
 use crate::global_paths::GlobalPaths;
 use crate::jsonstructs_versionsdb::JuliaupVersionDB;
 use crate::utils::check_server_supports_nightlies;
+use crate::utils::format_version_for_display;
 use crate::utils::get_bin_dir;
 use crate::utils::get_julianightlies_base_url;
 use crate::utils::get_juliaprs_base_url;
@@ -736,6 +737,10 @@ fn compute_relative_binary_path(
         })
 }
 
+fn format_julia_installation_name(fullversion: &str) -> String {
+    format!("Julia {}", format_version_for_display(fullversion))
+}
+
 /// Downloads and extracts a database version of Julia into a temporary
 /// directory inside `juliauphome`, without acquiring the configuration lock.
 ///
@@ -804,7 +809,7 @@ pub fn download_version_to_temp(
 
         print_juliaup_style(
             "Installing",
-            &format!("Julia {}", fullversion),
+            &format_julia_installation_name(fullversion),
             JuliaupMessageType::Progress,
         );
 
@@ -1683,7 +1688,7 @@ pub fn garbage_collect_versions(
         for i in versions_to_uninstall {
             print_juliaup_style(
                 "Tidyup",
-                &format!("Removed Julia {}", i),
+                &format!("Removed Julia {}", format_version_for_display(&i)),
                 JuliaupMessageType::Success,
             );
             config_data.installed_versions.remove(&i);
@@ -1781,14 +1786,18 @@ fn create_system_channel_symlink(
                 "symlink {} ( {} -> {} )",
                 symlink_name,
                 prev_target.to_string_lossy(),
-                version
+                format_version_for_display(version)
             ),
             JuliaupMessageType::Progress,
         );
     } else {
         print_juliaup_style(
             "Creating",
-            &format!("symlink {} for Julia {}", symlink_name, version),
+            &format!(
+                "symlink {} for Julia {}",
+                symlink_name,
+                format_version_for_display(version)
+            ),
             JuliaupMessageType::Progress,
         );
     }
@@ -1820,14 +1829,18 @@ fn create_direct_download_symlink(
                 "symlink {} ( {} -> {} )",
                 symlink_name,
                 prev_target.to_string_lossy(),
-                version
+                format_version_for_display(version)
             ),
             JuliaupMessageType::Progress,
         );
     } else {
         print_juliaup_style(
             "Creating",
-            &format!("symlink {} for Julia {}", symlink_name, version),
+            &format!(
+                "symlink {} for Julia {}",
+                symlink_name,
+                format_version_for_display(version)
+            ),
             JuliaupMessageType::Progress,
         );
     }
@@ -2972,6 +2985,14 @@ mod tests {
                 std::env::remove_var(self.key);
             }
         }
+    }
+
+    #[test]
+    fn julia_installation_name_omits_build_metadata() {
+        assert_eq!(
+            format_julia_installation_name("1.12.6+0.aarch64.apple.darwin14"),
+            "Julia 1.12.6"
+        );
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -438,6 +438,16 @@ pub fn get_arch() -> Result<String> {
     bail!("Running on an unknown arch: {}.", std::env::consts::ARCH)
 }
 
+pub fn format_version_for_display(value: &str) -> String {
+    match Version::parse(value) {
+        Ok(mut version) => {
+            version.build = BuildMetadata::EMPTY;
+            version.to_string()
+        }
+        Err(_) => value.to_string(),
+    }
+}
+
 pub fn parse_versionstring(value: &String) -> Result<(String, Version)> {
     let version = Version::parse(value).unwrap();
 
@@ -491,6 +501,24 @@ mod tests {
         let (p, v) = parse_versionstring(&s.to_owned()).unwrap();
         assert_eq!(p, "x64");
         assert_eq!(v, Version::new(1, 10, 10));
+    }
+
+    #[test]
+    fn format_version_for_display_removes_build_metadata() {
+        assert_eq!(
+            format_version_for_display("1.12.6+0.aarch64.apple.darwin14"),
+            "1.12.6"
+        );
+        assert_eq!(
+            format_version_for_display("1.13.0-rc1+0.x64.linux.gnu"),
+            "1.13.0-rc1"
+        );
+    }
+
+    #[test]
+    fn format_version_for_display_preserves_other_strings() {
+        assert_eq!(format_version_for_display("1.12.6"), "1.12.6");
+        assert_eq!(format_version_for_display("nightly"), "nightly");
     }
 
     #[test]

--- a/tests/command_gc.rs
+++ b/tests/command_gc.rs
@@ -1,4 +1,6 @@
 use predicates::prelude::*;
+use serde_json::json;
+use std::fs;
 
 mod utils;
 use utils::TestEnv;
@@ -51,4 +53,34 @@ fn command_gc() {
             .and(predicate::str::contains("julic").not())
             .and(predicate::str::contains("julib").not()),
     );
+}
+
+#[test]
+fn command_gc_formats_removed_versions_for_display() {
+    let env = TestEnv::new();
+    let config_path = env.config_path();
+    fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    fs::write(
+        &config_path,
+        serde_json::to_vec_pretty(&json!({
+            "Default": null,
+            "InstalledVersions": {
+                "1.12.6+0.aarch64.apple.darwin14": {
+                    "Path": "missing-version-directory"
+                }
+            },
+            "InstalledChannels": {},
+            "Settings": {},
+            "Overrides": []
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    env.juliaup()
+        .arg("gc")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Removed Julia 1.12.6"))
+        .stderr(predicate::str::contains("+0.").not());
 }

--- a/tests/command_initial_setup_from_launcher_test.rs
+++ b/tests/command_initial_setup_from_launcher_test.rs
@@ -30,7 +30,8 @@ fn command_initial_setup() {
                             .and(predicate::str::contains("done.\n"))
                             .or(predicate::str::contains("Mounting installer")),
                     ),
-            ),
+            )
+            .and(predicate::str::contains("+0.").not()),
         );
 
     depot_dir

--- a/tests/command_list_test.rs
+++ b/tests/command_list_test.rs
@@ -12,6 +12,7 @@ fn command_list() {
         .assert()
         .success()
         .stdout(predicate::str::starts_with(" Channel").and(predicate::str::contains("release")))
+        .stdout(predicate::str::contains("+0.").not())
         .stdout(predicate::str::contains("nightly"))
         .stdout(predicate::str::contains("x.y-nightly"))
         .stdout(predicate::str::contains("pr{number}"));

--- a/tests/command_status_test.rs
+++ b/tests/command_status_test.rs
@@ -1,3 +1,7 @@
+use predicates::prelude::*;
+use serde_json::json;
+use std::fs;
+
 mod utils;
 use utils::TestEnv;
 
@@ -16,4 +20,35 @@ fn command_status() {
         .assert()
         .success()
         .stdout(" Default  Channel  Version  Update \n-----------------------------------\n");
+}
+
+#[test]
+fn command_status_formats_system_versions_for_display() {
+    let env = TestEnv::new();
+    let config_path = env.config_path();
+    fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    fs::write(
+        &config_path,
+        serde_json::to_vec_pretty(&json!({
+            "Default": "release",
+            "InstalledVersions": {},
+            "InstalledChannels": {
+                "release": {
+                    "Version": "1.0.0+0.x64.apple.darwin14"
+                }
+            },
+            "Settings": {},
+            "Overrides": []
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    env.juliaup()
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("release"))
+        .stdout(predicate::str::contains("1.0.0"))
+        .stdout(predicate::str::contains("+0.").not());
 }


### PR DESCRIPTION
Co-authored-by: Codex <codex@openai.com>

Resolves #109.

Before:
```console
$ juliaup  list
 Channel                Version
---------------------------------------------------------------
 0                      0.7.0+0.x64.apple.darwin14
 0.7                    0.7.0+0.x64.apple.darwin14
 0.7.0                  0.7.0+0.x64.apple.darwin14
 0.7.0~x64              0.7.0+0.x64.apple.darwin14
 0.7~x64                0.7.0+0.x64.apple.darwin14
 0~x64                  0.7.0+0.x64.apple.darwin14
 1                      1.12.6+0.aarch64.apple.darwin14
 1.0                    1.0.5+0.x64.apple.darwin14
 1.0.0                  1.0.0+0.x64.apple.darwin14
 1.0.0~x64              1.0.0+0.x64.apple.darwin14
 1.0.1                  1.0.1+0.x64.apple.darwin14
 1.0.1~x64              1.0.1+0.x64.apple.darwin14
...
 release                1.12.6+0.aarch64.apple.darwin14
 release~aarch64        1.12.6+0.aarch64.apple.darwin14
 release~x64            1.12.6+0.x64.apple.darwin14
 nightly                latest-macos-aarch64
 nightly~aarch64        latest-macos-aarch64
 nightly~x64            latest-macos-x86_64
 x.y-nightly            x.y-nightly-macos-aarch64
 x.y-nightly~aarch64    x.y-nightly-macos-aarch64
 x.y-nightly~x64        x.y-nightly-macos-x86_64
 pr{number}             pr{number}-macos-aarch64
 pr{number}~aarch64     pr{number}-macos-aarch64
 pr{number}~x64         pr{number}-macos-x86_64
```

After:
```console
$ ./target/debug/juliaup list
 Channel                Version
--------------------------------------------------
 0                      0.7.0
 0.7                    0.7.0
 0.7.0                  0.7.0
 0.7.0~x64              0.7.0
 0.7~x64                0.7.0
 0~x64                  0.7.0
 1                      1.12.6
 1.0                    1.0.5
 1.0.0                  1.0.0
 1.0.0~x64              1.0.0
 1.0.1                  1.0.1
 1.0.1~x64              1.0.1
...
 release                1.12.6
 release~aarch64        1.12.6
 release~x64            1.12.6
 nightly                latest-macos-aarch64
 nightly~aarch64        latest-macos-aarch64
 nightly~x64            latest-macos-x86_64
 x.y-nightly            x.y-nightly-macos-aarch64
 x.y-nightly~aarch64    x.y-nightly-macos-aarch64
 x.y-nightly~x64        x.y-nightly-macos-x86_64
 pr{number}             pr{number}-macos-aarch64
 pr{number}~aarch64     pr{number}-macos-aarch64
 pr{number}~x64         pr{number}-macos-x86_64
```
