### PR TITLE
Support FreeBSD in juliaupgui

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,12 @@ jobs:
           df -h
           export CARGO_INCREMENTAL=0
           cargo build --verbose --release ${{matrix.bins}} --target ${{matrix.target}} --features ${{matrix.features}}
+          # juliaupgui needs X11/xkb/OpenGL headers, which live in ports rather
+          # than the FreeBSD base system. Unlike the other targets, the GUI is
+          # built inside this VM instead of via cross, because the cross FreeBSD
+          # sysroot only carries base.
+          pkg install -y pkgconf libX11 libxcb libxkbcommon mesa-libs
+          cargo build --verbose --release -p juliaupgui --target ${{matrix.target}}
     - uses: actions/upload-artifact@v7
       with:
         name: juliaup-${{matrix.label}}
@@ -560,6 +566,7 @@ jobs:
         chmod a+rx target/aarch64-unknown-linux-musl/julialauncher
         chmod a+rx target/x86_64-unknown-freebsd/juliaup
         chmod a+rx target/x86_64-unknown-freebsd/julialauncher
+        chmod a+rx -f target/x86_64-unknown-freebsd/juliaupgui || true
     - name: Export version
       run: |
         export VERSION=$(echo $GH_REF | sed 's:refs/tags/v::')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
           # than the FreeBSD base system. Unlike the other targets, the GUI is
           # built inside this VM instead of via cross, because the cross FreeBSD
           # sysroot only carries base.
-          pkg install -y pkgconf libX11 libxcb libxkbcommon mesa-libs
+          sudo pkg install -y pkgconf libX11 libxcb libxkbcommon mesa-libs
           cargo build --verbose --release -p juliaupgui --target ${{matrix.target}}
     - uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -334,3 +334,41 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
     - name: Test juliaupgui
       run: cargo test -p juliaupgui
+
+  # FreeBSD needs its own job: the GUI's X11/xkb/OpenGL dependencies come from
+  # ports, so it cannot be cross-compiled from the base-only cross sysroot the
+  # way the CLI is. It is built and tested inside a real FreeBSD VM instead.
+  test-juliaupgui-freebsd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: true
+        large-packages: false
+    - name: Test juliaupgui on FreeBSD
+      uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee # v1.3.0
+      with:
+        operating_system: freebsd
+        version: '13.4'
+        architecture: x86-64
+        cpu_count: 4
+        memory: '12G'
+        sync_files: runner-to-vm
+        shell: sh
+        run: |
+          df -h
+          RUST_VERSION=$(grep '^channel = ' rust-toolchain.toml | sed 's/channel = "\(.*\)"/\1/')
+          fetch https://sh.rustup.rs -o - | sh -s -- -y --default-toolchain "$RUST_VERSION" --profile minimal
+          . "${HOME}/.cargo/env"
+          export RUST_BACKTRACE=full
+          # Clean up to maximize available disk space
+          rm -rf target
+          rm -rf ~/.cargo/registry/cache
+          rm -rf ~/.cargo/git/db
+          pkg install -y pkgconf libX11 libxcb libxkbcommon mesa-libs
+          pkg clean -y
+          df -h
+          export CARGO_INCREMENTAL=0
+          cargo test --verbose -p juliaupgui

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -367,8 +367,8 @@ jobs:
           rm -rf target
           rm -rf ~/.cargo/registry/cache
           rm -rf ~/.cargo/git/db
-          pkg install -y pkgconf libX11 libxcb libxkbcommon mesa-libs
-          pkg clean -y
+          sudo pkg install -y pkgconf libX11 libxcb libxkbcommon mesa-libs
+          sudo pkg clean -y
           df -h
           export CARGO_INCREMENTAL=0
           cargo test --verbose -p juliaupgui

--- a/Cross.toml
+++ b/Cross.toml
@@ -41,6 +41,9 @@ pre-build = [
 passthrough = ["AWS_LC_SYS_CMAKE_BUILDER"]
 
 # FreeBSD is cross-compiled (HOST != target), so aws-lc-sys skips the memcmp
-# self-check; only the newer glibc from :edge is needed here.
+# self-check; only the newer glibc from :edge is needed here. No X11/OpenGL
+# pre-build packages: apt would install them for Linux, not into the FreeBSD
+# sysroot, which carries base only. juliaupgui is therefore built and tested
+# inside a real FreeBSD VM (see the workflows) rather than through cross.
 [target.x86_64-unknown-freebsd]
 image = "ghcr.io/cross-rs/x86_64-unknown-freebsd:edge"

--- a/juliaupgui/src/app.rs
+++ b/juliaupgui/src/app.rs
@@ -1853,6 +1853,17 @@ fn tab_config(app: &mut App, ui: &mut egui::Ui) {
                             {
                                 dialog = dialog.set_directory("/usr/bin");
                             }
+                            // On the BSDs, terminal emulators come from ports/pkg,
+                            // which install under /usr/local rather than /usr.
+                            #[cfg(any(
+                                target_os = "freebsd",
+                                target_os = "dragonfly",
+                                target_os = "netbsd",
+                                target_os = "openbsd"
+                            ))]
+                            {
+                                dialog = dialog.set_directory("/usr/local/bin");
+                            }
                             if let Some(path) = dialog.pick_file() {
                                 app.terminal_app = path.display().to_string();
                                 save_terminal_pref(&app.paths, &app.terminal_app);


### PR DESCRIPTION
Extends the GUI to work on FreeBSD.

Claude:

---

## What was already fine

Most of the GUI sources were already portable. The platform gating in `juliaupgui/src/app.rs` is written as `macos`/`windows` arms with `not(any(...))` fallbacks, so `shell_quote`, `build_launch_cmd`, `launch_in_terminal`, `launch_default_terminal` and the POSIX test module already compiled and behaved correctly on FreeBSD. `default_terminal_hint()` already falls through to `"xterm"`, which is the right answer there.

The dependency graph is fine too: winit, glutin, accesskit-unix and arboard all gate on the "free unix" set that includes FreeBSD, and `rfd` uses its XDG backend on any non-mac/non-Windows unix.

## What this changes

**`juliaupgui/src/app.rs`** — the "Browse..." picker for the terminal emulator defaulted to `/usr/bin` on Linux and the CWD everywhere else. On the BSDs terminal emulators come from ports/pkg under `/usr/local/bin`, so the dialog opened on a directory with nothing relevant in it. Adds a BSD arm covering FreeBSD and the other three, which share the layout.

**`.github/workflows/release.yml`** — FreeBSD was excluded from the `Build juliaupgui` step and not handled anywhere else, so no FreeBSD release ever shipped the GUI. Builds it inside the existing FreeBSD VM step after `pkg install`ing the X11/xkb/GL ports, and adds the matching `chmod a+rx`. The artifact upload glob and the `tar -czvf ... .` archive step are directory-wide, so they pick the binary up unchanged.

**`.github/workflows/test.yml`** — adds a `test-juliaupgui-freebsd` job. The existing `test-juliaupgui` matrix runs on plain GitHub runners, which have no FreeBSD option, so this uses a `cross-platform-actions` VM like the other FreeBSD jobs.

**`Cross.toml`** — documents why the FreeBSD target deliberately has no X11 `pre-build` block. The GUI can't be cross-compiled for FreeBSD the way the CLI is, because its X11/OpenGL dependencies come from ports while the cross sysroot carries base only. Copying the Linux `apt-get` lines over would install Linux libraries, not FreeBSD sysroot ones.

## Notes for review

- **None of this was compile-verified locally** — there was no Rust toolchain available on the machine this was written on, and cross-compiling to FreeBSD would not have exercised the ports dependencies anyway. The reasoning about the dependency graph above is from how those crates gate upstream, not from a build. The new CI job is what actually proves it; the `pkg install` list may need another library if a linker error names one that isn't there.
- **Disk space is the likely failure mode.** The FreeBSD VM jobs already `rm -rf target` and `pkg clean -y` to fit, and eframe's dependency tree is large. The release step builds the GUI into the same `target/` as the CLI so dependencies are shared, but if it runs out, `large-packages: true` on the `free-disk-space` action is the documented next lever (~5 GB more).

🤖 Generated with [Claude Code](https://claude.com/claude-code)