### PR TITLE
ui: stop update text overflowing the channel tiles and the status table

### DIFF
--- a/juliaupgui/src/app.rs
+++ b/juliaupgui/src/app.rs
@@ -1035,28 +1035,33 @@ fn tab_installed_tiles(app: &mut App, ui: &mut egui::Ui, state: &AppState) {
                             let btn_h = 24.0;
                             ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
                                 // ── secondary actions row ──
-                                if !row.is_default {
+                                // The default channel cannot be re-defaulted or
+                                // removed, but it can still be updated.
+                                let has_update = row.update.is_some();
+                                let actions =
+                                    usize::from(!row.is_default) * 2 + usize::from(has_update);
+                                if actions > 0 {
                                     ui.horizontal(|ui| {
                                         ui.spacing_mut().item_spacing.x = 4.0;
-                                        let has_update = row.update.is_some();
-                                        let action_w = if has_update {
-                                            (TILE_W - 8.0) / 3.0
-                                        } else {
-                                            (TILE_W - 4.0) / 2.0
-                                        };
-                                        if accessible_button_name(
-                                            ui.add_sized(
-                                                [action_w, btn_h],
-                                                egui::Button::new(
-                                                    RichText::new("Default").size(12.0),
+                                        let action_w =
+                                            (TILE_W - 4.0 * (actions - 1) as f32) / actions as f32;
+                                        if !row.is_default
+                                            && accessible_button_name(
+                                                ui.add_sized(
+                                                    [action_w, btn_h],
+                                                    egui::Button::new(
+                                                        RichText::new("Default").size(12.0),
+                                                    ),
                                                 ),
-                                            ),
-                                            format!("Set Julia channel {} as default", row.name),
-                                        )
-                                        .on_hover_text(
-                                            "Use this channel when no version is specified",
-                                        )
-                                        .clicked()
+                                                format!(
+                                                    "Set Julia channel {} as default",
+                                                    row.name
+                                                ),
+                                            )
+                                            .on_hover_text(
+                                                "Use this channel when no version is specified",
+                                            )
+                                            .clicked()
                                         {
                                             set_def = Some(row.name.clone());
                                         }
@@ -1075,17 +1080,18 @@ fn tab_installed_tiles(app: &mut App, ui: &mut egui::Ui, state: &AppState) {
                                         {
                                             do_update = Some(row.name.clone());
                                         }
-                                        if accessible_button_name(
-                                            ui.add_sized(
-                                                [action_w, btn_h],
-                                                egui::Button::new(
-                                                    RichText::new("Remove").size(12.0),
+                                        if !row.is_default
+                                            && accessible_button_name(
+                                                ui.add_sized(
+                                                    [action_w, btn_h],
+                                                    egui::Button::new(
+                                                        RichText::new("Remove").size(12.0),
+                                                    ),
                                                 ),
-                                            ),
-                                            format!("Remove Julia channel {}", row.name),
-                                        )
-                                        .on_hover_text("Remove this channel")
-                                        .clicked()
+                                                format!("Remove Julia channel {}", row.name),
+                                            )
+                                            .on_hover_text("Remove this channel")
+                                            .clicked()
                                         {
                                             do_remove = Some(row.name.clone());
                                         }

--- a/juliaupgui/src/app.rs
+++ b/juliaupgui/src/app.rs
@@ -39,8 +39,17 @@ struct InstalledRow {
     name: String,
     version: String,
     is_default: bool,
-    update: Option<String>,
+    update: Option<UpdateInfo>,
     pr_number: Option<String>,
+}
+
+/// A pending channel update, split into what fits in the UI and what does not.
+#[derive(Clone)]
+struct UpdateInfo {
+    /// Short text for the tile badge and the list column, e.g. `1.10.12`.
+    label: String,
+    /// Full text for the tooltip, e.g. `Update to 1.10.12+0.aarch64.apple.darwin14`.
+    detail: String,
 }
 
 #[derive(Clone)]
@@ -224,6 +233,7 @@ pub struct App {
 impl App {
     pub fn new(cc: &eframe::CreationContext<'_>, paths: GlobalPaths) -> Self {
         let paths = Arc::new(paths);
+        install_font_fallbacks(&cc.egui_ctx);
         let theme_mode = load_theme_pref(&paths);
         apply_theme(&cc.egui_ctx, theme_mode);
         let (op_tx, op_rx) = mpsc::sync_channel::<(Op, Arc<GlobalPaths>)>(8);
@@ -989,7 +999,8 @@ fn tab_installed_tiles(app: &mut App, ui: &mut egui::Ui, state: &AppState) {
                                         .color(secondary_text(ui.visuals().dark_mode)),
                                 )
                                 .truncate(),
-                            );
+                            )
+                            .on_hover_text(&row.version);
 
                             if row.is_default || row.update.is_some() {
                                 ui.add_space(4.0);
@@ -1003,112 +1014,124 @@ fn tab_installed_tiles(app: &mut App, ui: &mut egui::Ui, state: &AppState) {
                                         );
                                     }
                                     if let Some(upd) = &row.update {
-                                        ui.label(
-                                            RichText::new(format!("Update: {upd}"))
-                                                .size(12.0)
-                                                .color(warning_color(ui.visuals().dark_mode)),
-                                        );
+                                        ui.add(
+                                            egui::Label::new(
+                                                RichText::new(format!("Update: {}", upd.label))
+                                                    .size(12.0)
+                                                    .color(warning_color(ui.visuals().dark_mode)),
+                                            )
+                                            .truncate(),
+                                        )
+                                        .on_hover_text(upd.detail.as_str());
                                     }
                                 });
                             }
 
-                            // ── push buttons to bottom ──
-                            let used = ui.min_rect().height();
+                            // ── buttons, pinned to the bottom of the tile ──
+                            // The tile ui is sized to the whole tile up front,
+                            // so its `min_rect` says nothing about how tall the
+                            // content above actually is. Stack the rows upward
+                            // from the bottom instead of measuring.
                             let btn_h = 24.0;
-                            let btn_rows = if row.is_default { 1 } else { 2 };
-                            let buttons_h = btn_h * btn_rows as f32 + 4.0 * (btn_rows - 1) as f32;
-                            let remaining = (TILE_H - used - buttons_h).max(0.0);
-                            ui.add_space(remaining);
-
-                            // ── Launch row ──
-                            ui.horizontal(|ui| {
-                                ui.spacing_mut().item_spacing.x = 4.0;
-                                let launch_w = (TILE_W - 4.0) / 2.0;
-                                if accessible_button_name(
-                                    ui.add_sized(
-                                        [launch_w, btn_h],
-                                        egui::Button::new(
-                                            RichText::new("Launch")
-                                                .size(12.0)
-                                                .color(success_color(ui.visuals().dark_mode)),
-                                        ),
-                                    ),
-                                    format!("Launch Julia channel {}", row.name),
-                                )
-                                .on_hover_text(format!("Start julia +{}", row.name))
-                                .clicked()
-                                {
-                                    do_launch = Some(row.name.clone());
-                                }
-                                if accessible_button_name(
-                                    ui.add_sized(
-                                        [launch_w, btn_h],
-                                        egui::Button::new(RichText::new("Custom...").size(12.0)),
-                                    ),
-                                    format!(
-                                        "Launch Julia channel {} with custom options",
-                                        row.name
-                                    ),
-                                )
-                                .on_hover_text("Launch with custom project & args")
-                                .clicked()
-                                {
-                                    app.custom_launch_channel = Some(row.name.clone());
-                                }
-                            });
-
-                            // ── secondary actions row ──
-                            if !row.is_default {
-                                ui.add_space(4.0);
-                                ui.horizontal(|ui| {
-                                    ui.spacing_mut().item_spacing.x = 4.0;
-                                    let has_update = row.update.is_some();
-                                    let action_w = if has_update {
-                                        (TILE_W - 8.0) / 3.0
-                                    } else {
-                                        (TILE_W - 4.0) / 2.0
-                                    };
-                                    if accessible_button_name(
-                                        ui.add_sized(
-                                            [action_w, btn_h],
-                                            egui::Button::new(RichText::new("Default").size(12.0)),
-                                        ),
-                                        format!("Set Julia channel {} as default", row.name),
-                                    )
-                                    .on_hover_text("Use this channel when no version is specified")
-                                    .clicked()
-                                    {
-                                        set_def = Some(row.name.clone());
-                                    }
-                                    if has_update
-                                        && accessible_button_name(
+                            ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
+                                // ── secondary actions row ──
+                                if !row.is_default {
+                                    ui.horizontal(|ui| {
+                                        ui.spacing_mut().item_spacing.x = 4.0;
+                                        let has_update = row.update.is_some();
+                                        let action_w = if has_update {
+                                            (TILE_W - 8.0) / 3.0
+                                        } else {
+                                            (TILE_W - 4.0) / 2.0
+                                        };
+                                        if accessible_button_name(
                                             ui.add_sized(
                                                 [action_w, btn_h],
                                                 egui::Button::new(
-                                                    RichText::new("Update").size(12.0),
+                                                    RichText::new("Default").size(12.0),
                                                 ),
                                             ),
-                                            format!("Update Julia channel {}", row.name),
+                                            format!("Set Julia channel {} as default", row.name),
                                         )
-                                        .on_hover_text("Update to latest")
+                                        .on_hover_text(
+                                            "Use this channel when no version is specified",
+                                        )
                                         .clicked()
+                                        {
+                                            set_def = Some(row.name.clone());
+                                        }
+                                        if has_update
+                                            && accessible_button_name(
+                                                ui.add_sized(
+                                                    [action_w, btn_h],
+                                                    egui::Button::new(
+                                                        RichText::new("Update").size(12.0),
+                                                    ),
+                                                ),
+                                                format!("Update Julia channel {}", row.name),
+                                            )
+                                            .on_hover_text("Update to latest")
+                                            .clicked()
+                                        {
+                                            do_update = Some(row.name.clone());
+                                        }
+                                        if accessible_button_name(
+                                            ui.add_sized(
+                                                [action_w, btn_h],
+                                                egui::Button::new(
+                                                    RichText::new("Remove").size(12.0),
+                                                ),
+                                            ),
+                                            format!("Remove Julia channel {}", row.name),
+                                        )
+                                        .on_hover_text("Remove this channel")
+                                        .clicked()
+                                        {
+                                            do_remove = Some(row.name.clone());
+                                        }
+                                    });
+                                    ui.add_space(4.0);
+                                }
+
+                                // ── Launch row ──
+                                ui.horizontal(|ui| {
+                                    ui.spacing_mut().item_spacing.x = 4.0;
+                                    let launch_w = (TILE_W - 4.0) / 2.0;
+                                    if accessible_button_name(
+                                        ui.add_sized(
+                                            [launch_w, btn_h],
+                                            egui::Button::new(
+                                                RichText::new("Launch")
+                                                    .size(12.0)
+                                                    .color(success_color(ui.visuals().dark_mode)),
+                                            ),
+                                        ),
+                                        format!("Launch Julia channel {}", row.name),
+                                    )
+                                    .on_hover_text(format!("Start julia +{}", row.name))
+                                    .clicked()
                                     {
-                                        do_update = Some(row.name.clone());
+                                        do_launch = Some(row.name.clone());
                                     }
                                     if accessible_button_name(
                                         ui.add_sized(
-                                            [action_w, btn_h],
-                                            egui::Button::new(RichText::new("Remove").size(12.0)),
+                                            [launch_w, btn_h],
+                                            egui::Button::new(
+                                                RichText::new("Custom...").size(12.0),
+                                            ),
                                         ),
-                                        format!("Remove Julia channel {}", row.name),
+                                        format!(
+                                            "Launch Julia channel {} with custom options",
+                                            row.name
+                                        ),
                                     )
-                                    .on_hover_text("Remove this channel")
+                                    .on_hover_text("Launch with custom project & args")
                                     .clicked()
                                     {
-                                        do_remove = Some(row.name.clone());
+                                        app.custom_launch_channel = Some(row.name.clone());
                                     }
                                 });
-                            }
+                            });
                         }
                     } else {
                         // "Add another channel" tile
@@ -1249,19 +1272,27 @@ fn tab_installed_list(app: &mut App, ui: &mut egui::Ui, state: &AppState) {
                         });
                     });
                     cells.col(|ui| {
-                        ui.label(
-                            RichText::new(&row.version)
-                                .size(13.0)
-                                .color(secondary_text(ui.visuals().dark_mode)),
-                        );
+                        ui.add(
+                            egui::Label::new(
+                                RichText::new(&row.version)
+                                    .size(13.0)
+                                    .color(secondary_text(ui.visuals().dark_mode)),
+                            )
+                            .truncate(),
+                        )
+                        .on_hover_text(&row.version);
                     });
                     cells.col(|ui| {
                         if let Some(upd) = &row.update {
-                            ui.label(
-                                RichText::new(upd)
-                                    .size(12.0)
-                                    .color(warning_color(ui.visuals().dark_mode)),
-                            );
+                            ui.add(
+                                egui::Label::new(
+                                    RichText::new(&upd.label)
+                                        .size(12.0)
+                                        .color(warning_color(ui.visuals().dark_mode)),
+                                )
+                                .truncate(),
+                            )
+                            .on_hover_text(upd.detail.as_str());
                         } else {
                             ui.label(
                                 RichText::new("Current")
@@ -3122,24 +3153,44 @@ fn update_info(
     ch: &JuliaupConfigChannel,
     config: &juliaup::config_file::JuliaupReadonlyConfigFile,
     versiondb: &JuliaupVersionDB,
-) -> Option<String> {
+) -> Option<UpdateInfo> {
     match ch {
         JuliaupConfigChannel::DirectDownloadChannel {
             local_etag,
             server_etag,
             ..
-        } => (local_etag != server_etag).then(|| "Update available".to_string()),
+        } => (local_etag != server_etag).then(|| UpdateInfo {
+            label: "available".to_string(),
+            detail: "A newer build of this channel is available".to_string(),
+        }),
         JuliaupConfigChannel::SystemChannel { version } => versiondb
             .available_channels
             .get(name)
             .filter(|c| &c.version != version)
-            .map(|c| format!("→ {}", c.version)),
+            .map(|c| UpdateInfo {
+                label: short_target_version(version, &c.version),
+                detail: format!("Update to {}", c.version),
+            }),
         JuliaupConfigChannel::LinkedChannel { .. } => None,
         JuliaupConfigChannel::AliasChannel { target, .. } => config
             .data
             .installed_channels
             .get(target)
             .and_then(|tc| update_info(target, tc, config, versiondb)),
+    }
+}
+
+/// Julia versions carry a `+<build>.<platform>` tag that is the same for every
+/// build of a channel on a given machine, and it is already shown on the
+/// version line. Drop it from the update badge, which only has a 168pt tile to
+/// live in. Keep it when it differs from what is installed, since a change of
+/// platform is worth seeing.
+fn short_target_version(installed: &str, target: &str) -> String {
+    match (installed.split_once('+'), target.split_once('+')) {
+        (Some((_, installed_tag)), Some((core, target_tag))) if installed_tag == target_tag => {
+            core.to_string()
+        }
+        _ => target.to_string(),
     }
 }
 
@@ -3213,6 +3264,17 @@ fn paint_julia_dots(p: &egui::Painter, rect: egui::Rect) {
 }
 
 // ── theme ─────────────────────────────────────────────────────────────────────
+
+/// egui's proportional font (Ubuntu-Light) has no arrows, so `→` renders as a
+/// tofu box everywhere we use one. Hack ships with egui and covers them, so
+/// append it as a last-resort fallback for the proportional family.
+fn install_font_fallbacks(ctx: &egui::Context) {
+    let mut fonts = egui::FontDefinitions::default();
+    if let Some(family) = fonts.families.get_mut(&egui::FontFamily::Proportional) {
+        family.push("Hack".to_owned());
+    }
+    ctx.set_fonts(fonts);
+}
 
 fn apply_theme(ctx: &egui::Context, mode: ThemeMode) {
     for theme in [egui::Theme::Dark, egui::Theme::Light] {
@@ -3369,6 +3431,62 @@ pub fn run(paths: GlobalPaths) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── update badge text ─────────────────────────────────────────────────
+
+    #[test]
+    fn short_target_version_drops_the_shared_build_tag() {
+        assert_eq!(
+            short_target_version(
+                "1.10.11+0.aarch64.apple.darwin14",
+                "1.10.12+0.aarch64.apple.darwin14"
+            ),
+            "1.10.12"
+        );
+    }
+
+    #[test]
+    fn short_target_version_keeps_a_differing_build_tag() {
+        assert_eq!(
+            short_target_version(
+                "1.10.11+0.x64.apple.darwin14",
+                "1.10.12+0.aarch64.apple.darwin14"
+            ),
+            "1.10.12+0.aarch64.apple.darwin14"
+        );
+    }
+
+    #[test]
+    fn short_target_version_passes_through_untagged_versions() {
+        assert_eq!(
+            short_target_version("1.14.0-DEV.1", "1.14.0-DEV.2"),
+            "1.14.0-DEV.2"
+        );
+    }
+
+    // ── fonts ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn proportional_font_renders_arrows_after_fallback() {
+        // egui hands back texture deltas that panic if simply dropped.
+        fn pass(ctx: &egui::Context) {
+            ctx.run_ui(Default::default(), |_| {})
+                .textures_delta
+                .clear();
+        }
+
+        let arrow = egui::FontId::proportional(12.0);
+        let ctx = egui::Context::default();
+        pass(&ctx);
+        assert!(
+            !ctx.fonts_mut(|f| f.has_glyph(&arrow, '\u{2192}')),
+            "egui's default proportional font now covers arrows; install_font_fallbacks can go"
+        );
+
+        install_font_fallbacks(&ctx);
+        pass(&ctx);
+        assert!(ctx.fonts_mut(|f| f.has_glyph(&arrow, '\u{2192}')));
+    }
 
     // ── clean_line ────────────────────────────────────────────────────────
 

--- a/juliaupgui/src/app.rs
+++ b/juliaupgui/src/app.rs
@@ -1028,10 +1028,9 @@ fn tab_installed_tiles(app: &mut App, ui: &mut egui::Ui, state: &AppState) {
                             }
 
                             // ── buttons, pinned to the bottom of the tile ──
-                            // The tile ui is sized to the whole tile up front,
-                            // so its `min_rect` says nothing about how tall the
-                            // content above actually is. Stack the rows upward
-                            // from the bottom instead of measuring.
+                            // `min_rect` spans the full tile, not the content
+                            // above it, so stack the rows up from the bottom
+                            // rather than measuring.
                             let btn_h = 24.0;
                             ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
                                 // ── secondary actions row ──
@@ -3186,11 +3185,9 @@ fn update_info(
     }
 }
 
-/// Julia versions carry a `+<build>.<platform>` tag that is the same for every
-/// build of a channel on a given machine, and it is already shown on the
-/// version line. Drop it from the update badge, which only has a 168pt tile to
-/// live in. Keep it when it differs from what is installed, since a change of
-/// platform is worth seeing.
+/// Drops the `+<build>.<platform>` tag when it matches the installed version:
+/// the version line above already shows it, and the badge has a 168pt tile to
+/// fit in. A differing platform is worth seeing, so keep that.
 fn short_target_version(installed: &str, target: &str) -> String {
     match (installed.split_once('+'), target.split_once('+')) {
         (Some((_, installed_tag)), Some((core, target_tag))) if installed_tag == target_tag => {
@@ -3271,9 +3268,8 @@ fn paint_julia_dots(p: &egui::Painter, rect: egui::Rect) {
 
 // ── theme ─────────────────────────────────────────────────────────────────────
 
-/// egui's proportional font (Ubuntu-Light) has no arrows, so `→` renders as a
-/// tofu box everywhere we use one. Hack ships with egui and covers them, so
-/// append it as a last-resort fallback for the proportional family.
+/// Ubuntu-Light, egui's proportional font, has no arrows, so `→` renders as a
+/// tofu box. Hack ships with egui and covers them; append it as a fallback.
 fn install_font_fallbacks(ctx: &egui::Context) {
     let mut fonts = egui::FontDefinitions::default();
     if let Some(family) = fonts.families.get_mut(&egui::FontFamily::Proportional) {

--- a/src/command_status.rs
+++ b/src/command_status.rs
@@ -9,8 +9,9 @@ use cli_table::format::Separator;
 use cli_table::ColorChoice;
 use cli_table::{
     format::{Border, Justify},
-    print_stdout, Table, WithTitle,
+    print_stdout, Table, TableStruct, WithTitle,
 };
+use console::Term;
 use itertools::Itertools;
 use numeric_sort::cmp;
 use regex::Regex;
@@ -42,16 +43,41 @@ fn format_linked_command(command: &str, args: &Option<Vec<String>>) -> String {
     format!("Linked to `{combined_command}`")
 }
 
-fn format_version(channel_name: &str, channel: &JuliaupConfigChannel) -> String {
+/// Julia versions carry a `+<build>.<platform>` tag that is the same for every
+/// build on a given machine, so it is the first thing to drop when the table
+/// does not fit the terminal.
+fn strip_build_tag(version: &str) -> &str {
+    version.split_once('+').map_or(version, |(core, _)| core)
+}
+
+/// The update column only has to say what changes, and the build tag almost
+/// never does. Keep it when it differs from what is installed, since a change
+/// of platform is worth seeing.
+fn short_target_version(installed: &str, target: &str) -> String {
+    match (installed.split_once('+'), target.split_once('+')) {
+        (Some((_, installed_tag)), Some((core, target_tag))) if installed_tag == target_tag => {
+            core.to_string()
+        }
+        _ => target.to_string(),
+    }
+}
+
+/// `compact` trades the details that repeat across rows (the build tag, the
+/// pull request URL) for a table that fits a narrow terminal.
+fn format_version(channel_name: &str, channel: &JuliaupConfigChannel, compact: bool) -> String {
     match channel {
         JuliaupConfigChannel::DirectDownloadChannel { version, .. } => {
             match Regex::new(r"^pr(\d+)").unwrap().captures(channel_name) {
+                Some(caps) if compact => format!("{version} (#{})", &caps[1]),
                 Some(caps) => format!(
                     "{version} https://github.com/JuliaLang/julia/pull/{}",
                     &caps[1]
                 ),
                 None => version.clone(),
             }
+        }
+        JuliaupConfigChannel::SystemChannel { version } if compact => {
+            strip_build_tag(version).to_string()
         }
         JuliaupConfigChannel::SystemChannel { version } => version.clone(),
         JuliaupConfigChannel::LinkedChannel { command, args } => {
@@ -77,11 +103,11 @@ fn get_update_info(
             local_etag,
             server_etag,
             ..
-        } => (local_etag != server_etag).then(|| "Update available".to_string()),
+        } => (local_etag != server_etag).then(|| "available".to_string()),
         JuliaupConfigChannel::SystemChannel { version } => {
             match versiondb_data.available_channels.get(channel_name) {
                 Some(channel) if &channel.version != version => {
-                    Some(format!("Update to {} available", channel.version))
+                    Some(short_target_version(version, &channel.version))
                 }
                 _ => None,
             }
@@ -94,11 +120,11 @@ fn get_update_info(
                     local_etag,
                     server_etag,
                     ..
-                }) => (local_etag != server_etag).then(|| "Update available".to_string()),
+                }) => (local_etag != server_etag).then(|| "available".to_string()),
                 Some(JuliaupConfigChannel::SystemChannel { version }) => {
                     match versiondb_data.available_channels.get(target) {
                         Some(channel) if channel.version != *version => {
-                            Some(format!("Update to {} available", channel.version))
+                            Some(short_target_version(version, &channel.version))
                         }
                         _ => None,
                     }
@@ -129,35 +155,60 @@ pub fn run_command_status(paths: &GlobalPaths) -> Result<()> {
     let versiondb_data =
         load_versions_db(paths).with_context(|| "`status` command failed to load versions db.")?;
 
-    let rows_in_table: Vec<ChannelRow> = config_file
-        .data
-        .installed_channels
-        .iter()
-        .sorted_by(|(channel_name_a, _), (channel_name_b, _)| cmp(channel_name_a, channel_name_b))
-        .map(|(channel_name, channel)| ChannelRow {
-            default: match &config_file.data.default {
-                Some(ref default_value) if channel_name == default_value => "*",
-                _ => "",
-            },
-            name: channel_name.to_string(),
-            version: format_version(channel_name, channel),
-            update: get_update_info(channel_name, channel, &config_file, &versiondb_data),
-        })
-        .collect();
+    let build_rows = |compact: bool| -> Vec<ChannelRow> {
+        config_file
+            .data
+            .installed_channels
+            .iter()
+            .sorted_by(|(channel_name_a, _), (channel_name_b, _)| {
+                cmp(channel_name_a, channel_name_b)
+            })
+            .map(|(channel_name, channel)| ChannelRow {
+                default: match &config_file.data.default {
+                    Some(ref default_value) if channel_name == default_value => "*",
+                    _ => "",
+                },
+                name: channel_name.to_string(),
+                version: format_version(channel_name, channel, compact),
+                update: get_update_info(channel_name, channel, &config_file, &versiondb_data),
+            })
+            .collect()
+    };
 
-    print_stdout(
-        rows_in_table
-            .with_title()
-            .color_choice(ColorChoice::Never)
-            .border(Border::builder().build())
-            .separator(
-                Separator::builder()
-                    .title(Some(HorizontalLine::new('1', '2', '3', '-')))
-                    .build(),
-            ),
-    )?;
+    // Only a real terminal has a width to respect; piped output keeps the URLs
+    // and build tags intact.
+    let compact = match Term::stdout().size_checked() {
+        Some((_, cols)) => rendered_width(styled_table(build_rows(false)))? > cols as usize,
+        None => false,
+    };
+
+    print_stdout(styled_table(build_rows(compact)))?;
 
     Ok(())
+}
+
+fn styled_table(rows: Vec<ChannelRow>) -> TableStruct {
+    rows.with_title()
+        .color_choice(ColorChoice::Never)
+        .border(Border::builder().build())
+        .separator(
+            Separator::builder()
+                .title(Some(HorizontalLine::new('1', '2', '3', '-')))
+                .build(),
+        )
+}
+
+/// Width of the widest rendered row. `TableDisplay` trims the ends of the whole
+/// table, but the separator line it leaves untouched always spans the full
+/// width, so the maximum is still exact.
+fn rendered_width(table: TableStruct) -> Result<usize> {
+    Ok(table
+        .display()?
+        .to_string()
+        .lines()
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0))
 }
 
 #[cfg(test)]
@@ -178,7 +229,7 @@ mod tests {
     #[test]
     fn format_version_pr_channel_shows_pr_url() {
         assert_eq!(
-            format_version("pr59158", &direct_download_channel("1.14.0-DEV.123")),
+            format_version("pr59158", &direct_download_channel("1.14.0-DEV.123"), false),
             "1.14.0-DEV.123 https://github.com/JuliaLang/julia/pull/59158"
         );
     }
@@ -186,7 +237,11 @@ mod tests {
     #[test]
     fn format_version_pr_channel_with_platform_suffix_shows_pr_url() {
         assert_eq!(
-            format_version("pr59158~x64", &direct_download_channel("1.14.0-DEV.123")),
+            format_version(
+                "pr59158~x64",
+                &direct_download_channel("1.14.0-DEV.123"),
+                false
+            ),
             "1.14.0-DEV.123 https://github.com/JuliaLang/julia/pull/59158"
         );
     }
@@ -194,13 +249,94 @@ mod tests {
     #[test]
     fn format_version_nightly_channel_shows_only_version() {
         assert_eq!(
-            format_version("nightly", &direct_download_channel("1.14.0-DEV.456")),
+            format_version("nightly", &direct_download_channel("1.14.0-DEV.456"), false),
             "1.14.0-DEV.456"
         );
         assert_eq!(
-            format_version("1.13-nightly", &direct_download_channel("1.13.0-DEV.789")),
+            format_version(
+                "1.13-nightly",
+                &direct_download_channel("1.13.0-DEV.789"),
+                false
+            ),
             "1.13.0-DEV.789"
         );
+    }
+
+    #[test]
+    fn format_version_compact_pr_channel_shows_pr_number() {
+        assert_eq!(
+            format_version("pr59158", &direct_download_channel("1.14.0-DEV.123"), true),
+            "1.14.0-DEV.123 (#59158)"
+        );
+    }
+
+    #[test]
+    fn format_version_compact_system_channel_drops_build_tag() {
+        assert_eq!(
+            format_version(
+                "1.11",
+                &JuliaupConfigChannel::SystemChannel {
+                    version: "1.11.2+0.x64.apple.darwin14".to_string()
+                },
+                true
+            ),
+            "1.11.2"
+        );
+    }
+
+    #[test]
+    fn short_target_version_drops_the_shared_build_tag() {
+        assert_eq!(
+            short_target_version(
+                "1.10.11+0.aarch64.apple.darwin14",
+                "1.10.12+0.aarch64.apple.darwin14"
+            ),
+            "1.10.12"
+        );
+    }
+
+    #[test]
+    fn short_target_version_keeps_a_differing_build_tag() {
+        assert_eq!(
+            short_target_version(
+                "1.10.11+0.x64.apple.darwin14",
+                "1.10.12+0.aarch64.apple.darwin14"
+            ),
+            "1.10.12+0.aarch64.apple.darwin14"
+        );
+    }
+
+    #[test]
+    fn compact_rows_fit_a_narrow_terminal() {
+        let rows = |compact: bool| {
+            vec![
+                ChannelRow {
+                    default: "*",
+                    name: "release".to_string(),
+                    version: format_version(
+                        "release",
+                        &JuliaupConfigChannel::SystemChannel {
+                            version: "1.12.6+0.aarch64.apple.darwin14".to_string(),
+                        },
+                        compact,
+                    ),
+                    update: "1.12.7".to_string(),
+                },
+                ChannelRow {
+                    default: "",
+                    name: "pr62359".to_string(),
+                    version: format_version(
+                        "pr62359",
+                        &direct_download_channel("1.14.0-DEV.2875"),
+                        compact,
+                    ),
+                    update: String::new(),
+                },
+            ]
+        };
+
+        assert!(rendered_width(styled_table(rows(false))).unwrap() > 80);
+        assert!(rendered_width(styled_table(rows(true))).unwrap() <= 80);
     }
 
     #[test]
@@ -210,7 +346,8 @@ mod tests {
                 "1.11",
                 &JuliaupConfigChannel::SystemChannel {
                     version: "1.11.2+0.x64.apple.darwin14".to_string()
-                }
+                },
+                false
             ),
             "1.11.2+0.x64.apple.darwin14"
         );

--- a/src/command_status.rs
+++ b/src/command_status.rs
@@ -43,16 +43,12 @@ fn format_linked_command(command: &str, args: &Option<Vec<String>>) -> String {
     format!("Linked to `{combined_command}`")
 }
 
-/// Julia versions carry a `+<build>.<platform>` tag that is the same for every
-/// build on a given machine, so it is the first thing to drop when the table
-/// does not fit the terminal.
 fn strip_build_tag(version: &str) -> &str {
     version.split_once('+').map_or(version, |(core, _)| core)
 }
 
 /// The update column only has to say what changes, and the build tag almost
-/// never does. Keep it when it differs from what is installed, since a change
-/// of platform is worth seeing.
+/// never does. Keep it when it differs: a change of platform is worth seeing.
 fn short_target_version(installed: &str, target: &str) -> String {
     match (installed.split_once('+'), target.split_once('+')) {
         (Some((_, installed_tag)), Some((core, target_tag))) if installed_tag == target_tag => {


### PR DESCRIPTION
We need visual regression tests..

Master
<img width="878" height="585" alt="Screenshot 2026-08-20 at 10 22 54 PM" src="https://github.com/user-attachments/assets/a05ed22a-89d5-4daf-9d1a-a4d447c52456" />

PR

<img width="878" height="586" alt="Screenshot 2026-08-20 at 10 23 36 PM" src="https://github.com/user-attachments/assets/d2b5ac3c-e73e-4b63-80f3-211026e7abf4" />

Claude:

---

The GUI's channel tiles showed a pending update as `Update: → 1.12.7+0.aarch64.apple.darwin14`. The `→` was a tofu box: egui's proportional font is Ubuntu-Light, which has no arrows, and the bundled `Hack` face that covers U+2192 is not in the proportional chain. The text was also far too wide for a 168pt tile and sat on an untruncated label, so it wrapped and spilled over the neighbouring tile.

`Hack` is now appended to the proportional chain, which also fixes `Linked → …`, `Alias → …` and the override and link status messages. The badge reads `Update: 1.12.7`, with the `+<build>.<platform>` tag dropped when it matches what is installed and the full version in a tooltip. Update and version labels are truncated in both views; the list view needed that independently, because `egui_extras` columns do not clip by default. Tile buttons now stack up from the bottom with `Layout::bottom_up` rather than by arithmetic against `min_rect`, which the tile's own `set_min_size` had already made a no-op.

The secondary action row was gated as a whole on `!row.is_default`, so the default channel got an `Update:` badge and no button to act on it. `Default` and `Remove` belong behind that condition, `Update` does not; each is now gated on its own, as the list view already did.

`juliaup status` had the same problem in a terminal, reaching 140 columns with updates pending. The update column now says `1.12.7` rather than `Update to 1.12.7+0.aarch64.apple.darwin14 available`, and if the table still would not fit, the version column drops the build tag and shortens the pull request URL from #1561 to `(#62359)`. Wide terminals keep both, and output that is not going to a terminal is unchanged.

This overlaps #1558, which drops build metadata from `list` and `status` unconditionally rather than only when the table would not fit.
