### PR TITLE
Skip download in `add` when the version is already installed

### DIFF
--- a/src/command_add.rs
+++ b/src/command_add.rs
@@ -10,7 +10,7 @@ use crate::operations::{
 };
 use crate::utils::{print_juliaup_style, JuliaupMessageType};
 use crate::versions_file::load_versions_db;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use regex::Regex;
 use tempfile::TempDir;
 
@@ -23,6 +23,10 @@ enum AddChannelOutcome {
 /// Commits a downloaded database version after re-checking the channel under
 /// the exclusive configuration lock.
 ///
+/// `downloaded` is `None` when the required version was already installed and
+/// no download was made; the caller must have verified under the same
+/// exclusive lock that the version is still installed.
+///
 /// A concurrent system-channel install only wins when it selected the same
 /// version. If it selected a different version, keep the completed download
 /// and move the channel to the version this `add` resolved before downloading.
@@ -30,7 +34,7 @@ enum AddChannelOutcome {
 fn commit_downloaded_channel(
     channel: &str,
     required_version: &str,
-    downloaded: TempDir,
+    downloaded: Option<TempDir>,
     config_data: &mut JuliaupConfig,
     paths: &GlobalPaths,
 ) -> Result<AddChannelOutcome> {
@@ -40,7 +44,23 @@ fn commit_downloaded_channel(
         None => {}
     }
 
-    commit_version_install(downloaded, required_version, config_data, paths)?;
+    match downloaded {
+        Some(downloaded) => {
+            commit_version_install(downloaded, required_version, config_data, paths)?
+        }
+        None => {
+            if !config_data
+                .installed_versions
+                .contains_key(required_version)
+            {
+                bail!(
+                    "Failed to add '{}' because version '{}' is not installed.",
+                    channel,
+                    required_version
+                );
+            }
+        }
+    }
 
     config_data.installed_channels.insert(
         channel.to_string(),
@@ -79,7 +99,7 @@ pub fn run_command_add(channel: &str, paths: &GlobalPaths) -> Result<()> {
 
     // Check whether the channel is already installed before downloading. This
     // read only briefly takes a shared lock, which is released immediately.
-    {
+    let version_already_installed = {
         let config_file = load_config_db(paths, None)
             .with_context(|| "`add` command failed to load configuration data.")?;
 
@@ -87,15 +107,48 @@ pub fn run_command_add(channel: &str, paths: &GlobalPaths) -> Result<()> {
             eprintln!("'{}' is already installed.", channel);
             return Ok(());
         }
-    }
+
+        config_file
+            .data
+            .installed_versions
+            .contains_key(required_version)
+    };
 
     // Download and extract the version without holding the configuration lock,
-    // so concurrent juliaup processes (and the launcher) are not blocked.
-    let downloaded = download_version_to_temp(required_version, &version_db, paths)?;
+    // so concurrent juliaup processes (and the launcher) are not blocked. If
+    // another channel already installed the required version, skip the
+    // download and only move the channel pointer below.
+    let mut downloaded = if version_already_installed {
+        None
+    } else {
+        Some(download_version_to_temp(
+            required_version,
+            &version_db,
+            paths,
+        )?)
+    };
 
     // Re-acquire the exclusive lock to commit the installation.
     let mut config_file = load_mut_config_db(paths)
         .with_context(|| "`add` command failed to load configuration data.")?;
+
+    // A version seen as installed above may have been removed concurrently
+    // (e.g. by `juliaup gc`); download it after all, again without the lock.
+    if downloaded.is_none()
+        && !config_file
+            .data
+            .installed_versions
+            .contains_key(required_version)
+    {
+        drop(config_file);
+        downloaded = Some(download_version_to_temp(
+            required_version,
+            &version_db,
+            paths,
+        )?);
+        config_file = load_mut_config_db(paths)
+            .with_context(|| "`add` command failed to load configuration data.")?;
+    }
 
     if commit_downloaded_channel(
         channel,
@@ -266,8 +319,13 @@ mod tests {
             },
         );
 
-        let outcome =
-            commit_downloaded_channel("1.10", "1.10.12+0.test", downloaded, &mut config, &paths)?;
+        let outcome = commit_downloaded_channel(
+            "1.10",
+            "1.10.12+0.test",
+            Some(downloaded),
+            &mut config,
+            &paths,
+        )?;
 
         assert_eq!(outcome, AddChannelOutcome::Installed);
         assert!(config.installed_versions.contains_key("1.10.12+0.test"));
@@ -305,12 +363,59 @@ mod tests {
             },
         );
 
-        let outcome =
-            commit_downloaded_channel("1.10", "1.10.12+0.test", downloaded, &mut config, &paths)?;
+        let outcome = commit_downloaded_channel(
+            "1.10",
+            "1.10.12+0.test",
+            Some(downloaded),
+            &mut config,
+            &paths,
+        )?;
 
         assert_eq!(outcome, AddChannelOutcome::AlreadyInstalled);
         assert!(!downloaded_path.exists());
         assert_eq!(std::fs::read_to_string(target.join("julia"))?, "existing");
+        Ok(())
+    }
+
+    #[test]
+    fn already_installed_version_commits_without_download() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = test_paths(dir.path());
+        let mut config = JuliaupConfig::default();
+
+        config.installed_versions.insert(
+            "1.10.12+0.test".to_string(),
+            installed_version("./julia-1.10.12+0.test"),
+        );
+        config.installed_channels.insert(
+            "release".to_string(),
+            JuliaupConfigChannel::SystemChannel {
+                version: "1.10.12+0.test".to_string(),
+            },
+        );
+
+        let outcome =
+            commit_downloaded_channel("1.10", "1.10.12+0.test", None, &mut config, &paths)?;
+
+        assert_eq!(outcome, AddChannelOutcome::Installed);
+        assert!(matches!(
+            config.installed_channels.get("1.10"),
+            Some(JuliaupConfigChannel::SystemChannel { version })
+                if version == "1.10.12+0.test"
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn missing_version_without_download_fails() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let paths = test_paths(dir.path());
+        let mut config = JuliaupConfig::default();
+
+        let result = commit_downloaded_channel("1.10", "1.10.12+0.test", None, &mut config, &paths);
+
+        assert!(result.is_err());
+        assert!(!config.installed_channels.contains_key("1.10"));
         Ok(())
     }
 
@@ -326,8 +431,13 @@ mod tests {
         let downloaded = downloaded_install(dir.path(), "downloaded")?;
         let downloaded_path = downloaded.path().to_path_buf();
 
-        let outcome =
-            commit_downloaded_channel("1.10", "1.10.12+0.test", downloaded, &mut config, &paths)?;
+        let outcome = commit_downloaded_channel(
+            "1.10",
+            "1.10.12+0.test",
+            Some(downloaded),
+            &mut config,
+            &paths,
+        )?;
 
         assert_eq!(outcome, AddChannelOutcome::AlreadyInstalled);
         assert!(!downloaded_path.exists());

--- a/tests/command_add.rs
+++ b/tests/command_add.rs
@@ -1,3 +1,4 @@
+use predicates::boolean::PredicateBooleanExt;
 use predicates::prelude::predicate;
 
 mod utils;
@@ -83,4 +84,46 @@ fn command_add_pr_warning() {
         .stderr(predicate::str::contains(
             "Review code at https://github.com/JuliaLang/julia/pull/123",
         ));
+}
+
+#[test]
+fn command_add_reuses_installed_version() {
+    let env = TestEnv::new();
+
+    env.juliaup()
+        .arg("add")
+        .arg("1.10")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Installing Julia 1.10."));
+
+    let version_output = env
+        .julia()
+        .arg("+1.10")
+        .arg("--startup-file=no")
+        .arg("-e")
+        .arg("print(VERSION)")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let version = std::str::from_utf8(&version_output).unwrap();
+
+    // The version is already installed for the `1.10` channel, so adding it
+    // by exact version must only add the channel and not download it again.
+    env.juliaup()
+        .arg("add")
+        .arg(version)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Installing").not());
+
+    env.julia()
+        .arg(format!("+{}", version))
+        .arg("-e")
+        .arg("print(VERSION)")
+        .assert()
+        .success()
+        .stdout(version.to_string());
 }


### PR DESCRIPTION
`juliaup add` only checked whether the *channel* name was installed before downloading, never whether the *version* it resolves to already is. So after `juliaup update release` installed 1.13.0, both `juliaup add 1.13` and `juliaup add 1.13.0` downloaded the full archive again, only for `commit_version_install` to silently discard it. This also hits the launcher's channel auto-install, which shells out to `juliaup add`.

Now `add` checks `installed_versions` during the existing shared-lock pre-check and, when the version is already installed, skips the download and only commits the channel pointer. If the version is removed concurrently (e.g. `juliaup gc`) between that check and the exclusive-lock commit, it drops the lock, downloads after all, and re-acquires, so the lock is still never held during a download.