### PR TITLE
fix: keep #compdef as the literal first line of zsh completions

### DIFF
--- a/src/command_completions.rs
+++ b/src/command_completions.rs
@@ -124,14 +124,30 @@ fn generate_completions_to_writer<T: CommandFactory>(
     app_name: &str,
     writer: &mut impl Write,
 ) {
-    if matches!(shell, CompletionShell::Zsh) {
-        generate_zsh_compinit_guard(writer);
-    }
     let mut cmd = T::command();
-    match GeneratorType::from(shell.clone()) {
-        GeneratorType::Standard(s) => generate(s, &mut cmd, app_name, writer),
-        GeneratorType::Nushell => {
-            generate(clap_complete_nushell::Nushell, &mut cmd, app_name, writer)
+    if matches!(shell, CompletionShell::Zsh) {
+        // clap_complete's zsh output starts with a `#compdef <name>` line.
+        // zsh's compinit only recognizes a file in $fpath as a completion
+        // function if that line is literally the first line of the file, so
+        // the compinit guard must be inserted after it rather than before it
+        // (see #1580).
+        let mut generated = Vec::new();
+        generate(Shell::Zsh, &mut cmd, app_name, &mut generated);
+        let split_at = generated
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|i| i + 1)
+            .unwrap_or(generated.len());
+        let (compdef_line, rest) = generated.split_at(split_at);
+        let _ = writer.write_all(compdef_line);
+        generate_zsh_compinit_guard(writer);
+        let _ = writer.write_all(rest);
+    } else {
+        match GeneratorType::from(shell.clone()) {
+            GeneratorType::Standard(s) => generate(s, &mut cmd, app_name, writer),
+            GeneratorType::Nushell => {
+                generate(clap_complete_nushell::Nushell, &mut cmd, app_name, writer)
+            }
         }
     }
     generate_julia_launcher_completion(shell, writer);

--- a/tests/command_completions_test.rs
+++ b/tests/command_completions_test.rs
@@ -50,6 +50,30 @@ fn completions_zsh() {
 }
 
 #[test]
+fn completions_zsh_compdef_is_first_line() {
+    // zsh's compinit only recognizes a file in $fpath as a completion
+    // function if `#compdef` is literally the first line (see #1580), so
+    // this pins that invariant regardless of what else gets written before
+    // the rest of the generated completion script.
+    let depot_dir = tempfile::Builder::new()
+        .prefix("juliauptest")
+        .tempdir()
+        .unwrap();
+
+    let output = cargo_bin_cmd!("juliaup")
+        .arg("completions")
+        .arg("zsh")
+        .env("JULIA_DEPOT_PATH", depot_dir.path())
+        .env("JULIAUP_DEPOT_PATH", depot_dir.path())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let first_line = stdout.lines().next().unwrap();
+    assert_eq!(first_line, "#compdef juliaup");
+}
+
+#[test]
 fn completions_fish() {
     test_shell_completion(
         "fish",


### PR DESCRIPTION
## Summary
- zsh's `compinit` only recognizes a file in `$fpath` as a completion function by reading its first line and checking for `#compdef`.
- The compinit guard added in #1482 was written before the `clap_complete` output. This causes completion files installed into $fpath (e.g. Homebrew's `_juliaup` in `$(brew --prefix)/share/zsh/site-functions/`) to be silently ignored by compinit's fpath scan, so `juliaup <TAB>` never completes.
- This PR reorders the output so `#compdef juliaup` stays the literal first line, and the compinit guard is inserted right after it. This keeps both delivery paths working:
  - fpath/compinit-discovery (Homebrew and similar static-file setups)
  - the direct-`source` case in juliaup's own shell init block, which the guard was originally added for in #1482

Fixes #1580

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (full suite, root package)
- [x] Added `completions_zsh_compdef_is_first_line` to pin the invariant that broke in #1580
- [x] Manually inspected `juliaup completions zsh` output to confirm `#compdef juliaup` is line 1, followed by the compinit guard, then the rest of the generated script
