### PR TITLE
ci: ship juliaupgui in the Linux archives

### DIFF
--- a/.github/actions/build-juliaupgui-linux/action.yml
+++ b/.github/actions/build-juliaupgui-linux/action.yml
@@ -1,0 +1,47 @@
+name: Build juliaupgui for Linux
+description: >
+  Builds juliaupgui against an old glibc and checks the result. Must run in a
+  job whose `container` is a manylinux_2_28 image (AlmaLinux 8, glibc 2.28)
+  matching the target architecture.
+
+  Linux installs of juliaup use the static musl build of the CLI, which cannot
+  dlopen the X11/Wayland/OpenGL libraries the GUI needs at runtime. The GUI is
+  therefore built dynamically against glibc here and shipped alongside the
+  musl binaries, so it has to keep running on any glibc >= 2.28 distribution.
+inputs:
+  target:
+    description: Rust target tuple, x86_64-unknown-linux-gnu or aarch64-unknown-linux-gnu
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install build dependencies
+      shell: bash
+      # cmake and perl are for aws-lc-sys: its cc builder runs a memcmp self-check
+      # that panics with the toolset's GCC (gcc bug 95189), so the CMake builder
+      # is used instead (see AWS_LC_SYS_CMAKE_BUILDER below). The rest are the
+      # X11/xkb/OpenGL headers eframe's dependencies want at build time.
+      run: dnf install -y cmake perl libxkbcommon-devel libxcb-devel mesa-libGL-devel
+    - name: Install Rust
+      shell: bash
+      # rustup picks the channel and components up from rust-toolchain.toml.
+      run: |
+        curl --proto '=https' --tlsv1.2 --retry 10 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+    - name: Build juliaupgui
+      shell: bash
+      run: cargo build --release -p juliaupgui --target ${{ inputs.target }}
+      env:
+        AWS_LC_SYS_CMAKE_BUILDER: "1"
+    - name: Check glibc floor
+      shell: bash
+      run: |
+        bin=target/${{ inputs.target }}/release/juliaupgui
+        readelf -d "$bin" | grep NEEDED
+        floor=$(objdump -T "$bin" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -Vu | tail -1)
+        echo "highest glibc symbol version: $floor"
+        newest=$(printf '%s\n' GLIBC_2.28 "$floor" | sort -V | tail -1)
+        if [ "$newest" != GLIBC_2.28 ]; then
+          echo "::error::juliaupgui requires $floor but must run on glibc 2.28"
+          exit 1
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,9 @@ jobs:
         CARGO_TARGET_aarch64-unknown-linux-musl: ${{matrix.rustflags}}
         AWS_LC_SYS_CMAKE_BUILDER: "1"
     - name: Build juliaupgui
-      if: ${{ ! contains(matrix.target, 'freebsd') && ! contains(matrix.label, 'portable') && ! contains(matrix.target, 'musl') }}
+      # Linux GUIs come from the build-juliaupgui-linux job so they run on old
+      # glibc; FreeBSD's is built inside the VM below.
+      if: ${{ ! contains(matrix.target, 'freebsd') && matrix.os != 'ubuntu' }}
       uses: clechasseur/rs-cargo@9a5c570d3347f8dee3916c8871f3ffaf38909956 # v5.0.8
       with:
         command: build
@@ -323,6 +325,31 @@ jobs:
         path: |
           target/${{matrix.target}}/release/juliainstaller
           target/${{matrix.target}}/release/juliainstaller.exe
+
+  # Linux users get the static musl CLI, which cannot dlopen the X11/Wayland/
+  # OpenGL libraries the GUI needs, so the GUI is built against glibc 2.28 in
+  # a manylinux container and packaged into every Linux archive, musl included.
+  build-juliaupgui-linux:
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.image }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            image: quay.io/pypa/manylinux_2_28_x86_64@sha256:53390351aeb4688114b02c36a23b3e6ce1166ee9b7afc5df1a4f776354fc764c # 2026.09.05-1
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            image: quay.io/pypa/manylinux_2_28_aarch64@sha256:ad74e53b713f3b07d8c889c526dc0c6500da9827b45e38739570875fef52e28f # 2026.09.05-1
+    steps:
+    - uses: actions/checkout@v7
+    - uses: ./.github/actions/build-juliaupgui-linux
+      with:
+        target: ${{ matrix.target }}
+    - uses: actions/upload-artifact@v7
+      with:
+        name: juliaupgui-${{matrix.target}}
+        path: target/${{matrix.target}}/release/juliaupgui
 
   test-juliaup:
     runs-on: ${{ matrix.runner }}
@@ -460,7 +487,7 @@ jobs:
           df -h
           CARGO_INCREMENTAL=0 cargo test --target ${{matrix.target}} --features ${{matrix.features}}
   package-unix:
-    needs: [build-juliaup,test-juliaup]
+    needs: [build-juliaup,build-juliaupgui-linux,test-juliaup]
     environment: package
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
@@ -510,6 +537,22 @@ jobs:
       with:
         name: juliaup-x86_64-unknown-freebsd
         path: target/x86_64-unknown-freebsd
+    - name: Download Linux x64 juliaupgui artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: juliaupgui-x86_64-unknown-linux-gnu
+        path: target/x86_64-unknown-linux-gnu
+    - name: Download Linux aarch64 juliaupgui artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: juliaupgui-aarch64-unknown-linux-gnu
+        path: target/aarch64-unknown-linux-gnu
+    - name: Add juliaupgui to the musl archives
+      # The Linux installer and self-update use the musl archives; see
+      # build-juliaupgui-linux for why the GUI in them is a glibc binary.
+      run: |
+        cp target/x86_64-unknown-linux-gnu/juliaupgui target/x86_64-unknown-linux-musl/
+        cp target/aarch64-unknown-linux-gnu/juliaupgui target/aarch64-unknown-linux-musl/
     - name: Download installer artifacts for x86_64-apple-darwin
       uses: actions/download-artifact@v8
       with:
@@ -559,25 +602,26 @@ jobs:
       run: |
         chmod a+rx target/x86_64-unknown-linux-gnu/juliaup
         chmod a+rx target/x86_64-unknown-linux-gnu/julialauncher
-        chmod a+rx -f target/x86_64-unknown-linux-gnu/juliaupgui || true
+        chmod a+rx target/x86_64-unknown-linux-gnu/juliaupgui
         chmod a+rx target/x86_64-unknown-linux-musl/juliaup
         chmod a+rx target/x86_64-unknown-linux-musl/julialauncher
+        chmod a+rx target/x86_64-unknown-linux-musl/juliaupgui
         chmod a+rx target/i686-unknown-linux-gnu/juliaup
         chmod a+rx target/i686-unknown-linux-gnu/julialauncher
-        chmod a+rx -f target/i686-unknown-linux-gnu/juliaupgui || true
         chmod a+rx target/i686-unknown-linux-musl/juliaup
         chmod a+rx target/i686-unknown-linux-musl/julialauncher
         chmod a+rx target/x86_64-apple-darwin/juliaup
         chmod a+rx target/x86_64-apple-darwin/julialauncher
-        chmod a+rx -f target/x86_64-apple-darwin/juliaupgui || true
+        chmod a+rx target/x86_64-apple-darwin/juliaupgui
         chmod a+rx target/aarch64-apple-darwin/juliaup
         chmod a+rx target/aarch64-apple-darwin/julialauncher
-        chmod a+rx -f target/aarch64-apple-darwin/juliaupgui || true
+        chmod a+rx target/aarch64-apple-darwin/juliaupgui
         chmod a+rx target/aarch64-unknown-linux-gnu/juliaup
         chmod a+rx target/aarch64-unknown-linux-gnu/julialauncher
-        chmod a+rx -f target/aarch64-unknown-linux-gnu/juliaupgui || true
+        chmod a+rx target/aarch64-unknown-linux-gnu/juliaupgui
         chmod a+rx target/aarch64-unknown-linux-musl/juliaup
         chmod a+rx target/aarch64-unknown-linux-musl/julialauncher
+        chmod a+rx target/aarch64-unknown-linux-musl/juliaupgui
         chmod a+rx target/x86_64-unknown-freebsd/juliaup
         chmod a+rx target/x86_64-unknown-freebsd/julialauncher
         chmod a+rx -f target/x86_64-unknown-freebsd/juliaupgui || true
@@ -639,7 +683,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   package-unix-portable:
-    needs: [build-juliaup,test-juliaup]
+    needs: [build-juliaup,build-juliaupgui-linux,test-juliaup]
     environment: package
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
@@ -669,18 +713,32 @@ jobs:
       with:
         name: juliaup-aarch64-apple-darwin-portable
         path: target/aarch64-apple-darwin-portable
+    - name: Download x86_64 Linux juliaupgui artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: juliaupgui-x86_64-unknown-linux-gnu
+        path: target/x86_64-unknown-linux-musl-portable
+    - name: Download aarch64 Linux juliaupgui artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: juliaupgui-aarch64-unknown-linux-gnu
+        path: target/aarch64-unknown-linux-musl-portable
     - name: Set permissions
       run: |
         chmod a+rx target/x86_64-apple-darwin-portable/juliaup
         chmod a+rx target/x86_64-apple-darwin-portable/julia
+        chmod a+rx target/x86_64-apple-darwin-portable/juliaupgui
         chmod a+rx target/x86_64-unknown-linux-musl-portable/juliaup
         chmod a+rx target/x86_64-unknown-linux-musl-portable/julia
+        chmod a+rx target/x86_64-unknown-linux-musl-portable/juliaupgui
         chmod a+rx target/i686-unknown-linux-musl-portable/juliaup
         chmod a+rx target/i686-unknown-linux-musl-portable/julia
         chmod a+rx target/aarch64-unknown-linux-musl-portable/juliaup
         chmod a+rx target/aarch64-unknown-linux-musl-portable/julia
+        chmod a+rx target/aarch64-unknown-linux-musl-portable/juliaupgui
         chmod a+rx target/aarch64-apple-darwin-portable/juliaup
         chmod a+rx target/aarch64-apple-darwin-portable/julia
+        chmod a+rx target/aarch64-apple-darwin-portable/juliaupgui
     - name: Export version
       run: |
         export VERSION=$(echo $GH_REF | sed 's:refs/tags/v::')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -337,6 +337,28 @@ jobs:
     - name: Test juliaupgui
       run: cargo test -p juliaupgui
 
+  # The Linux GUI that ships to users is built against glibc 2.28 in a
+  # manylinux container (see the action for why); make sure it keeps building
+  # there and that the glibc floor does not creep up.
+  test-juliaupgui-linux-glibc:
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: ${{ github.ref != 'refs/heads/main' }}
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            image: quay.io/pypa/manylinux_2_28_x86_64@sha256:53390351aeb4688114b02c36a23b3e6ce1166ee9b7afc5df1a4f776354fc764c # 2026.09.05-1
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            image: quay.io/pypa/manylinux_2_28_aarch64@sha256:ad74e53b713f3b07d8c889c526dc0c6500da9827b45e38739570875fef52e28f # 2026.09.05-1
+    steps:
+    - uses: actions/checkout@v7
+    - uses: ./.github/actions/build-juliaupgui-linux
+      with:
+        target: ${{ matrix.target }}
+
   # FreeBSD needs its own job: the GUI's X11/xkb/OpenGL dependencies come from
   # ports, so it cannot be cross-compiled from the base-only cross sysroot the
   # way the CLI is. It is built and tested inside a real FreeBSD VM instead.

--- a/Cross.toml
+++ b/Cross.toml
@@ -8,20 +8,12 @@
 
 [target.i686-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/i686-unknown-linux-gnu:edge"
-pre-build = [
-    "dpkg --add-architecture i386",
-    "apt-get update && apt-get install -y libxcb-render0-dev:i386 libxcb-shape0-dev:i386 libxcb-xfixes0-dev:i386 libxkbcommon-dev:i386 libgl-dev:i386"
-]
 
 [target.i686-unknown-linux-musl]
 image = "ghcr.io/cross-rs/i686-unknown-linux-musl:edge"
 
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
-pre-build = [
-    "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt-get update && apt-get install -y libxcb-render0-dev:$CROSS_DEB_ARCH libxcb-shape0-dev:$CROSS_DEB_ARCH libxcb-xfixes0-dev:$CROSS_DEB_ARCH libxkbcommon-dev:$CROSS_DEB_ARCH libgl-dev:$CROSS_DEB_ARCH"
-]
 
 [target.aarch64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:edge"
@@ -30,11 +22,12 @@ image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:edge"
 # builder memcmp self-check, which panics with the newer GCC in the :edge image
 # (gcc bug 95189). Force aws-lc-sys to use its CMake builder instead, which skips
 # that check: install cmake and pass AWS_LC_SYS_CMAKE_BUILDER=1 into the container.
-# The remaining packages provide the X11/OpenGL dependencies used by juliaupgui.
+# juliaupgui is not built through cross: the :edge images are Ubuntu 24.04, so
+# their binaries need glibc 2.39. See .github/actions/build-juliaupgui-linux.
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:edge"
 pre-build = [
-    "apt-get update && apt-get install --assume-yes cmake libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libgl-dev"
+    "apt-get update && apt-get install --assume-yes cmake"
 ]
 
 [target.x86_64-unknown-linux-gnu.env]

--- a/src/command_selfuninstall.rs
+++ b/src/command_selfuninstall.rs
@@ -60,6 +60,7 @@ pub fn run_command_selfuninstall(paths: &crate::global_paths::GlobalPaths) -> Re
         let julia_symlink_path = juliaup_binfolder_path.join("julia");
         let julialauncher_path = juliaup_binfolder_path.join("julialauncher");
         let juliaup_path = juliaup_binfolder_path.join("juliaup");
+        let juliaupgui_path = juliaup_binfolder_path.join("juliaupgui");
         let juliaup_config_path = paths.juliaupselfhome.join("juliaupself.json");
 
         eprint!("Deleting julia symlink {}.", julia_symlink_path.display());
@@ -82,6 +83,15 @@ pub fn run_command_selfuninstall(paths: &crate::global_paths::GlobalPaths) -> Re
             Ok(_) => eprintln!(" Success."),
             Err(e) => eprintln!(" Failed: {e}."),
         };
+
+        // Installs from before the GUI shipped do not have it.
+        if juliaupgui_path.exists() {
+            eprint!("Deleting juliaupgui binary {}.", juliaupgui_path.display());
+            match std::fs::remove_file(&juliaupgui_path) {
+                Ok(_) => eprintln!(" Success."),
+                Err(e) => eprintln!(" Failed: {e}."),
+            };
+        }
 
         if juliaup_binfolder_path
             .read_dir()


### PR DESCRIPTION
Claude:

---

Linux installs of juliaup have never included the GUI. `juliaup-init.sh` always selects the musl build, and the release workflow skipped `juliaupgui` for musl targets because the static musl binary cannot dlopen the X11/Wayland/OpenGL libraries the GUI needs at runtime. The gnu archives did carry a GUI, but it was built in the cross `:edge` images (Ubuntu 24.04) and so requires glibc 2.39, which would not have helped most users either.

This builds the Linux GUI in pinned manylinux_2_28 containers instead, natively on x86_64 and arm64 runners, so it runs on any distribution with glibc >= 2.28 (2018 onwards, RHEL 8 included). A new composite action does the build and fails if the binary's glibc floor creeps above 2.28. The release workflow runs it as a job and packs the result into the gnu, musl and portable Linux archives, so the installer and `juliaup self update` deliver it. The same action runs in `test.yml` on both architectures.

The binary produced in CI on this branch needs only `libc`, `libm`, `libdl`, `libpthread` and `libgcc_s`; everything else is loaded on demand.

Also in this change: the portable macOS and Windows archives are no longer excluded from the GUI build, the cross images drop the X11 packages that nothing builds with anymore, and `juliaup self uninstall` removes `juliaupgui`.

The release workflow only runs on tags, so the packaging steps are reviewed by reading rather than exercised.

Fixes #1593
