### PR TITLE
ci: cross-compile i686-pc-windows-gnu from the x86_64 host toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,9 +231,11 @@ jobs:
       shell: bash
       run: |
         ver=$(grep '^channel = ' rust-toolchain.toml | sed 's/channel = "\(.*\)"/\1/')
+        # stable-i686-gnu keeps the x86_64 host toolchain and cross-compiles to the
+        # i686 target: rustup >= 1.29.1 refuses to install i686 Windows host
+        # toolchains on 64-bit Windows without --force-non-host.
         case "${{ matrix.toolchain }}" in
           stable-gnu) echo "name=${ver}-x86_64-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
-          stable-i686-gnu) echo "name=${ver}-i686-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
           *) echo "name=${ver}" >> "$GITHUB_OUTPUT" ;;
         esac
     - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -397,9 +399,11 @@ jobs:
       shell: bash
       run: |
         ver=$(grep '^channel = ' rust-toolchain.toml | sed 's/channel = "\(.*\)"/\1/')
+        # stable-i686-gnu keeps the x86_64 host toolchain and cross-compiles to the
+        # i686 target: rustup >= 1.29.1 refuses to install i686 Windows host
+        # toolchains on 64-bit Windows without --force-non-host.
         case "${{ matrix.toolchain }}" in
           stable-gnu) echo "name=${ver}-x86_64-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
-          stable-i686-gnu) echo "name=${ver}-i686-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
           *) echo "name=${ver}" >> "$GITHUB_OUTPUT" ;;
         esac
     - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,9 +240,11 @@ jobs:
       shell: bash
       run: |
         ver=$(grep '^channel = ' rust-toolchain.toml | sed 's/channel = "\(.*\)"/\1/')
+        # stable-i686-gnu keeps the x86_64 host toolchain and cross-compiles to the
+        # i686 target: rustup >= 1.29.1 refuses to install i686 Windows host
+        # toolchains on 64-bit Windows without --force-non-host.
         case "${{ matrix.toolchain }}" in
           stable-gnu) echo "name=${ver}-x86_64-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
-          stable-i686-gnu) echo "name=${ver}-i686-pc-windows-gnu" >> "$GITHUB_OUTPUT" ;;
           *) echo "name=${ver}" >> "$GITHUB_OUTPUT" ;;
         esac
     - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0


### PR DESCRIPTION
Claude:

---

The `test-juliaup (i686-pc-windows-gnu)` job has failed on every push to main since the `windows-latest` image update on Sept 8 (windows-2025-vs2026 20260907.229). That image moved rustup from 1.29.0 to 1.29.1, and rustup 1.29.1 removed the special case that let an i686 Windows host toolchain be installed on 64-bit Windows (rust-lang/rustup#4935). The job resolves `stable-i686-gnu` to `1.97.0-i686-pc-windows-gnu` and dies at toolchain install:

```
error: toolchain '1.97.0-i686-pc-windows-gnu' may not be able to run on this system
note: to build software for that platform, try `rustup target add i686-pc-windows-gnu` instead
note: add the `--force-non-host` flag to install the toolchain anyway
```

Runners are being swapped gradually, which is why PR branches and sibling jobs in the same run still passed on the old image.

`actions-rust-lang/setup-rust-toolchain` cannot pass `--force-non-host` (actions-rust-lang/setup-rust-toolchain#101), so this does what rustup recommends: use the x86_64 host toolchain and add `i686-pc-windows-gnu` as a target. The `check-juliaup (i686-pc-windows-gnu-msi)` job already builds the target that way and passes on the new image. `setup-mingw` still keys off the `stable-i686-gnu` matrix label, so the i686 gcc used for linking is unchanged. The same mapping in `release.yml` is updated too, since the release build and test jobs would hit the same error.
