### PR TITLE
ci: give each release matrix job its own rust-cache key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,11 @@ jobs:
       with:
         toolchain: ${{ steps.toolchain.outputs.name }}
         target: ${{matrix.target}}
+        # Without this, all matrix jobs on one OS share a single job-id-based
+        # cache key. The cross containers differ in glibc version (see
+        # Cross.toml), so a target/ dir saved by a new-glibc job breaks build
+        # scripts when restored into an old-glibc container.
+        cache-key: ${{matrix.label}}
     - name: Release build
       if: ${{ ! contains(matrix.target, 'freebsd') }}
       uses: clechasseur/rs-cargo@8ccb6817fc46c9af3b058a5a7b31932edb82cf13 # v5.0.7
@@ -402,6 +407,11 @@ jobs:
       with:
         toolchain: ${{ steps.toolchain.outputs.name }}
         target: ${{matrix.target}}
+        # Without this, all matrix jobs on one OS share a single job-id-based
+        # cache key. The cross containers differ in glibc version (see
+        # Cross.toml), so a target/ dir saved by a new-glibc job breaks build
+        # scripts when restored into an old-glibc container.
+        cache-key: ${{matrix.label}}
     - name: Test
       if: ${{ ! contains(matrix.target, 'freebsd') }}
       uses: clechasseur/rs-cargo@8ccb6817fc46c9af3b058a5a7b31932edb82cf13 # v5.0.7


### PR DESCRIPTION
Claude:

---

The v1.22.3 release run failed in `build-juliaup (x86_64-unknown-linux-musl)`, and matrix fail-fast cancelled the other 21 build jobs. The `libc` build script died with `/lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.32' not found` (and 2.33, 2.34, 2.39).

`setup-rust-toolchain` enables rust-cache, and `release.yml` never set a cache key, so every Linux entry of the `build-juliaup` matrix shared `v0-rust-build-juliaup-Linux-x64-...`. The cross containers differ in glibc version (see `Cross.toml`): a sibling job on an `:edge` image saves a `target/` dir holding host build-script binaries linked against glibc 2.39, and the musl job, which runs on the 0.2.5 image with glibc 2.31, restores that and cannot execute them.

#1551 fixed this for `check-juliaup` in `test.yml`; `build-juliaup` and `test-juliaup` in `release.yml` were missed. This applies the same per-label cache key to both.

Re-running the failed jobs on the existing `v1.22.3` tag will still fail, since a re-run uses `release.yml` as of the tagged commit. The stale cache entry has to be deleted first, or the tag has to move onto this fix.
