### PR TITLE
Fix SIGILL when closing the GUI window on macOS

### DIFF
--- a/juliaupgui/src/app.rs
+++ b/juliaupgui/src/app.rs
@@ -3337,6 +3337,13 @@ pub fn run(paths: GlobalPaths) -> anyhow::Result<()> {
             .with_icon(icon)
             .with_inner_size([860.0, 540.0])
             .with_min_inner_size([754.0, 380.0]),
+        // Do not use winit's `run_on_demand`. Returning from the event loop
+        // tears the window down while NSApplication is still alive, and AppKit
+        // then throws while unregistering its touch bar KVO observer on the
+        // dead window. An unhandled ObjC exception becomes SIGILL, so closing
+        // the window killed the process with "illegal hardware instruction".
+        // Letting the event loop own shutdown avoids that path entirely.
+        run_and_return: false,
         ..Default::default()
     };
 

--- a/src/bin/juliaup.rs
+++ b/src/bin/juliaup.rs
@@ -175,10 +175,18 @@ fn main() -> Result<()> {
                     exe.display()
                 );
             }
-            std::process::Command::new(&exe)
+            let status = std::process::Command::new(&exe)
                 .status()
-                .with_context(|| format!("Failed to launch GUI at '{}'", exe.display()))
-                .map(|_| ())
+                .with_context(|| format!("Failed to launch GUI at '{}'", exe.display()))?;
+            // Surface a crash or non-zero exit instead of reporting success.
+            // On Unix `status` renders signal deaths as e.g. `signal: 4 (SIGILL)`.
+            if !status.success() {
+                anyhow::bail!(
+                    "The GUI at '{}' exited abnormally ({status}).",
+                    exe.display()
+                );
+            }
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
Claude:

---

Closing the juliaupgui window killed the process on macOS:

```
% juliaupgui
zsh: illegal hardware instruction  juliaupgui
```

## Cause

From the crash reports in `~/Library/Logs/DiagnosticReports/`:

```
EXC_BAD_INSTRUCTION (SIGILL) in -[NSApplication _crashOnException:]
  -[_NSTouchBarFinderObservation invalidate]
  -[NSObject removeObserver:forKeyPath:context:]   <- throws here
```

eframe defaults `run_and_return` to `true`, which drives the event loop through
winit's `run_on_demand`. That tears the window down and hands control back to
Rust while `NSApplication` is still alive. AppKit then throws while
unregistering its touch bar KVO observer against the dead window, and any
unhandled ObjC exception is turned into SIGILL.

This is not a regression from the recent egui 0.29 -> 0.36 bump. Both use winit
0.30 and `run_and_return` has defaulted to `true` throughout. The dev channel
release was simply the first time the window got closed on a released build.

## Fix

Set `run_and_return: false`, so `EventLoop::run` owns shutdown and the process
exits through normal NSApplication termination, never reaching that teardown
path. eframe documents `false` as the escape hatch for exactly this kind of bug.

Verified with a temporary auto-close harness, same binary, that flag the only
variable:

| `run_and_return` | Result |
| --- | --- |
| `true` (default) | exit 132, SIGILL |
| `false` | exit 0, three consecutive runs |

## Also

`juliaup gui` was discarding the GUI's exit status via `.status().map(|_| ())`,
so a crashing GUI still looked like a clean run and this bug was only visible
when invoking `juliaupgui` directly. It now surfaces a non-zero or signal exit.

## Caveat

Verified under the debug profile. The release profile uses `lto = true` and
`codegen-units = 1`, so a smoke test of the real release binary is worth doing
before cutting a release.
